### PR TITLE
Dim lcd panels on system shutdown

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -210,10 +210,10 @@ namespace InfoPanel
         void App_SessionEnding(object sender, SessionEndingCancelEventArgs e)
         {
             Task.Run(async () => {
-                await BeadaPanelTask.Instance.StopAsync();
-                await TuringPanelATask.Instance.StopAsync();
-                await TuringPanelCTask.Instance.StopAsync();
-                await TuringPanelETask.Instance.StopAsync();
+                await BeadaPanelTask.Instance.StopAsync(true);
+                await TuringPanelATask.Instance.StopAsync(true);
+                await TuringPanelCTask.Instance.StopAsync(true);
+                await TuringPanelETask.Instance.StopAsync(true);
             }).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 

--- a/InfoPanel/Services/BackgroundTask.cs
+++ b/InfoPanel/Services/BackgroundTask.cs
@@ -16,9 +16,12 @@ namespace InfoPanel
 
         public bool IsRunning => _task is not null && !_task.IsCompleted && _cts is not null && !_cts.IsCancellationRequested;
 
+        protected bool _shutdown = false;
+
         public async Task StartAsync()
         {
             await _startStopSemaphore.WaitAsync();
+            _shutdown = false;
             try
             {
                 if (IsRunning) return;
@@ -32,10 +35,12 @@ namespace InfoPanel
             }
         }
 
-        public async Task StopAsync()
+        public async Task StopAsync(bool shutdown = false)
         {
             Trace.WriteLine($"{this.GetType().Name} Task stopping");
+
             await _startStopSemaphore.WaitAsync();
+            _shutdown = shutdown;
             try
             {
                 if (_cts is null || _task is null) return;

--- a/InfoPanel/Services/BeadaPanelTask.cs
+++ b/InfoPanel/Services/BeadaPanelTask.cs
@@ -170,13 +170,22 @@ namespace InfoPanel
                 {
                     try
                     {
-                        //var resetTag = new PanelLinkStreamTag(3);
-                        //iface.OutPipe.Write(resetTag.ToBuffer());
-                        //Trace.WriteLine("Sent ResetTag to clear screen");
+                        if (_shutdown)
+                        {
+                            //var resetTag = new PanelLinkStreamTag(3);
+                            //iface.OutPipe.Write(resetTag.ToBuffer());
+                            //Trace.WriteLine("Sent ResetTag to clear screen");
+                            iface.OutPipe.Write(clearTag.ToBuffer());
 
-                        using var bitmap = PanelDrawTask.RenderSplash(_panelWidth, _panelHeight,
-                        rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.BeadaPanelRotation));
-                        iface.Pipes[0x1].Write(BitmapToRgb16(bitmap));
+                            brightnessTag.SetBrightness(0);
+                            iface.Pipes[0x2].Write(brightnessTag.ToBuffer());
+                        }
+                        else
+                        {
+                            using var bitmap = PanelDrawTask.RenderSplash(_panelWidth, _panelHeight,
+                            rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.BeadaPanelRotation));
+                            iface.Pipes[0x1].Write(BitmapToRgb16(bitmap));
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/InfoPanel/Services/PanelDrawTask.cs
+++ b/InfoPanel/Services/PanelDrawTask.cs
@@ -50,8 +50,11 @@ namespace InfoPanel
                             };
                             Parallel.ForEach(profiles, options, profile =>
                             {
-                                using var bitmap = Render(profile);
-                                SharedModel.Instance.SetPanelBitmap(profile, bitmap);
+                                try
+                                {
+                                    using var bitmap = Render(profile);
+                                    SharedModel.Instance.SetPanelBitmap(profile, bitmap);
+                                }catch(Exception e) { Trace.WriteLine($"Exception during parallel execution: {e.Message}"); }
                             });
                         }
                         catch (Exception e)

--- a/InfoPanel/Services/TuringPanelATask.cs
+++ b/InfoPanel/Services/TuringPanelATask.cs
@@ -146,11 +146,18 @@ namespace InfoPanel
                 {
                     sentBitmap?.Dispose();
                     Trace.WriteLine("Resetting screen");
-                    //screen.Clear();
 
-                    using var bitmap = PanelDrawTask.RenderSplash(screen.Width, screen.Height,
+                    if (_shutdown)
+                    {
+                        screen.Clear();
+                        screen.SetBrightness(0);
+                    }
+                    else
+                    {
+                        using var bitmap = PanelDrawTask.RenderSplash(screen.Width, screen.Height,
                        rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.TuringPanelARotation));
-                    screen.DisplayBuffer(screen.CreateBufferFrom(bitmap));
+                        screen.DisplayBuffer(screen.CreateBufferFrom(bitmap));
+                    }
                     //screen.Reset();
                 }
             }

--- a/InfoPanel/Services/TuringPanelCTask.cs
+++ b/InfoPanel/Services/TuringPanelCTask.cs
@@ -147,13 +147,18 @@ namespace InfoPanel
                 finally
                 {
                     sentBitmap?.Dispose();
-                    Trace.WriteLine("Resetting screen");
-                    //screen.Clear();
 
-                    using var bitmap = PanelDrawTask.RenderSplash(screen.Width, screen.Height,
-                        rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.TuringPanelCRotation));
-                    screen.DisplayBuffer(screen.CreateBufferFrom(bitmap));
-                    //screen.Reset();
+                    if (_shutdown)
+                    {
+                        screen.Clear();
+                        screen.SetBrightness(0);
+                    }
+                    else
+                    {
+                        using var bitmap = PanelDrawTask.RenderSplash(screen.Width, screen.Height,
+                            rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.TuringPanelCRotation));
+                        screen.DisplayBuffer(screen.CreateBufferFrom(bitmap));
+                    }
                 }
             }
             catch (Exception e)

--- a/InfoPanel/Services/TuringPanelETask.cs
+++ b/InfoPanel/Services/TuringPanelETask.cs
@@ -147,11 +147,18 @@ namespace InfoPanel
                 {
                     sentBitmap?.Dispose();
                     Trace.WriteLine("Resetting screen");
-                    //screen.Clear();
 
-                    using var bitmap = PanelDrawTask.RenderSplash(screen.Width, screen.Height, 
-                        rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.TuringPanelERotation));
-                    screen.DisplayBuffer(screen.CreateBufferFrom(bitmap));
+                    if (_shutdown)
+                    {
+                        screen.Clear();
+                        screen.SetBrightness(0);
+                    }
+                    else
+                    {
+                        using var bitmap = PanelDrawTask.RenderSplash(screen.Width, screen.Height,
+                            rotateFlipType: (RotateFlipType)Enum.ToObject(typeof(RotateFlipType), ConfigModel.Instance.Settings.TuringPanelERotation));
+                        screen.DisplayBuffer(screen.CreateBufferFrom(bitmap));
+                    }
                     //screen.Reset();
                 }
             }


### PR DESCRIPTION
This pull request includes changes to the `InfoPanel` project, focusing on improving the shutdown behavior of various background tasks. The most important changes include adding a shutdown flag to the `BackgroundTask` class, updating the `StopAsync` method to handle the shutdown flag, and modifying the `DoWorkAsync` methods in various panel tasks to clear the screen and set brightness to zero during shutdown.

Improvements to shutdown behavior:

* [`InfoPanel/Services/BackgroundTask.cs`](diffhunk://#diff-866576e080ff84d8ef2008ad3e3e7d8ff1070bc7da675e8d75bc8dd579836710R19-R24): Added a `_shutdown` flag to the `BackgroundTask` class and updated the `StopAsync` method to accept a `shutdown` parameter, setting the `_shutdown` flag accordingly. [[1]](diffhunk://#diff-866576e080ff84d8ef2008ad3e3e7d8ff1070bc7da675e8d75bc8dd579836710R19-R24) [[2]](diffhunk://#diff-866576e080ff84d8ef2008ad3e3e7d8ff1070bc7da675e8d75bc8dd579836710L35-R43)
* [`InfoPanel/App.xaml.cs`](diffhunk://#diff-285cb7fa3a32e42fb460b0f14a06e6d99b4e5196afaab0106ce535d0e40a891fL213-R216): Updated the `App_SessionEnding` method to pass `true` to the `StopAsync` method, indicating a shutdown scenario.

Modifications to panel tasks:

* [`InfoPanel/Services/BeadaPanelTask.cs`](diffhunk://#diff-782800276f41e9d1eab3a0cf4cd1733f2330744ed01c4a9726c2d5161de71147R172-R189): Modified the `DoWorkAsync` method to clear the screen and set brightness to zero if `_shutdown` is true.
* [`InfoPanel/Services/TuringPanelATask.cs`](diffhunk://#diff-eceeb381c97f33a2255240f53c37439d1319664209923b8f8712cecad35d2323L149-R160): Modified the `DoWorkAsync` method to clear the screen and set brightness to zero if `_shutdown` is true.
* [`InfoPanel/Services/TuringPanelCTask.cs`](diffhunk://#diff-d743f00f5c502a2b6221e3bb637726ec82b505bba8d3928eac556c088c92cb86L150-R161): Modified the `DoWorkAsync` method to clear the screen and set brightness to zero if `_shutdown` is true.
* [`InfoPanel/Services/TuringPanelETask.cs`](diffhunk://#diff-36cdf7171239e6598291df56ca57f03e85dc2272a9a683e41cf12857a97d83a8L150-R161): Modified the `DoWorkAsync` method to clear the screen and set brightness to zero if `_shutdown` is true.

Additionally, an exception handling block was added to the `PanelDrawTask` class to log exceptions during parallel execution:

* [`InfoPanel/Services/PanelDrawTask.cs`](diffhunk://#diff-eb6c1cac21d58b0e7c10827473b72830a1c2a32e94f3a0c95b15bde184e4f100R52-R57): Added a try-catch block within the `DoWorkAsync` method to handle and log exceptions during parallel execution.