### PR TITLE
Stop LCD panels on session end

### DIFF
--- a/InfoPanel/App.xaml
+++ b/InfoPanel/App.xaml
@@ -5,7 +5,8 @@
     xmlns:enums="clr-namespace:InfoPanel.Enums"
     xmlns:local="clr-namespace:InfoPanel"
     xmlns:sys="clr-namespace:System;assembly=mscorlib"
-    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    SessionEnding="App_SessionEnding">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/InfoPanel/Services/BackgroundTask.cs
+++ b/InfoPanel/Services/BackgroundTask.cs
@@ -34,6 +34,7 @@ namespace InfoPanel
 
         public async Task StopAsync()
         {
+            Trace.WriteLine($"{this.GetType().Name} Task stopping");
             await _startStopSemaphore.WaitAsync();
             try
             {
@@ -62,6 +63,8 @@ namespace InfoPanel
             {
                 _startStopSemaphore.Release();
             }
+
+            Trace.WriteLine($"{this.GetType().Name} Task stopped");
         }
 
         protected abstract Task DoWorkAsync(CancellationToken token);

--- a/InfoPanel/Services/PanelDrawTask.cs
+++ b/InfoPanel/Services/PanelDrawTask.cs
@@ -42,11 +42,22 @@ namespace InfoPanel
                         var profiles = ConfigModel.Instance.GetProfilesCopy().Where(profile =>
                         (profile.Active && !profile.Direct2DMode)).ToList();
 
-                         Parallel.ForEach(profiles, profile =>
-                         {
-                             using var bitmap = Render(profile);
-                                 SharedModel.Instance.SetPanelBitmap(profile, bitmap);
-                             });
+                        try
+                        {
+                            var options = new ParallelOptions
+                            {
+                                CancellationToken = token
+                            };
+                            Parallel.ForEach(profiles, options, profile =>
+                            {
+                                using var bitmap = Render(profile);
+                                SharedModel.Instance.SetPanelBitmap(profile, bitmap);
+                            });
+                        }
+                        catch (Exception e)
+                        {
+                            Trace.WriteLine($"Exception during parallel execution: {e.Message}");
+                        }
 
                         var frameTime = stopwatch.ElapsedMilliseconds;
                         //Trace.WriteLine($"Frametime: {frameTime}");


### PR DESCRIPTION
This pull request includes several changes to the `InfoPanel` application, focusing on improving shutdown procedures, adding logging, and enhancing error handling during parallel execution.

### Improvements to shutdown procedures:

* [`InfoPanel/App.xaml`](diffhunk://#diff-e169ea453a0fb12d9974b66885da03929af2eb400cd6ed865c50d42c2faea300L8-R9): Added `SessionEnding="App_SessionEnding"` to handle session ending events.
* [`InfoPanel/App.xaml.cs`](diffhunk://#diff-285cb7fa3a32e42fb460b0f14a06e6d99b4e5196afaab0106ce535d0e40a891fL202-R217): Modified the `OnSessionEnding` method to `App_SessionEnding` and updated it to stop various panel tasks asynchronously before shutting down.
* [`InfoPanel/App.xaml.cs`](diffhunk://#diff-285cb7fa3a32e42fb460b0f14a06e6d99b4e5196afaab0106ce535d0e40a891fR284-R288): Updated `CleanShutDown` to invoke `Application.Current.Shutdown()` on the dispatcher thread.

### Logging enhancements:

* [`InfoPanel/Services/BackgroundTask.cs`](diffhunk://#diff-866576e080ff84d8ef2008ad3e3e7d8ff1070bc7da675e8d75bc8dd579836710R37): Added logging statements to indicate when tasks are stopping and have stopped in the `StopAsync` method. [[1]](diffhunk://#diff-866576e080ff84d8ef2008ad3e3e7d8ff1070bc7da675e8d75bc8dd579836710R37) [[2]](diffhunk://#diff-866576e080ff84d8ef2008ad3e3e7d8ff1070bc7da675e8d75bc8dd579836710R66-R67)

### Error handling improvements:

* [`InfoPanel/Services/PanelDrawTask.cs`](diffhunk://#diff-eb6c1cac21d58b0e7c10827473b72830a1c2a32e94f3a0c95b15bde184e4f100L45-R60): Added try-catch block to handle exceptions during parallel execution and log any errors encountered.