### PR TITLE
Add support for grouped display items

### DIFF
--- a/InfoPanel/Drawing/PanelDraw.cs
+++ b/InfoPanel/Drawing/PanelDraw.cs
@@ -60,240 +60,12 @@ namespace InfoPanel.Drawing
                 }
             }
 
-            DisplayItem? selectedItem = SharedModel.Instance.SelectedItem;
             List<SelectedRectangle> selectedRectangles = [];
 
             foreach (var displayItem in SharedModel.Instance.GetProfileDisplayItemsCopy(profile))
             {
                 if (displayItem.Hidden) continue;
-
-                var x = (int)Math.Ceiling(displayItem.X * scale);
-                var y = (int)Math.Ceiling(displayItem.Y * scale);
-
-                switch (displayItem)
-                {
-                    case TextDisplayItem textDisplayItem:
-                        {
-
-                            var fontSize = (int)Math.Ceiling(textDisplayItem.FontSize * scale);
-                            (var text, var color) = textDisplayItem.EvaluateTextAndColor();
-
-                            if (textDisplayItem is TableSensorDisplayItem tableSensorDisplayItem
-                                && tableSensorDisplayItem.GetValue() is SensorReading sensorReading
-                                && sensorReading.ValueTable is DataTable table)
-                            {
-                                var format = tableSensorDisplayItem.TableFormat;
-
-                                var maxRows = tableSensorDisplayItem.MaxRows;
-
-                                var formatParts = format.Split('|');
-
-                                if (formatParts.Length > 0)
-                                {
-                                    (float fWidth, float fHeight) = g.MeasureString("A", textDisplayItem.Font, fontSize, textDisplayItem.Bold,
-                                                  textDisplayItem.Italic, textDisplayItem.Underline, textDisplayItem.Strikeout);
-
-                                    var tWidth = 0;
-                                    for (int i = 0; i < formatParts.Length; i++)
-                                    {
-                                        var split = formatParts[i].Split(':');
-                                        if (split.Length == 2)
-                                        {
-                                            if (int.TryParse(split[0], out var column) && column < table.Columns.Count && int.TryParse(split[1], out var length))
-                                            {
-                                                if (tableSensorDisplayItem.ShowHeader)
-                                                {
-                                                    g.DrawString(table.Columns[column].ColumnName, textDisplayItem.Font, fontSize, color,
-                                                        x + tWidth, y,
-                                              i != 0 && textDisplayItem.RightAlign, textDisplayItem.CenterAlign, textDisplayItem.Bold,
-                                              textDisplayItem.Italic, textDisplayItem.Underline,
-                                              textDisplayItem.Strikeout, length, 0);
-                                                }
-
-                                                var rows = Math.Min(table.Rows.Count, maxRows);
-
-                                                for (int j = 0; j < rows; j++)
-                                                {
-                                                    var col = table.Rows[j][column];
-
-                                                    if (table.Rows[j][column] is IPluginData pluginData)
-                                                    {
-
-                                                        g.DrawString(pluginData.ToString(), textDisplayItem.Font, fontSize, color,
-                                                            x + tWidth, (int)(y + (fHeight * (j + (tableSensorDisplayItem.ShowHeader ? 1 : 0)))),
-                                           i != 0 && textDisplayItem.RightAlign, textDisplayItem.CenterAlign, textDisplayItem.Bold,
-                                           textDisplayItem.Italic, textDisplayItem.Underline,
-                                           textDisplayItem.Strikeout, length, 0);
-                                                    }
-                                                }
-
-                                                tWidth += length + 10;
-                                            }
-                                        }
-                                    }
-
-                                    if (displayItem.Selected)
-                                    {
-                                        var size = tableSensorDisplayItem.EvaluateSize();
-                                        selectedRectangles.Add(new SelectedRectangle(x, y, (int)size.Width, (int)size.Height));
-                                    }
-                                }
-
-                                break;
-                            }
-
-                            g.DrawString(text, textDisplayItem.Font, fontSize, color, x, y, textDisplayItem.RightAlign, textDisplayItem.CenterAlign,
-                                textDisplayItem.Bold, textDisplayItem.Italic, textDisplayItem.Underline, textDisplayItem.Strikeout,
-                                textDisplayItem.Width);
-
-
-                            if (displayItem.Selected)
-                            {
-                                var size = textDisplayItem.EvaluateSize();
-                                int rectX = textDisplayItem.Width == 0 && textDisplayItem.RightAlign ? (int)(x - size.Width) : x;
-
-                                selectedRectangles.Add(new SelectedRectangle(rectX, y, (int)size.Width, (int)size.Height));
-                            }
-
-                            break;
-                        }
-                    case ImageDisplayItem imageDisplayItem:
-                        {
-                            if (imageDisplayItem is SensorImageDisplayItem sensorImageDisplayItem)
-                            {
-                                if (!sensorImageDisplayItem.ShouldShow())
-                                {
-                                    break;
-                                }
-                            }
-
-                            LockedImage? cachedImage = null;
-
-                            if (imageDisplayItem is HttpImageDisplayItem httpImageDisplayItem)
-                            {
-                                var sensorReading = httpImageDisplayItem.GetValue();
-
-                                if (sensorReading.HasValue && sensorReading.Value.ValueText != null)
-                                {
-                                    cachedImage = Cache.GetLocalImage(sensorReading.Value.ValueText);
-                                }
-                            }
-                            else
-                            {
-                                if (imageDisplayItem.CalculatedPath != null)
-                                {
-                                    cachedImage = Cache.GetLocalImage(imageDisplayItem.CalculatedPath);
-                                }
-                            }
-
-                            var size = imageDisplayItem.EvaluateSize();
-                            var scaledWidth = (int)size.Width;
-                            var scaledHeight = (int)size.Height;
-
-                            scaledWidth = (int)Math.Ceiling(scaledWidth * scale);
-                            scaledHeight = (int)Math.Ceiling(scaledHeight * scale);
-
-                            if (cachedImage != null)
-                            {
-                                g.DrawImage(cachedImage, x, y, scaledWidth, scaledHeight, imageDisplayItem.Rotation, (int)(x + scaledWidth / 2.0f), (int)(y + scaledHeight / 2.0f), imageDisplayItem.Cache && cache);
-
-                                if (imageDisplayItem.Layer)
-                                {
-                                    g.FillRectangle(imageDisplayItem.LayerColor, x, y, scaledWidth, scaledHeight);
-                                }
-                            }
-
-                            if (displayItem.Selected)
-                            {
-                                selectedRectangles.Add(new SelectedRectangle(x - 2, y - 2, scaledWidth + 4, scaledHeight + 4, imageDisplayItem.Rotation));
-                            }
-                            break;
-                        }
-                    case GaugeDisplayItem gaugeDisplayItem:
-                        {
-                            var imageDisplayItem = gaugeDisplayItem.EvaluateImage();
-
-                            if (imageDisplayItem?.CalculatedPath != null)
-                            {
-                                var cachedImage = Cache.GetLocalImage(imageDisplayItem.CalculatedPath);
-
-                                if (cachedImage != null)
-                                {
-                                    var scaledWidth = gaugeDisplayItem.Width;
-                                    var scaledHeight = gaugeDisplayItem.Height;
-
-                                    if (scaledWidth == 0)
-                                    {
-                                        scaledWidth = cachedImage.Width;
-                                    }
-
-                                    if (scaledHeight == 0)
-                                    {
-                                        scaledHeight = cachedImage.Height;
-                                    }
-
-                                    scaledWidth = (int)Math.Ceiling(scaledWidth * gaugeDisplayItem.Scale / 100.0f * scale);
-                                    scaledHeight = (int)Math.Ceiling(scaledHeight * gaugeDisplayItem.Scale / 100.0f * scale);
-
-                                    g.DrawImage(cachedImage, x, y, scaledWidth, scaledHeight, 0, 0, 0, cache);
-
-                                    if (displayItem.Selected)
-                                    {
-                                        selectedRectangles.Add(new SelectedRectangle(x - 2, y - 2, scaledWidth + 4, scaledHeight + 4));
-                                    }
-                                }
-                            }
-                            break;
-                        }
-                    case ChartDisplayItem chartDisplayItem:
-                        if (g is CompatGraphics)
-                        {
-                            var width = scale == 1 ? (int)chartDisplayItem.Width : (int)Math.Ceiling(chartDisplayItem.Width * scale);
-                            var height = scale == 1 ? (int)chartDisplayItem.Height : (int)Math.Ceiling(chartDisplayItem.Height * scale);
-                            using var graphBitmap = new Bitmap(chartDisplayItem.Width, chartDisplayItem.Height);
-                            using var g1 = CompatGraphics.FromBitmap(graphBitmap);
-                            GraphDraw.Run(chartDisplayItem, g1);
-
-                            if (chartDisplayItem.FlipX)
-                            {
-                                graphBitmap.RotateFlip(RotateFlipType.RotateNoneFlipX);
-                            }
-
-                            g.DrawBitmap(graphBitmap, x, y, width, height);
-                        }
-                        else if (g is AcceleratedGraphics acceleratedGraphics)
-                        {
-                            using var d2dGraphics = acceleratedGraphics.D2DDevice
-                                .CreateBitmapGraphics(chartDisplayItem.Width, chartDisplayItem.Height);
-
-                            if (d2dGraphics != null)
-                            {
-                                //d2dGraphics.SetDPI(96, 96);
-                                d2dGraphics.Antialias = true;
-
-                                if (chartDisplayItem.FlipX)
-                                {
-                                    var flipMatrix = Matrix3x2.CreateScale(-1.0f, 1.0f) *
-                                         Matrix3x2.CreateTranslation(chartDisplayItem.Width, 0);
-                                    d2dGraphics.SetTransform(flipMatrix);
-                                }
-
-                                using var g1 = AcceleratedGraphics.FromD2DGraphics(d2dGraphics, acceleratedGraphics);
-                                d2dGraphics.BeginRender();
-                                GraphDraw.Run(chartDisplayItem, g1);
-                                d2dGraphics.EndRender();
-
-                                g.DrawBitmap(d2dGraphics, chartDisplayItem.X, chartDisplayItem.Y, chartDisplayItem.Width, chartDisplayItem.Height);
-                            }
-                        }
-
-                        if (displayItem.Selected)
-                        {
-                            selectedRectangles.Add(new SelectedRectangle(chartDisplayItem.X - 2, chartDisplayItem.Y - 2, chartDisplayItem.Width + 4, chartDisplayItem.Height + 4));
-                        }
-
-                        break;
-                }
+                Draw(g, scale, cache, displayItem, selectedRectangles);
             }
 
             if (drawSelected && SharedModel.Instance.SelectedProfile == profile && selectedRectangles.Any())
@@ -355,5 +127,247 @@ namespace InfoPanel.Drawing
                 }
             }
         }
+
+        private static void Draw(MyGraphics g, double scale, bool cache, DisplayItem displayItem, List<SelectedRectangle> selectedRectangles)
+        {
+            var x = (int)Math.Ceiling(displayItem.X * scale);
+            var y = (int)Math.Ceiling(displayItem.Y * scale);
+
+            switch (displayItem)
+            {
+                case GroupDisplayItem groupDisplayItem:
+                    {
+                        foreach (var item in groupDisplayItem.DisplayItems)
+                        {
+                            if (item.Hidden) continue;
+                            Draw(g, scale, cache, item, selectedRectangles);
+                        }
+                        break;
+                    }
+                case TextDisplayItem textDisplayItem:
+                    {
+
+                        var fontSize = (int)Math.Ceiling(textDisplayItem.FontSize * scale);
+                        (var text, var color) = textDisplayItem.EvaluateTextAndColor();
+
+                        if (textDisplayItem is TableSensorDisplayItem tableSensorDisplayItem
+                            && tableSensorDisplayItem.GetValue() is SensorReading sensorReading
+                            && sensorReading.ValueTable is DataTable table)
+                        {
+                            var format = tableSensorDisplayItem.TableFormat;
+
+                            var maxRows = tableSensorDisplayItem.MaxRows;
+
+                            var formatParts = format.Split('|');
+
+                            if (formatParts.Length > 0)
+                            {
+                                (float fWidth, float fHeight) = g.MeasureString("A", textDisplayItem.Font, fontSize, textDisplayItem.Bold,
+                                              textDisplayItem.Italic, textDisplayItem.Underline, textDisplayItem.Strikeout);
+
+                                var tWidth = 0;
+                                for (int i = 0; i < formatParts.Length; i++)
+                                {
+                                    var split = formatParts[i].Split(':');
+                                    if (split.Length == 2)
+                                    {
+                                        if (int.TryParse(split[0], out var column) && column < table.Columns.Count && int.TryParse(split[1], out var length))
+                                        {
+                                            if (tableSensorDisplayItem.ShowHeader)
+                                            {
+                                                g.DrawString(table.Columns[column].ColumnName, textDisplayItem.Font, fontSize, color,
+                                                    x + tWidth, y,
+                                          i != 0 && textDisplayItem.RightAlign, textDisplayItem.CenterAlign, textDisplayItem.Bold,
+                                          textDisplayItem.Italic, textDisplayItem.Underline,
+                                          textDisplayItem.Strikeout, length, 0);
+                                            }
+
+                                            var rows = Math.Min(table.Rows.Count, maxRows);
+
+                                            for (int j = 0; j < rows; j++)
+                                            {
+                                                var col = table.Rows[j][column];
+
+                                                if (table.Rows[j][column] is IPluginData pluginData)
+                                                {
+
+                                                    g.DrawString(pluginData.ToString(), textDisplayItem.Font, fontSize, color,
+                                                        x + tWidth, (int)(y + (fHeight * (j + (tableSensorDisplayItem.ShowHeader ? 1 : 0)))),
+                                       i != 0 && textDisplayItem.RightAlign, textDisplayItem.CenterAlign, textDisplayItem.Bold,
+                                       textDisplayItem.Italic, textDisplayItem.Underline,
+                                       textDisplayItem.Strikeout, length, 0);
+                                                }
+                                            }
+
+                                            tWidth += length + 10;
+                                        }
+                                    }
+                                }
+
+                                if (displayItem.Selected)
+                                {
+                                    var size = tableSensorDisplayItem.EvaluateSize();
+                                    selectedRectangles.Add(new SelectedRectangle(x, y, (int)size.Width, (int)size.Height));
+                                }
+                            }
+
+                            break;
+                        }
+
+                        g.DrawString(text, textDisplayItem.Font, fontSize, color, x, y, textDisplayItem.RightAlign, textDisplayItem.CenterAlign,
+                            textDisplayItem.Bold, textDisplayItem.Italic, textDisplayItem.Underline, textDisplayItem.Strikeout,
+                            textDisplayItem.Width);
+
+
+                        if (displayItem.Selected)
+                        {
+                            var size = textDisplayItem.EvaluateSize();
+                            int rectX = textDisplayItem.Width == 0 && textDisplayItem.RightAlign ? (int)(x - size.Width) : x;
+
+                            selectedRectangles.Add(new SelectedRectangle(rectX, y, (int)size.Width, (int)size.Height));
+                        }
+
+                        break;
+                    }
+                case ImageDisplayItem imageDisplayItem:
+                    {
+                        if (imageDisplayItem is SensorImageDisplayItem sensorImageDisplayItem)
+                        {
+                            if (!sensorImageDisplayItem.ShouldShow())
+                            {
+                                break;
+                            }
+                        }
+
+                        LockedImage? cachedImage = null;
+
+                        if (imageDisplayItem is HttpImageDisplayItem httpImageDisplayItem)
+                        {
+                            var sensorReading = httpImageDisplayItem.GetValue();
+
+                            if (sensorReading.HasValue && sensorReading.Value.ValueText != null)
+                            {
+                                cachedImage = Cache.GetLocalImage(sensorReading.Value.ValueText);
+                            }
+                        }
+                        else
+                        {
+                            if (imageDisplayItem.CalculatedPath != null)
+                            {
+                                cachedImage = Cache.GetLocalImage(imageDisplayItem.CalculatedPath);
+                            }
+                        }
+
+                        var size = imageDisplayItem.EvaluateSize();
+                        var scaledWidth = (int)size.Width;
+                        var scaledHeight = (int)size.Height;
+
+                        scaledWidth = (int)Math.Ceiling(scaledWidth * scale);
+                        scaledHeight = (int)Math.Ceiling(scaledHeight * scale);
+
+                        if (cachedImage != null)
+                        {
+                            g.DrawImage(cachedImage, x, y, scaledWidth, scaledHeight, imageDisplayItem.Rotation, (int)(x + scaledWidth / 2.0f), (int)(y + scaledHeight / 2.0f), imageDisplayItem.Cache && cache);
+
+                            if (imageDisplayItem.Layer)
+                            {
+                                g.FillRectangle(imageDisplayItem.LayerColor, x, y, scaledWidth, scaledHeight);
+                            }
+                        }
+
+                        if (displayItem.Selected)
+                        {
+                            selectedRectangles.Add(new SelectedRectangle(x - 2, y - 2, scaledWidth + 4, scaledHeight + 4, imageDisplayItem.Rotation));
+                        }
+                        break;
+                    }
+                case GaugeDisplayItem gaugeDisplayItem:
+                    {
+                        var imageDisplayItem = gaugeDisplayItem.EvaluateImage();
+
+                        if (imageDisplayItem?.CalculatedPath != null)
+                        {
+                            var cachedImage = Cache.GetLocalImage(imageDisplayItem.CalculatedPath);
+
+                            if (cachedImage != null)
+                            {
+                                var scaledWidth = gaugeDisplayItem.Width;
+                                var scaledHeight = gaugeDisplayItem.Height;
+
+                                if (scaledWidth == 0)
+                                {
+                                    scaledWidth = cachedImage.Width;
+                                }
+
+                                if (scaledHeight == 0)
+                                {
+                                    scaledHeight = cachedImage.Height;
+                                }
+
+                                scaledWidth = (int)Math.Ceiling(scaledWidth * gaugeDisplayItem.Scale / 100.0f * scale);
+                                scaledHeight = (int)Math.Ceiling(scaledHeight * gaugeDisplayItem.Scale / 100.0f * scale);
+
+                                g.DrawImage(cachedImage, x, y, scaledWidth, scaledHeight, 0, 0, 0, cache);
+
+                                if (displayItem.Selected)
+                                {
+                                    selectedRectangles.Add(new SelectedRectangle(x - 2, y - 2, scaledWidth + 4, scaledHeight + 4));
+                                }
+                            }
+                        }
+                        break;
+                    }
+                case ChartDisplayItem chartDisplayItem:
+                    if (g is CompatGraphics)
+                    {
+                        var width = scale == 1 ? (int)chartDisplayItem.Width : (int)Math.Ceiling(chartDisplayItem.Width * scale);
+                        var height = scale == 1 ? (int)chartDisplayItem.Height : (int)Math.Ceiling(chartDisplayItem.Height * scale);
+                        using var graphBitmap = new Bitmap(chartDisplayItem.Width, chartDisplayItem.Height);
+                        using var g1 = CompatGraphics.FromBitmap(graphBitmap);
+                        GraphDraw.Run(chartDisplayItem, g1);
+
+                        if (chartDisplayItem.FlipX)
+                        {
+                            graphBitmap.RotateFlip(RotateFlipType.RotateNoneFlipX);
+                        }
+
+                        g.DrawBitmap(graphBitmap, x, y, width, height);
+                    }
+                    else if (g is AcceleratedGraphics acceleratedGraphics)
+                    {
+                        using var d2dGraphics = acceleratedGraphics.D2DDevice
+                            .CreateBitmapGraphics(chartDisplayItem.Width, chartDisplayItem.Height);
+
+                        if (d2dGraphics != null)
+                        {
+                            //d2dGraphics.SetDPI(96, 96);
+                            d2dGraphics.Antialias = true;
+
+                            if (chartDisplayItem.FlipX)
+                            {
+                                var flipMatrix = Matrix3x2.CreateScale(-1.0f, 1.0f) *
+                                     Matrix3x2.CreateTranslation(chartDisplayItem.Width, 0);
+                                d2dGraphics.SetTransform(flipMatrix);
+                            }
+
+                            using var g1 = AcceleratedGraphics.FromD2DGraphics(d2dGraphics, acceleratedGraphics);
+                            d2dGraphics.BeginRender();
+                            GraphDraw.Run(chartDisplayItem, g1);
+                            d2dGraphics.EndRender();
+
+                            g.DrawBitmap(d2dGraphics, chartDisplayItem.X, chartDisplayItem.Y, chartDisplayItem.Width, chartDisplayItem.Height);
+                        }
+                    }
+
+                    if (displayItem.Selected)
+                    {
+                        selectedRectangles.Add(new SelectedRectangle(chartDisplayItem.X - 2, chartDisplayItem.Y - 2, chartDisplayItem.Width + 4, chartDisplayItem.Height + 4));
+                    }
+
+                    break;
+            }
+        }
+
+
     }
 }

--- a/InfoPanel/Models/DisplayItem.cs
+++ b/InfoPanel/Models/DisplayItem.cs
@@ -47,6 +47,8 @@ public abstract class DisplayItem : ObservableObject, ICloneable
         {
             switch (this)
             {
+                case GroupDisplayItem:
+                    return "Group";
                 case SensorDisplayItem:
                     return "Sensor";
                 case TableSensorDisplayItem:

--- a/InfoPanel/Models/DisplayItem.cs
+++ b/InfoPanel/Models/DisplayItem.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using System;
 using System.ComponentModel;
 using System.Drawing;
@@ -8,7 +9,7 @@ using System.Xml.Serialization;
 namespace InfoPanel.Models;
 
 [Serializable]
-public abstract class DisplayItem : ObservableObject, ICloneable
+public abstract partial class DisplayItem : ObservableObject, ICloneable
 {
     [XmlIgnore]
     public Guid Guid { get; set; } = Guid.NewGuid();

--- a/InfoPanel/Models/GroupDisplayItem.cs
+++ b/InfoPanel/Models/GroupDisplayItem.cs
@@ -1,0 +1,52 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Xml.Serialization;
+
+namespace InfoPanel.Models
+{
+    public partial class GroupDisplayItem : DisplayItem
+    {
+        public ObservableCollection<DisplayItem> DisplayItems { get; } = [];
+
+        [ObservableProperty]
+        private bool _isExpanded = true;
+
+
+        public override object Clone()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Rect EvaluateBounds()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string EvaluateColor()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override SizeF EvaluateSize()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string EvaluateText()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override (string, string) EvaluateTextAndColor()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/InfoPanel/Models/GroupDisplayItem.cs
+++ b/InfoPanel/Models/GroupDisplayItem.cs
@@ -18,6 +18,21 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _isExpanded = true;
 
+        public new int X
+        {
+            get { return 0; }
+            set
+            {
+            }
+        }
+        public new int Y
+        {
+            get { return 0; }
+            set
+            {
+            }
+        }
+
 
         public override object Clone()
         {

--- a/InfoPanel/Models/GroupDisplayItem.cs
+++ b/InfoPanel/Models/GroupDisplayItem.cs
@@ -1,7 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Drawing;
 using System.Linq;
 using System.Text;
@@ -16,23 +18,34 @@ namespace InfoPanel.Models
         public ObservableCollection<DisplayItem> DisplayItems { get; } = [];
 
         [ObservableProperty]
+        private int _displayItemsCount;
+
+        [ObservableProperty]
         private bool _isExpanded = true;
 
-        public new int X
+        [ObservableProperty]
+        private bool _isLocked = false;
+
+        public GroupDisplayItem()
         {
-            get { return 0; }
-            set
-            {
-            }
-        }
-        public new int Y
-        {
-            get { return 0; }
-            set
-            {
-            }
+            // Initialize count
+            DisplayItemsCount = DisplayItems.Count;
+
+            // Subscribe to collection changes
+            DisplayItems.CollectionChanged += OnDisplayItemsChanged;
         }
 
+        private void OnDisplayItemsChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            DisplayItemsCount = DisplayItems.Count;
+        }
+
+
+        [RelayCommand]
+        private void ToggleLock()
+        {
+            IsLocked = !IsLocked;
+        }
 
         public override object Clone()
         {

--- a/InfoPanel/Models/GroupDisplayItem.cs
+++ b/InfoPanel/Models/GroupDisplayItem.cs
@@ -21,7 +21,17 @@ namespace InfoPanel.Models
 
         public override object Clone()
         {
-            throw new NotImplementedException();
+            var clone = new GroupDisplayItem
+            {
+                Name = Name
+            };
+
+            foreach (var displayItem in DisplayItems)
+            {
+                clone.DisplayItems.Add((DisplayItem)displayItem.Clone());
+            }
+
+            return clone;
         }
 
         public override Rect EvaluateBounds()

--- a/InfoPanel/Models/SharedModel.cs
+++ b/InfoPanel/Models/SharedModel.cs
@@ -328,8 +328,16 @@ namespace InfoPanel
             }
             set
             {
-                //SetProperty(ref _selectedItem, value);
-                //IsItemSelected = value != null;
+                if (value is DisplayItem displayItem)
+                {
+                   foreach(var selectedItem in SelectedItems)
+                    {
+                        selectedItem.Selected = false;
+                    }
+
+                    displayItem.Selected = true;
+                    NotifySelectedItemChange();
+                }
             }
         }
 
@@ -477,16 +485,16 @@ namespace InfoPanel
                 }
 
                 // Moving into a group
-                if (parentGroup == null)
+                if (displayItem is not GroupDisplayItem && parentGroup == null)
                 {
                     int targetIndex = index + count;
                     if (targetIndex >= 0 && targetIndex < DisplayItems.Count)
                     {
                         var target = DisplayItems[targetIndex];
-                        if (target is GroupDisplayItem targetGroup && targetGroup.DisplayItems != null)
+                        if (target is GroupDisplayItem targetGroup && targetGroup.IsExpanded && targetGroup.DisplayItems != null)
                         {
                             parentCollection.RemoveAt(index);
-                            targetGroup.DisplayItems.Insert(0, displayItem);
+                            targetGroup.DisplayItems.Insert(count > 0 ? 0: targetGroup.DisplayItems.Count, displayItem);
                             return;
                         }
                     }

--- a/InfoPanel/Services/BeadaPanelTask.cs
+++ b/InfoPanel/Services/BeadaPanelTask.cs
@@ -241,9 +241,9 @@ namespace InfoPanel
                             {
                                 stopwatch2.Restart();
                                 dataWriter.Write(frame, 2000, out int _);
-                                Trace.WriteLine($"Post render: {stopwatch2.ElapsedMilliseconds}ms.");
+                                //Trace.WriteLine($"Post render: {stopwatch2.ElapsedMilliseconds}ms.");
                                 fpsCounter.Update();
-                                Trace.WriteLine($"FPS: {fpsCounter.FramesPerSecond}");
+                                //Trace.WriteLine($"FPS: {fpsCounter.FramesPerSecond}");
 
                                 SharedModel.Instance.BeadaPanelFrameRate = fpsCounter.FramesPerSecond;
                                 SharedModel.Instance.BeadaPanelFrameTime = stopwatch2.ElapsedMilliseconds;
@@ -252,7 +252,7 @@ namespace InfoPanel
                                 if (stopwatch2.ElapsedMilliseconds < targetFrameTime)
                                 {
                                     var sleep = (int)(targetFrameTime - stopwatch2.ElapsedMilliseconds);
-                                    Trace.WriteLine($"Sleep {sleep}ms");
+                                    //Trace.WriteLine($"Sleep {sleep}ms");
                                     await Task.Delay(sleep, token);
                                 }
                             }

--- a/InfoPanel/ViewModels/DesignViewModel.cs
+++ b/InfoPanel/ViewModels/DesignViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using InfoPanel.Models;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,7 @@ using Wpf.Ui.Mvvm.Contracts;
 
 namespace InfoPanel.ViewModels
 {
-    public class DesignViewModel : ObservableObject, INavigationAware
+    public partial class DesignViewModel : ObservableObject, INavigationAware
     {
         private readonly INavigationService _navigationService;
         private ICommand? _navigateCommand;

--- a/InfoPanel/Views/Components/CommonProperties.xaml
+++ b/InfoPanel/Views/Components/CommonProperties.xaml
@@ -1,79 +1,131 @@
-﻿<UserControl x:Class="InfoPanel.Views.Components.CommonProperties"
-      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-      xmlns:local="clr-namespace:InfoPanel.Views.Components"
-      xmlns:app="clr-namespace:InfoPanel"
-      xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
-      xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
-      mc:Ignorable="d" 
-      Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-      DataContext="{Binding RelativeSource={RelativeSource self}}">
+﻿<UserControl
+    x:Class="InfoPanel.Views.Components.CommonProperties"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:app="clr-namespace:InfoPanel"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:InfoPanel.Views.Components"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    DataContext="{Binding RelativeSource={RelativeSource self}}"
+    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+    mc:Ignorable="d">
 
-    <Grid Margin="0,0,0,0" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem, Converter={StaticResource NullToBooleanConverter}}">
+    <Grid Margin="0,0,0,0" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}">
         <Grid.RowDefinitions>
-            <RowDefinition Height="auto"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="auto"/>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="auto" />
         </Grid.RowDefinitions>
-        <StackPanel Grid.Row="2" Orientation="Vertical" Margin="0,0,0,0">
-            <ui:NumberBox Margin="0,8,0,0" TextChanged="NumberBoxX_TextChanged"
-                       FontSize="12" MaxDecimalPlaces="1"
-                       SmallChange="{Binding Source={x:Static app:SharedModel.Instance}, Path=MoveValue}"
-                       Text="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.X}"/>
-             <TextBlock Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="Position X" FontSize="12" Margin="5,0,0,0" />
+        <StackPanel
+            Grid.Row="2"
+            Margin="0,0,0,0"
+            Orientation="Vertical">
+            <ui:NumberBox
+                Margin="0,8,0,0"
+                FontSize="12"
+                MaxDecimalPlaces="1"
+                SmallChange="{Binding Source={x:Static app:SharedModel.Instance}, Path=MoveValue}"
+                Text="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.X}"
+                TextChanged="NumberBoxX_TextChanged" />
+            <TextBlock
+                Margin="5,0,0,0"
+                FontSize="12"
+                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                Text="Position X" />
 
-           <ui:NumberBox Margin="0,8,0,0" TextChanged="NumberBoxY_TextChanged"
-                   FontSize="12" MaxDecimalPlaces="1"
-                   SmallChange="{Binding Source={x:Static app:SharedModel.Instance}, Path=MoveValue}"
-                   Text="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Y}"/>
-             <TextBlock Foreground="{DynamicResource TextFillColorDisabledBrush}" Text="Position Y" FontSize="12" Margin="5,0,0,0" />
+            <ui:NumberBox
+                Margin="0,8,0,0"
+                FontSize="12"
+                MaxDecimalPlaces="1"
+                SmallChange="{Binding Source={x:Static app:SharedModel.Instance}, Path=MoveValue}"
+                Text="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Y}"
+                TextChanged="NumberBoxY_TextChanged" />
+            <TextBlock
+                Margin="5,0,0,0"
+                FontSize="12"
+                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                Text="Position Y" />
         </StackPanel>
 
         <Grid Grid.Row="0" Margin="0,10,0,0">
             <Grid.RowDefinitions>
-                <RowDefinition/>
-                <RowDefinition/>
-                <RowDefinition/>
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
             </Grid.RowDefinitions>
 
             <Grid.ColumnDefinitions>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
-                <ColumnDefinition/>
+                <ColumnDefinition />
+                <ColumnDefinition />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
 
-            <ui:Button 
-                x:Name="ButtonLeft" Icon="ArrowLeft20"
-                  Grid.Row="1" Margin="0,0,10,0" Width="40" Height="40"
-                  CommandParameter="{x:Static Dock.Left}"
-                  Click="ButtonLeft_Click" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+            <ui:Button
+                x:Name="ButtonLeft"
+                Grid.Row="1"
+                Width="40"
+                Height="40"
+                Margin="0,0,10,0"
+                Click="ButtonLeft_Click"
+                CommandParameter="{x:Static Dock.Left}"
+                Icon="ArrowLeft20"
+                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
 
-            <ui:Button x:Name="ButtonUp" Grid.Row="0" Icon="ArrowUp20"
-                  Grid.Column="1" Margin="0,0,0,10" Width="40" Height="40"
-                  CommandParameter="{x:Static Dock.Top}"
-                 Click="ButtonUp_Click" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+            <ui:Button
+                x:Name="ButtonUp"
+                Grid.Row="0"
+                Grid.Column="1"
+                Width="40"
+                Height="40"
+                Margin="0,0,0,10"
+                Click="ButtonUp_Click"
+                CommandParameter="{x:Static Dock.Top}"
+                Icon="ArrowUp20"
+                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
 
 
-            <ui:Button x:Name="ButtonRight" Grid.Row="1" Icon="ArrowRight20"
-                  Grid.Column="2" Margin="10,0,0,0" Width="40" Height="40"
-                  CommandParameter="{x:Static Dock.Right}"
-                  Click="ButtonRight_Click" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+            <ui:Button
+                x:Name="ButtonRight"
+                Grid.Row="1"
+                Grid.Column="2"
+                Width="40"
+                Height="40"
+                Margin="10,0,0,0"
+                Click="ButtonRight_Click"
+                CommandParameter="{x:Static Dock.Right}"
+                Icon="ArrowRight20"
+                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
 
 
-            <ui:Button x:Name="ButtonDown" Grid.Row="2" Icon="ArrowDown20"
-                  Grid.Column="1" Margin="0,10,0,0" Width="40" Height="40"
-                  CommandParameter="{x:Static Dock.Bottom}"
-                   Click="ButtonDown_Click" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+            <ui:Button
+                x:Name="ButtonDown"
+                Grid.Row="2"
+                Grid.Column="1"
+                Width="40"
+                Height="40"
+                Margin="0,10,0,0"
+                Click="ButtonDown_Click"
+                CommandParameter="{x:Static Dock.Bottom}"
+                Icon="ArrowDown20"
+                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
 
 
-            <ui:Button x:Name="ButtonMoveValue" 
-                 Grid.Row="1" Grid.Column="1" Margin="0,0,0,0" Width="40" Height="40"
-                  Click="ButtonMoveValue_Click" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem.Hidden, Converter={StaticResource InverseBooleanConverter}}">
+            <ui:Button
+                x:Name="ButtonMoveValue"
+                Grid.Row="1"
+                Grid.Column="1"
+                Width="40"
+                Height="40"
+                Margin="0,0,0,0"
+                Click="ButtonMoveValue_Click">
                 <Button.Content>
-                    <TextBlock TextDecorations="Underline" Margin="-10,0,-10,0" FontSize="12"
-                                Text="{Binding Source={x:Static app:SharedModel.Instance}, Path=MoveValue, StringFormat={}{0} px}"/>
+                    <TextBlock
+                        Margin="-10,0,-10,0"
+                        FontSize="12"
+                        Text="{Binding Source={x:Static app:SharedModel.Instance}, Path=MoveValue, StringFormat={}{0} px}"
+                        TextDecorations="Underline" />
                 </Button.Content>
             </ui:Button>
         </Grid>

--- a/InfoPanel/Views/Components/CommonProperties.xaml
+++ b/InfoPanel/Views/Components/CommonProperties.xaml
@@ -12,7 +12,7 @@
     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
     mc:Ignorable="d">
 
-    <Grid Margin="0,0,0,0" IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}">
+    <Grid Margin="0,0,0,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="auto" />
             <RowDefinition Height="*" />
@@ -21,6 +21,7 @@
         <StackPanel
             Grid.Row="2"
             Margin="0,0,0,0"
+            IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSelectedItemMovable}"
             Orientation="Vertical">
             <ui:NumberBox
                 Margin="0,8,0,0"
@@ -49,7 +50,10 @@
                 Text="Position Y" />
         </StackPanel>
 
-        <Grid Grid.Row="0" Margin="0,10,0,0">
+        <Grid
+            Grid.Row="0"
+            Margin="0,10,0,0"
+            IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSelectedItemsMovable}">
             <Grid.RowDefinitions>
                 <RowDefinition />
                 <RowDefinition />
@@ -70,8 +74,7 @@
                 Margin="0,0,10,0"
                 Click="ButtonLeft_Click"
                 CommandParameter="{x:Static Dock.Left}"
-                Icon="ArrowLeft20"
-                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
+                Icon="ArrowLeft20" />
 
             <ui:Button
                 x:Name="ButtonUp"
@@ -82,8 +85,7 @@
                 Margin="0,0,0,10"
                 Click="ButtonUp_Click"
                 CommandParameter="{x:Static Dock.Top}"
-                Icon="ArrowUp20"
-                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
+                Icon="ArrowUp20" />
 
 
             <ui:Button
@@ -95,8 +97,7 @@
                 Margin="10,0,0,0"
                 Click="ButtonRight_Click"
                 CommandParameter="{x:Static Dock.Right}"
-                Icon="ArrowRight20"
-                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
+                Icon="ArrowRight20" />
 
 
             <ui:Button
@@ -108,8 +109,7 @@
                 Margin="0,10,0,0"
                 Click="ButtonDown_Click"
                 CommandParameter="{x:Static Dock.Bottom}"
-                Icon="ArrowDown20"
-                IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemMovable}" />
+                Icon="ArrowDown20" />
 
 
             <ui:Button

--- a/InfoPanel/Views/Components/CommonProperties.xaml.cs
+++ b/InfoPanel/Views/Components/CommonProperties.xaml.cs
@@ -30,34 +30,56 @@ namespace InfoPanel.Views.Components
 
         private void ButtonUp_Click(object sender, RoutedEventArgs e)
         {
-            if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //{
+            //    displayItem.Y -= SharedModel.Instance.MoveValue;
+            //}
+
+            foreach (var item in SharedModel.Instance.SelectedItems)
             {
-                displayItem.Y -= SharedModel.Instance.MoveValue;
+                item.Y -= SharedModel.Instance.MoveValue;
             }
         }
 
         private void ButtonDown_Click(object sender, RoutedEventArgs e)
         {
-            if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //{
+            //    displayItem.Y += SharedModel.Instance.MoveValue;
+            //}
+
+            foreach (var item in SharedModel.Instance.SelectedItems)
             {
-                displayItem.Y += SharedModel.Instance.MoveValue;
+                item.Y += SharedModel.Instance.MoveValue;
             }
         }
 
         private void ButtonLeft_Click(object sender, RoutedEventArgs e)
         {
-            if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //{
+            //    displayItem.X -= SharedModel.Instance.MoveValue;
+            //}
+
+            foreach (var item in SharedModel.Instance.SelectedItems)
             {
-                displayItem.X -= SharedModel.Instance.MoveValue;
+                item.X -= SharedModel.Instance.MoveValue;
             }
         }
 
         private void ButtonRight_Click(object sender, RoutedEventArgs e)
         {
-            if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //if (SharedModel.Instance.SelectedItem is DisplayItem displayItem)
+            //{
+            //    displayItem.X += SharedModel.Instance.MoveValue;
+            //}
+
+            foreach (var item in SharedModel.Instance.SelectedItems)
             {
-                displayItem.X += SharedModel.Instance.MoveValue;
+                item.X += SharedModel.Instance.MoveValue;
             }
+
+
         }
 
         private void ButtonMoveValue_Click(object sender, RoutedEventArgs e)

--- a/InfoPanel/Views/Components/DisplayItemView.xaml
+++ b/InfoPanel/Views/Components/DisplayItemView.xaml
@@ -1,0 +1,115 @@
+﻿<UserControl
+    x:Class="InfoPanel.Views.Components.DisplayItemView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:InfoPanel.Views.Components"
+    xmlns:ui="clr-namespace:Wpf.Ui.Controls;assembly=Wpf.Ui"
+    x:Name="Root"
+    Width="Auto"
+    Height="Auto">
+    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="25" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="30" />
+            <ColumnDefinition Width="80" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <!--  Symbol Icon  -->
+        <ui:SymbolIcon
+            Grid.Column="0"
+            Width="20"
+            Height="20"
+            Margin="0,4,5,0"
+            VerticalAlignment="Center">
+            <ui:SymbolIcon.Style>
+                <Style BasedOn="{StaticResource {x:Type ui:SymbolIcon}}" TargetType="{x:Type ui:SymbolIcon}">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding Kind}" Value="Text">
+                            <Setter Property="Symbol" Value="Text16" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Image">
+                            <Setter Property="Symbol" Value="Image20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Sensor">
+                            <Setter Property="Symbol" Value="Temperature20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Table">
+                            <Setter Property="Symbol" Value="Table20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Clock">
+                            <Setter Property="Symbol" Value="Clock20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Calendar">
+                            <Setter Property="Symbol" Value="Calendar3Day20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Graph">
+                            <Setter Property="Symbol" Value="DataBarVertical20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Bar">
+                            <Setter Property="Symbol" Value="DataBarHorizontal20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Donut">
+                            <Setter Property="Symbol" Value="DataPie20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Gauge">
+                            <Setter Property="Symbol" Value="Gauge20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Sensor Image">
+                            <Setter Property="Symbol" Value="CircleImage20" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Http Image">
+                            <Setter Property="Symbol" Value="WebAsset20" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ui:SymbolIcon.Style>
+        </ui:SymbolIcon>
+
+        <!--  Name  -->
+        <TextBlock
+            Grid.Column="1"
+            VerticalAlignment="Center"
+            Text="{Binding Name}"
+            TextTrimming="CharacterEllipsis" />
+
+        <!--  Sensor Type Icon  -->
+        <Image
+            Grid.Column="2"
+            Width="20"
+            Height="20"
+            Margin="0,4,10,0"
+            VerticalAlignment="Center">
+            <Image.Style>
+                <Style TargetType="Image">
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="HwInfo">
+                            <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/hwinfo_icon.ico" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="Libre">
+                            <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/libre_icon.ico" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Image.Style>
+        </Image>
+
+        <!--  Coordinates  -->
+        <TextBlock Grid.Column="3" VerticalAlignment="Center">
+            <TextBlock.Text>
+                <MultiBinding StringFormat="{}{0}, {1}">
+                    <Binding Path="X" />
+                    <Binding Path="Y" />
+                </MultiBinding>
+            </TextBlock.Text>
+        </TextBlock>
+
+        <!--  Visibility Checkbox  -->
+        <CheckBox
+            Grid.Column="4"
+            Margin="10,0,0,0"
+            VerticalAlignment="Center"
+            IsChecked="{Binding Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+    </Grid>
+</UserControl>

--- a/InfoPanel/Views/Components/DisplayItemView.xaml
+++ b/InfoPanel/Views/Components/DisplayItemView.xaml
@@ -10,7 +10,7 @@
     <Grid HorizontalAlignment="Stretch" VerticalAlignment="Center">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="25" />
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="200" />
             <ColumnDefinition Width="30" />
             <ColumnDefinition Width="80" />
             <ColumnDefinition Width="Auto" />
@@ -79,7 +79,7 @@
             Grid.Column="2"
             Width="20"
             Height="20"
-            Margin="0,4,10,0"
+            Margin="0,0,10,0"
             VerticalAlignment="Center">
             <Image.Style>
                 <Style TargetType="Image">
@@ -96,7 +96,10 @@
         </Image>
 
         <!--  Coordinates  -->
-        <TextBlock Grid.Column="3" VerticalAlignment="Center">
+        <TextBlock
+            Grid.Column="3"
+            HorizontalAlignment="Left"
+            VerticalAlignment="Center">
             <TextBlock.Text>
                 <MultiBinding StringFormat="{}{0}, {1}">
                     <Binding Path="X" />

--- a/InfoPanel/Views/Components/DisplayItemView.xaml.cs
+++ b/InfoPanel/Views/Components/DisplayItemView.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace InfoPanel.Views.Components
+{
+    /// <summary>
+    /// Interaction logic for DisplayItemView.xaml
+    /// </summary>
+    public partial class DisplayItemView : UserControl
+    {
+        public DisplayItemView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/InfoPanel/Views/Components/DisplayItems.xaml
+++ b/InfoPanel/Views/Components/DisplayItems.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:app="clr-namespace:InfoPanel"
     xmlns:components="clr-namespace:InfoPanel.Views.Components"
+    xmlns:converters="clr-namespace:InfoPanel.Views.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:InfoPanel.Views.Components"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -13,80 +14,105 @@
     mc:Ignorable="d">
 
     <UserControl.Resources>
+        <converters:LockSymbolConverter x:Key="LockSymbolConverter" />
+        <converters:LockColorConverter x:Key="LockColorConverter" />
+
         <DataTemplate x:Key="SimpleItemTemplate_MarginA">
-            <local:DisplayItemView Margin="0,0,30,0" />
+            <local:DisplayItemView Width="375" Margin="10,0,30,0" />
         </DataTemplate>
 
         <DataTemplate x:Key="SimpleItemTemplate_MarginB">
-            <local:DisplayItemView Margin="0,0,15,0" />
+            <local:DisplayItemView Width="365" Margin="0,0,10,0" />
         </DataTemplate>
 
         <DataTemplate x:Key="GroupItemTemplate">
             <Expander
-                Grid.Row="1"
                 Margin="0,0,0,0"
+                HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 Background="#601A1a1a"
                 IsExpanded="{Binding IsExpanded}">
 
                 <Expander.Header>
-                    <StackPanel Margin="-10,-10,5,-10" Orientation="Horizontal">
-
+                    <Grid Margin="0,-8,0,-10" HorizontalAlignment="Stretch">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="auto" />
+                            <ColumnDefinition Width="auto" />
+                        </Grid.ColumnDefinitions>
                         <!--  Group Header  -->
-                        <Border PreviewMouseLeftButtonDown="Border_MouseDown">
-                            <StackPanel Orientation="Horizontal">
+                        <Border
+                            Grid.Column="0"
+                            Background="#00FFFFFF"
+                            PreviewMouseLeftButtonDown="Border_MouseDown">
+                            <Grid HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="auto" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="auto" />
+                                </Grid.ColumnDefinitions>
                                 <ui:SymbolIcon
                                     Width="20"
                                     Height="20"
-                                    Margin="10,0,0,0"
+                                    Margin="0,0,0,0"
                                     VerticalAlignment="Center"
                                     Symbol="Group24" />
                                 <TextBlock
-                                    Width="270"
-                                    Margin="5,0,0,5"
+                                    Grid.Column="1"
+                                    MaxWidth="180"
+                                    Margin="5,2,0,5"
+                                    HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
                                     FontSize="12"
                                     Text="{Binding Name}" />
-                            </StackPanel>
+                                <TextBlock
+                                    Grid.Column="2"
+                                    Margin="5,2,0,5"
+                                    VerticalAlignment="Center"
+                                    FontSize="12"
+                                    Foreground="Gray"
+                                    Text="{Binding DisplayItemsCount, StringFormat={} {0} Items}" />
+                            </Grid>
                         </Border>
 
-                        <ui:SymbolIcon
+                        <Button
+                            Grid.Column="1"
                             Width="20"
                             Height="20"
-                            Margin="10,5,-10,0"
+                            Margin="10,0,-10,0"
+                            Padding="0"
                             VerticalAlignment="Center"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            Command="{Binding ToggleLockCommand}"
                             Cursor="Hand"
-                            Foreground="Gray"
-                            Symbol="LockClosed24"
-                            Visibility="{Binding IsExpanded, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
-
-                        <ui:SymbolIcon
-                            Width="20"
-                            Height="20"
-                            Margin="10,5,-10,0"
-                            VerticalAlignment="Center"
-                            Cursor="Hand"
-                            Foreground="DodgerBlue"
-                            Symbol="LockOpen24"
-                            Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            ToolTip="Lock items from moving in and out">
+                            <ui:SymbolIcon Foreground="{Binding IsLocked, Converter={StaticResource LockColorConverter}}" Symbol="{Binding IsLocked, Converter={StaticResource LockSymbolConverter}}" />
+                        </Button>
 
                         <!--  Visibility Checkbox  -->
                         <CheckBox
-                            Margin="20,0,0,0"
+                            Grid.Column="2"
+                            Margin="20,0,5,0"
                             VerticalAlignment="Center"
                             IsChecked="{Binding Hidden, Converter={StaticResource InverseBooleanConverter}}" />
-                    </StackPanel>
+                    </Grid>
                 </Expander.Header>
                 <!--  Child Items ListView  -->
                 <ListView
-                    Margin="-5,-10,0,-10"
+                    Margin="0,-10,0,-10"
                     HorizontalContentAlignment="Stretch"
                     Background="Transparent"
                     BorderThickness="0"
                     ItemTemplate="{StaticResource SimpleItemTemplate_MarginB}"
                     ItemsSource="{Binding DisplayItems}"
+                    PreviewMouseWheel="InnerListView_PreviewMouseWheel"
+                    ScrollViewer.CanContentScroll="False"
+                    ScrollViewer.VerticalScrollBarVisibility="Disabled"
                     SelectionChanged="ListViewGroupItems_SelectionChanged"
-                    SelectionMode="Extended">
+                    SelectionMode="Extended"
+                    VirtualizingStackPanel.IsVirtualizing="False"
+                    VirtualizingStackPanel.IsVirtualizingWhenGrouping="False">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="Margin" Value="0,1,0,1" />
@@ -163,7 +189,7 @@
                     <!--  Name  -->
                     <TextBlock
                         Width="200"
-                        Margin="25,0,0,0"
+                        Margin="35,0,0,0"
                         VerticalAlignment="Center"
                         Text="Name"
                         TextTrimming="CharacterEllipsis" />
@@ -191,9 +217,12 @@
                     Background="Transparent"
                     ItemTemplateSelector="{StaticResource PanelItemsSelector}"
                     ItemsSource="{Binding Source={x:Static app:SharedModel.Instance}, Path=DisplayItems}"
+                    ScrollViewer.CanContentScroll="False"
                     ScrollViewer.VerticalScrollBarVisibility="Visible"
                     SelectionChanged="ListViewItems_SelectionChanged"
-                    SelectionMode="Extended">
+                    SelectionMode="Extended"
+                    VirtualizingStackPanel.IsVirtualizing="False"
+                    VirtualizingStackPanel.IsVirtualizingWhenGrouping="False">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
                             <Setter Property="Margin" Value="0,1,0,1" />

--- a/InfoPanel/Views/Components/DisplayItems.xaml
+++ b/InfoPanel/Views/Components/DisplayItems.xaml
@@ -5,11 +5,174 @@
     xmlns:app="clr-namespace:InfoPanel"
     xmlns:components="clr-namespace:InfoPanel.Views.Components"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="clr-namespace:InfoPanel"
+    xmlns:local="clr-namespace:InfoPanel.Views.Components"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="clr-namespace:InfoPanel.Models"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
     mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <!--  Simple Item Template  -->
+        <DataTemplate x:Key="SimpleItemTemplate">
+            <StackPanel
+                Margin="0"
+                VerticalAlignment="Center"
+                Orientation="Horizontal">
+                <!--  Symbol Icon  -->
+                <ui:SymbolIcon
+                    Width="20"
+                    Height="20"
+                    Margin="0,4,5,0"
+                    VerticalAlignment="Center">
+                    <ui:SymbolIcon.Style>
+                        <Style BasedOn="{StaticResource {x:Type ui:SymbolIcon}}" TargetType="{x:Type ui:SymbolIcon}">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Kind}" Value="Text">
+                                    <Setter Property="Symbol" Value="Text16" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Image">
+                                    <Setter Property="Symbol" Value="Image20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Sensor">
+                                    <Setter Property="Symbol" Value="Temperature20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Table">
+                                    <Setter Property="Symbol" Value="Table20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Clock">
+                                    <Setter Property="Symbol" Value="Clock20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Calendar">
+                                    <Setter Property="Symbol" Value="Calendar3Day20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Graph">
+                                    <Setter Property="Symbol" Value="DataBarVertical20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Bar">
+                                    <Setter Property="Symbol" Value="DataBarHorizontal20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Donut">
+                                    <Setter Property="Symbol" Value="DataPie20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Gauge">
+                                    <Setter Property="Symbol" Value="Gauge20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Sensor Image">
+                                    <Setter Property="Symbol" Value="CircleImage20" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding Kind}" Value="Http Image">
+                                    <Setter Property="Symbol" Value="WebAsset20" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </ui:SymbolIcon.Style>
+                </ui:SymbolIcon>
+
+                <!--  Name  -->
+                <TextBlock
+                    Width="200"
+                    VerticalAlignment="Center"
+                    Text="{Binding Name}"
+                    TextTrimming="CharacterEllipsis" />
+
+                <!--  Sensor Type Icon  -->
+                <Image
+                    Width="20"
+                    Height="20"
+                    Margin="0,4,10,0"
+                    VerticalAlignment="Center">
+                    <Image.Style>
+                        <Style TargetType="Image">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="HwInfo">
+                                    <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/hwinfo_icon.ico" />
+                                </DataTrigger>
+                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="Libre">
+                                    <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/libre_icon.ico" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Image.Style>
+                </Image>
+
+                <!--  Coordinates  -->
+                <TextBlock Width="80" VerticalAlignment="Center">
+                    <TextBlock.Text>
+                        <MultiBinding StringFormat="{}{0}, {1}">
+                            <Binding Path="X" />
+                            <Binding Path="Y" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </TextBlock>
+
+                <!--  Visibility Checkbox  -->
+                <CheckBox
+                    Margin="10,0,0,0"
+                    VerticalAlignment="Center"
+                    IsChecked="{Binding Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+            </StackPanel>
+        </DataTemplate>
+
+
+        <DataTemplate x:Key="GroupItemTemplate">
+            <Expander
+                Grid.Row="1"
+                Margin="0,0,0,0"
+                VerticalAlignment="Stretch"
+                Background="#601A1a1a"
+                IsExpanded="{Binding IsExpanded}">
+
+                <Expander.Header>
+                    <StackPanel
+                        Margin="-10,-10,5,-10"
+                        Orientation="Horizontal"
+                        PreviewMouseLeftButtonDown="StackPanel_MouseDown">
+                        <ui:SymbolIcon
+                            Width="20"
+                            Height="20"
+                            Margin="10,0,0,0"
+                            VerticalAlignment="Center"
+                            Symbol="Group24" />
+                        <!--  Group Header  -->
+                        <TextBlock
+                            Width="290"
+                            Margin="5,0,0,5"
+                            VerticalAlignment="Center"
+                            Text="{Binding Name}" />
+                        <!--  Visibility Checkbox  -->
+                        <CheckBox
+                            Margin="20,0,0,0"
+                            VerticalAlignment="Center"
+                            IsChecked="{Binding Hidden, Converter={StaticResource InverseBooleanConverter}}" />
+                    </StackPanel>
+                </Expander.Header>
+                <!--  Child Items ListView  -->
+                <ListView
+                    Margin="0,0,0,0"
+                    Background="Transparent"
+                    BorderThickness="0"
+                    ItemTemplate="{StaticResource SimpleItemTemplate}"
+                    ItemsSource="{Binding DisplayItems}"
+                    SelectionChanged="ListViewGroupItems_SelectionChanged"
+                    SelectionMode="Extended">
+                    <ListView.ItemContainerStyle>
+                        <Style TargetType="ListViewItem">
+                            <Setter Property="Margin" Value="0,0,0,0" />
+                            <Setter Property="IsSelected" Value="{Binding Selected}" />
+                        </Style>
+                    </ListView.ItemContainerStyle>
+                </ListView>
+            </Expander>
+        </DataTemplate>
+
+        <local:PanelItemTemplateSelector
+            x:Key="PanelItemsSelector"
+            GroupTemplate="{StaticResource GroupItemTemplate}"
+            SimpleTemplate="{StaticResource SimpleItemTemplate}" />
+
+
+    </UserControl.Resources>
 
     <Grid Margin="10,10,10,0">
         <Grid.RowDefinitions>
@@ -41,12 +204,12 @@
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
                     DisplayMemberPath="Name"
-                    ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Profiles}"
-                    SelectedItem="{Binding Source={x:Static local:SharedModel.Instance}, Path=SelectedProfile}" />
+                    ItemsSource="{Binding Source={x:Static app:ConfigModel.Instance}, Path=Profiles}"
+                    SelectedItem="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedProfile}" />
             </Grid>
         </StackPanel>
 
-        <Grid Grid.Row="1" Margin="0,10,0,0">
+        <Grid Grid.Row="1" Margin="0,0,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="auto" />
                 <ColumnDefinition Width="auto" />
@@ -59,187 +222,84 @@
                     <RowDefinition Height="auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <Grid Grid.Row="0" Margin="5,0,10,5">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="40" />
-                        <ColumnDefinition Width="230" />
-                        <ColumnDefinition Width="50" />
-                        <ColumnDefinition Width="80" />
-                        <ColumnDefinition Width="40" />
-                    </Grid.ColumnDefinitions>
-                    <Label Grid.Column="0" Foreground="{DynamicResource TextFillColorSecondaryBrush}">
-                        <TextBlock
-                            Grid.Column="0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Text="Type" />
-                    </Label>
-                    <Label Grid.Column="1">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="Name" />
-                    </Label>
-                    <Label Grid.Column="2">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="Source" />
-                    </Label>
-                    <Label Grid.Column="3">
-                        <TextBlock>
-                            <TextBlock
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Text="X, Y" />
-                        </TextBlock>
-                    </Label>
-                    <Label Grid.Column="4">
-                        <TextBlock
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="Enabled" />
-                    </Label>
-                </Grid>
+
+                <StackPanel
+                    Margin="5"
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal">
+
+                    <!--  Name  -->
+                    <TextBlock
+                        Width="200"
+                        Margin="25,0,0,0"
+                        VerticalAlignment="Center"
+                        Text="Name"
+                        TextTrimming="CharacterEllipsis" />
+
+                    <!--  Coordinates  -->
+                    <TextBlock
+                        Width="80"
+                        Margin="25,0,5,0"
+                        VerticalAlignment="Center"
+                        Text="Location" />
+
+                    <!--  Visibility Checkbox  -->
+                    <TextBlock
+                        Width="80"
+                        Margin="0,0,5,0"
+                        VerticalAlignment="Center"
+                        Text="Enabled" />
+                </StackPanel>
 
                 <ListView
-                    Name="ListViewItems"
+                    x:Name="ListViewItems"
                     Grid.Row="1"
                     Width="auto"
+                    Background="Transparent"
+                    ItemTemplateSelector="{StaticResource PanelItemsSelector}"
                     ItemsSource="{Binding Source={x:Static app:SharedModel.Instance}, Path=DisplayItems}"
                     ScrollViewer.VerticalScrollBarVisibility="Visible"
-                    SelectedItem="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedItem}"
                     SelectionChanged="ListViewItems_SelectionChanged"
                     SelectionMode="Extended">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
-                            <Setter Property="Margin" Value="0,0,0,5" />
+                            <Setter Property="Margin" Value="0,0,0,0" />
                             <Setter Property="IsSelected" Value="{Binding Selected}" />
+                            <!--  Only apply the border style to GroupDisplayItem  -->
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Kind}" Value="Group">
+                                    <Setter Property="Background" Value="Transparent" />
+                                    <Setter Property="BorderThickness" Value="1" />
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="ListViewItem">
+                                                <Border
+                                                    x:Name="Border"
+                                                    Background="{TemplateBinding Background}"
+                                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                                    BorderThickness="{TemplateBinding BorderThickness}">
+                                                    <ContentPresenter
+                                                        Margin="2"
+                                                        HorizontalAlignment="Stretch"
+                                                        VerticalAlignment="Center" />
+                                                </Border>
+                                                <ControlTemplate.Triggers>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter TargetName="Border" Property="BorderThickness" Value="1" />
+                                                        <Setter Property="BorderBrush" Value="DeepSkyBlue" />
+                                                    </Trigger>
+                                                    <Trigger Property="IsSelected" Value="True">
+                                                        <Setter TargetName="Border" Property="BorderThickness" Value="1" />
+                                                        <Setter Property="BorderBrush" Value="DeepSkyBlue" />
+                                                    </Trigger>
+                                                </ControlTemplate.Triggers>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </DataTrigger>
+                            </Style.Triggers>
                         </Style>
                     </ListView.ItemContainerStyle>
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <Grid Margin="0,0,0,0">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="40" />
-                                    <ColumnDefinition Width="230" />
-                                    <ColumnDefinition Width="50" />
-                                    <ColumnDefinition Width="80" />
-                                    <ColumnDefinition Width="40" />
-                                </Grid.ColumnDefinitions>
-                                <ui:SymbolIcon
-                                    Grid.Column="0"
-                                    Margin="5,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center">
-                                    <ui:SymbolIcon.Style>
-                                        <Style BasedOn="{StaticResource {x:Type ui:SymbolIcon}}" TargetType="{x:Type ui:SymbolIcon}">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Text">
-                                                    <Setter Property="Symbol" Value="Text16" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Image">
-                                                    <Setter Property="Symbol" Value="Image20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Sensor">
-                                                    <Setter Property="Symbol" Value="Temperature20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Table">
-                                                    <Setter Property="Symbol" Value="Table20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Clock">
-                                                    <Setter Property="Symbol" Value="Clock20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Calendar">
-                                                    <Setter Property="Symbol" Value="Calendar3Day20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Graph">
-                                                    <Setter Property="Symbol" Value="DataBarVertical20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Bar">
-                                                    <Setter Property="Symbol" Value="DataBarHorizontal20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Donut">
-                                                    <Setter Property="Symbol" Value="DataPie20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Gauge">
-                                                    <Setter Property="Symbol" Value="Gauge20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Sensor Image">
-                                                    <Setter Property="Symbol" Value="CircleImage20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding Kind}" Value="Http Image">
-                                                    <Setter Property="Symbol" Value="WebAsset20" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </ui:SymbolIcon.Style>
-                                </ui:SymbolIcon>
-                                <Label
-                                    Grid.Column="1"
-                                    Margin="0,0,10,0"
-                                    VerticalAlignment="Center">
-                                    <TextBlock
-                                        VerticalAlignment="Center"
-                                        Text="{Binding Name}"
-                                        TextTrimming="CharacterEllipsis" />
-                                </Label>
-                                <Image
-                                    Grid.Column="2"
-                                    Width="20"
-                                    Height="20"
-                                    HorizontalAlignment="Left"
-                                    VerticalAlignment="Center">
-                                    <Image.Style>
-                                        <Style TargetType="Image">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="HwInfo">
-                                                    <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/hwinfo_icon.ico" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="Libre">
-                                                    <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/libre_icon.ico" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Image.Style>
-                                </Image>
-                                <!--<ui:SymbolIcon Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5,0,0,0">
-                                    <ui:SymbolIcon.Style>
-                                        <Style TargetType="{x:Type ui:SymbolIcon}" BasedOn="{StaticResource {x:Type ui:SymbolIcon}}">
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding SensorType}" Value="HwInfo">
-                                                    <Setter Property="Symbol" Value="HardDrive20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding SensorType}" Value="Libre">
-                                                    <Setter Property="Symbol" Value="HardDrive20" />
-                                                </DataTrigger>
-                                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="Default">
-                                                    <Setter Property="Symbol" Value="Text16" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </ui:SymbolIcon.Style>
-                                </ui:SymbolIcon>-->
-                                <Label Grid.Column="3" VerticalAlignment="Center">
-                                    <TextBlock>
-                                        <TextBlock.Text>
-                                            <MultiBinding StringFormat="{}{0}, {1}">
-                                                <Binding Path="X" />
-                                                <Binding Path="Y" />
-                                            </MultiBinding>
-                                        </TextBlock.Text>
-                                    </TextBlock>
-                                </Label>
-                                <Label Grid.Column="4" VerticalAlignment="Center">
-                                    <CheckBox HorizontalAlignment="Center" IsChecked="{Binding Hidden, Converter={StaticResource InverseBooleanConverter}}" />
-                                </Label>
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
                 </ListView>
             </Grid>
 
@@ -247,6 +307,15 @@
                 Grid.Column="1"
                 Margin="10,0,0,0"
                 VerticalAlignment="Bottom">
+
+                <ui:Button
+                    x:Name="ButtonGroup"
+                    Margin="0,10,0,0"
+                    Appearance="Success"
+                    Click="ButtonGroup_Click"
+                    Content=""
+                    Icon="Group20"
+                    ToolTip="New Group" />
                 <ui:Button
                     x:Name="ButtonPushBack"
                     Margin="0,10,0,0"
@@ -254,7 +323,7 @@
                     Content=""
                     Icon="ArrowUpload20"
                     IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
-                    ToolTip="Push selected item to the back (overlapped by items below)" />
+                    ToolTip="Push selected item to the top (overlapped by items below)" />
                 <ui:Button
                     x:Name="ButtonPushUp"
                     Margin="0,10,0,0"
@@ -262,7 +331,7 @@
                     Content=""
                     Icon="ArrowUp20"
                     IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
-                    ToolTip="Push selected item backwards 1 level (overlapped by items below)" />
+                    ToolTip="Push selected item up (overlapped by items below)" />
                 <ui:Button
                     x:Name="ButtonPushDown"
                     Margin="0,10,0,0"
@@ -270,7 +339,7 @@
                     Content=""
                     Icon="ArrowDown20"
                     IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
-                    ToolTip="Bring selected item forward 1 level (overlap items above)" />
+                    ToolTip="Bring selected item down (overlap items above)" />
                 <ui:Button
                     x:Name="ButtonPushFront"
                     Margin="0,10,0,0"
@@ -278,7 +347,7 @@
                     Content=""
                     Icon="ArrowDownload20"
                     IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
-                    ToolTip="Bring selected item to front (overlap items above)" />
+                    ToolTip="Bring selected item to bottom (overlap items above)" />
                 <ui:Button
                     x:Name="ButtonDuplicate"
                     Margin="0,10,0,0"

--- a/InfoPanel/Views/Components/DisplayItems.xaml
+++ b/InfoPanel/Views/Components/DisplayItems.xaml
@@ -13,107 +13,13 @@
     mc:Ignorable="d">
 
     <UserControl.Resources>
-        <!--  Simple Item Template  -->
-        <DataTemplate x:Key="SimpleItemTemplate">
-            <StackPanel
-                Margin="0"
-                VerticalAlignment="Center"
-                Orientation="Horizontal">
-                <!--  Symbol Icon  -->
-                <ui:SymbolIcon
-                    Width="20"
-                    Height="20"
-                    Margin="0,4,5,0"
-                    VerticalAlignment="Center">
-                    <ui:SymbolIcon.Style>
-                        <Style BasedOn="{StaticResource {x:Type ui:SymbolIcon}}" TargetType="{x:Type ui:SymbolIcon}">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding Kind}" Value="Text">
-                                    <Setter Property="Symbol" Value="Text16" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Image">
-                                    <Setter Property="Symbol" Value="Image20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Sensor">
-                                    <Setter Property="Symbol" Value="Temperature20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Table">
-                                    <Setter Property="Symbol" Value="Table20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Clock">
-                                    <Setter Property="Symbol" Value="Clock20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Calendar">
-                                    <Setter Property="Symbol" Value="Calendar3Day20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Graph">
-                                    <Setter Property="Symbol" Value="DataBarVertical20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Bar">
-                                    <Setter Property="Symbol" Value="DataBarHorizontal20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Donut">
-                                    <Setter Property="Symbol" Value="DataPie20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Gauge">
-                                    <Setter Property="Symbol" Value="Gauge20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Sensor Image">
-                                    <Setter Property="Symbol" Value="CircleImage20" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding Kind}" Value="Http Image">
-                                    <Setter Property="Symbol" Value="WebAsset20" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </ui:SymbolIcon.Style>
-                </ui:SymbolIcon>
-
-                <!--  Name  -->
-                <TextBlock
-                    Width="200"
-                    VerticalAlignment="Center"
-                    Text="{Binding Name}"
-                    TextTrimming="CharacterEllipsis" />
-
-                <!--  Sensor Type Icon  -->
-                <Image
-                    Width="20"
-                    Height="20"
-                    Margin="0,4,10,0"
-                    VerticalAlignment="Center">
-                    <Image.Style>
-                        <Style TargetType="Image">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="HwInfo">
-                                    <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/hwinfo_icon.ico" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding SensorType, FallbackValue=Default}" Value="Libre">
-                                    <Setter Property="Source" Value="/InfoPanel;component/Resources/Images/libre_icon.ico" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Image.Style>
-                </Image>
-
-                <!--  Coordinates  -->
-                <TextBlock Width="80" VerticalAlignment="Center">
-                    <TextBlock.Text>
-                        <MultiBinding StringFormat="{}{0}, {1}">
-                            <Binding Path="X" />
-                            <Binding Path="Y" />
-                        </MultiBinding>
-                    </TextBlock.Text>
-                </TextBlock>
-
-                <!--  Visibility Checkbox  -->
-                <CheckBox
-                    Margin="10,0,0,0"
-                    VerticalAlignment="Center"
-                    IsChecked="{Binding Hidden, Converter={StaticResource InverseBooleanConverter}}" />
-            </StackPanel>
+        <DataTemplate x:Key="SimpleItemTemplate_MarginA">
+            <local:DisplayItemView Margin="0,0,30,0" />
         </DataTemplate>
 
+        <DataTemplate x:Key="SimpleItemTemplate_MarginB">
+            <local:DisplayItemView Margin="0,0,15,0" />
+        </DataTemplate>
 
         <DataTemplate x:Key="GroupItemTemplate">
             <Expander
@@ -124,22 +30,46 @@
                 IsExpanded="{Binding IsExpanded}">
 
                 <Expander.Header>
-                    <StackPanel
-                        Margin="-10,-10,5,-10"
-                        Orientation="Horizontal"
-                        PreviewMouseLeftButtonDown="StackPanel_MouseDown">
+                    <StackPanel Margin="-10,-10,5,-10" Orientation="Horizontal">
+
+                        <!--  Group Header  -->
+                        <Border PreviewMouseLeftButtonDown="Border_MouseDown">
+                            <StackPanel Orientation="Horizontal">
+                                <ui:SymbolIcon
+                                    Width="20"
+                                    Height="20"
+                                    Margin="10,0,0,0"
+                                    VerticalAlignment="Center"
+                                    Symbol="Group24" />
+                                <TextBlock
+                                    Width="270"
+                                    Margin="5,0,0,5"
+                                    VerticalAlignment="Center"
+                                    FontSize="12"
+                                    Text="{Binding Name}" />
+                            </StackPanel>
+                        </Border>
+
                         <ui:SymbolIcon
                             Width="20"
                             Height="20"
-                            Margin="10,0,0,0"
+                            Margin="10,5,-10,0"
                             VerticalAlignment="Center"
-                            Symbol="Group24" />
-                        <!--  Group Header  -->
-                        <TextBlock
-                            Width="290"
-                            Margin="5,0,0,5"
+                            Cursor="Hand"
+                            Foreground="Gray"
+                            Symbol="LockClosed24"
+                            Visibility="{Binding IsExpanded, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+
+                        <ui:SymbolIcon
+                            Width="20"
+                            Height="20"
+                            Margin="10,5,-10,0"
                             VerticalAlignment="Center"
-                            Text="{Binding Name}" />
+                            Cursor="Hand"
+                            Foreground="DodgerBlue"
+                            Symbol="LockOpen24"
+                            Visibility="{Binding IsExpanded, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
                         <!--  Visibility Checkbox  -->
                         <CheckBox
                             Margin="20,0,0,0"
@@ -149,16 +79,18 @@
                 </Expander.Header>
                 <!--  Child Items ListView  -->
                 <ListView
-                    Margin="0,0,0,0"
+                    Margin="-5,-10,0,-10"
+                    HorizontalContentAlignment="Stretch"
                     Background="Transparent"
                     BorderThickness="0"
-                    ItemTemplate="{StaticResource SimpleItemTemplate}"
+                    ItemTemplate="{StaticResource SimpleItemTemplate_MarginB}"
                     ItemsSource="{Binding DisplayItems}"
                     SelectionChanged="ListViewGroupItems_SelectionChanged"
                     SelectionMode="Extended">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
-                            <Setter Property="Margin" Value="0,0,0,0" />
+                            <Setter Property="Margin" Value="0,1,0,1" />
+                            <Setter Property="FontSize" Value="12" />
                             <Setter Property="IsSelected" Value="{Binding Selected}" />
                         </Style>
                     </ListView.ItemContainerStyle>
@@ -169,7 +101,7 @@
         <local:PanelItemTemplateSelector
             x:Key="PanelItemsSelector"
             GroupTemplate="{StaticResource GroupItemTemplate}"
-            SimpleTemplate="{StaticResource SimpleItemTemplate}" />
+            SimpleTemplate="{StaticResource SimpleItemTemplate_MarginA}" />
 
 
     </UserControl.Resources>
@@ -255,6 +187,7 @@
                     x:Name="ListViewItems"
                     Grid.Row="1"
                     Width="auto"
+                    HorizontalContentAlignment="Stretch"
                     Background="Transparent"
                     ItemTemplateSelector="{StaticResource PanelItemsSelector}"
                     ItemsSource="{Binding Source={x:Static app:SharedModel.Instance}, Path=DisplayItems}"
@@ -263,11 +196,12 @@
                     SelectionMode="Extended">
                     <ListView.ItemContainerStyle>
                         <Style TargetType="ListViewItem">
-                            <Setter Property="Margin" Value="0,0,0,0" />
+                            <Setter Property="Margin" Value="0,1,0,1" />
                             <Setter Property="IsSelected" Value="{Binding Selected}" />
                             <!--  Only apply the border style to GroupDisplayItem  -->
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding Kind}" Value="Group">
+                                    <Setter Property="Margin" Value="0,0,0,0" />
                                     <Setter Property="Background" Value="Transparent" />
                                     <Setter Property="BorderThickness" Value="1" />
                                     <Setter Property="Template">
@@ -286,7 +220,7 @@
                                                 <ControlTemplate.Triggers>
                                                     <Trigger Property="IsMouseOver" Value="True">
                                                         <Setter TargetName="Border" Property="BorderThickness" Value="1" />
-                                                        <Setter Property="BorderBrush" Value="DeepSkyBlue" />
+                                                        <Setter Property="BorderBrush" Value="LightSkyBlue" />
                                                     </Trigger>
                                                     <Trigger Property="IsSelected" Value="True">
                                                         <Setter TargetName="Border" Property="BorderThickness" Value="1" />

--- a/InfoPanel/Views/Components/DisplayItems.xaml.cs
+++ b/InfoPanel/Views/Components/DisplayItems.xaml.cs
@@ -154,10 +154,17 @@ namespace InfoPanel.Views.Components
         {
             var groupDisplayItem = new GroupDisplayItem
             {
-                Name = "-- New Group"
+                Name = "New Group"
             };
 
             SharedModel.Instance.AddDisplayItem(groupDisplayItem);
+
+            var selectedItem = SharedModel.Instance.SelectedItem;
+            if (selectedItem != null)
+            {
+                SharedModel.Instance.PushDisplayItemTo(groupDisplayItem, selectedItem);
+            }
+
             SharedModel.Instance.SelectedItem = groupDisplayItem;
             ListViewItems.ScrollIntoView(groupDisplayItem);
         }
@@ -313,7 +320,7 @@ namespace InfoPanel.Views.Components
                     return;
                 }
 
-                foreach (var item in SharedModel.Instance.DisplayItems)
+                foreach (var item in SharedModel.Instance.SelectedItems)
                 {
                     if (item != innerListView.SelectedItem)
                     {
@@ -330,18 +337,18 @@ namespace InfoPanel.Views.Components
             }
         }
 
-        private void StackPanel_MouseDown(object sender, MouseButtonEventArgs e)
+        private void Border_MouseDown(object sender, MouseButtonEventArgs e)
         {
             e.Handled = true;
 
             if (e.ChangedButton != MouseButton.Left)
                 return;
 
-            if (sender is not StackPanel stackPanel)
+            if (sender is not Border border)
                 return;
 
-            var dataItem = stackPanel.DataContext;
-            var listViewItem = FindAncestor<ListViewItem>(stackPanel);
+            var dataItem = border.DataContext;
+            var listViewItem = FindAncestor<ListViewItem>(border);
             if (listViewItem == null)
                 return;
 

--- a/InfoPanel/Views/Components/Group/GroupProperties.xaml
+++ b/InfoPanel/Views/Components/Group/GroupProperties.xaml
@@ -5,18 +5,37 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:InfoPanel.Views.Components"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:Wpf.Ui.Controls;assembly=Wpf.Ui"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
     <Grid Margin="10,10,10,10">
-        <StackPanel Grid.Column="1">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="2*" />
+        </Grid.ColumnDefinitions>
+        <StackPanel Grid.Column="0">
             <StackPanel>
-                <TextBox x:Name="TextBoxName" Text="{Binding Name}" />
-                <TextBlock
-                    Margin="5,0,0,0"
-                    FontSize="12"
-                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
-                    Text="Group Name" />
+                <StackPanel>
+                    <TextBox
+                        x:Name="TextBoxName"
+                        MaxLength="20"
+                        MaxLines="1"
+                        Text="{Binding Name}" />
+                    <TextBlock
+                        Margin="5,0,0,0"
+                        FontSize="12"
+                        Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                        Text="Group Name" />
+                </StackPanel>
+                <StackPanel Margin="0,10,0,0" Orientation="Horizontal">
+                    <ui:ToggleSwitch IsChecked="{Binding IsLocked}" />
+                    <TextBlock
+                        Margin="10,0,0,0"
+                        FontSize="12"
+                        Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                        Text="Lock - Prevent items from moving in or out" />
+                </StackPanel>
             </StackPanel>
         </StackPanel>
     </Grid>

--- a/InfoPanel/Views/Components/Group/GroupProperties.xaml
+++ b/InfoPanel/Views/Components/Group/GroupProperties.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+    x:Class="InfoPanel.Views.Components.GroupProperties"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:InfoPanel.Views.Components"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+    <Grid Margin="10,10,10,10">
+        <StackPanel Grid.Column="1">
+            <StackPanel>
+                <TextBox x:Name="TextBoxName" Text="{Binding Name}" />
+                <TextBlock
+                    Margin="5,0,0,0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                    Text="Group Name" />
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/InfoPanel/Views/Components/Group/GroupProperties.xaml.cs
+++ b/InfoPanel/Views/Components/Group/GroupProperties.xaml.cs
@@ -1,0 +1,37 @@
+﻿using InfoPanel.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace InfoPanel.Views.Components
+{
+    /// <summary>
+    /// Interaction logic for GroupProperties.xaml
+    /// </summary>
+    public partial class GroupProperties : UserControl
+    {
+        public static readonly DependencyProperty ItemProperty =
+   DependencyProperty.Register("GroupDisplayItem", typeof(GroupDisplayItem), typeof(GroupProperties));
+
+        public GroupDisplayItem GroupDisplayItem
+        {
+            get { return (GroupDisplayItem)GetValue(ItemProperty); }
+            set { SetValue(ItemProperty, value); }
+        }
+        public GroupProperties()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/InfoPanel/Views/Components/PanelItemTemplateSelector.cs
+++ b/InfoPanel/Views/Components/PanelItemTemplateSelector.cs
@@ -1,0 +1,22 @@
+﻿using InfoPanel.Models;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace InfoPanel.Views.Components
+{
+    public class PanelItemTemplateSelector: DataTemplateSelector
+    {
+        public required DataTemplate SimpleTemplate { get; set; }
+
+        public required DataTemplate GroupTemplate { get; set; }
+
+        public override DataTemplate SelectTemplate(object item, DependencyObject container)
+        {
+            return item switch
+            {
+                GroupDisplayItem => GroupTemplate,
+                _ => SimpleTemplate
+            };
+        }
+    }
+}

--- a/InfoPanel/Views/Components/Sensors/CommonActions.xaml.cs
+++ b/InfoPanel/Views/Components/Sensors/CommonActions.xaml.cs
@@ -23,7 +23,6 @@ namespace InfoPanel.Views.Components
                 Color = SharedModel.Instance.SelectedProfile!.Color
             };
             SharedModel.Instance.AddDisplayItem(item);
-            SharedModel.Instance.SelectedItem = item;
         }
 
         private void ButtonNewImage_Click(object sender, RoutedEventArgs e)
@@ -36,7 +35,6 @@ namespace InfoPanel.Views.Components
                     Height = 100
                 };
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -50,7 +48,6 @@ namespace InfoPanel.Views.Components
 
             };
             SharedModel.Instance.AddDisplayItem(item);
-            SharedModel.Instance.SelectedItem = item;
         }
 
         private void ButtonNewCalendar_Click(object sender, RoutedEventArgs e)
@@ -62,7 +59,6 @@ namespace InfoPanel.Views.Components
                 Color = SharedModel.Instance.SelectedProfile!.Color
             };
             SharedModel.Instance.AddDisplayItem(item);
-            SharedModel.Instance.SelectedItem = item;
         }
     }
 }

--- a/InfoPanel/Views/Components/Sensors/HwInfoSensors.xaml.cs
+++ b/InfoPanel/Views/Components/Sensors/HwInfoSensors.xaml.cs
@@ -131,7 +131,6 @@ namespace InfoPanel.Views.Components
                 };
 
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -184,7 +183,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new GraphDisplayItem(sensorItem.Name, GraphDisplayItem.GraphType.LINE, sensorItem.ParentId, sensorItem.ParentInstance, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -194,7 +192,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new BarDisplayItem(sensorItem.Name, sensorItem.ParentId, sensorItem.ParentInstance, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -204,7 +201,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new DonutDisplayItem(sensorItem.Name, sensorItem.ParentId, sensorItem.ParentInstance, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -214,7 +210,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new GaugeDisplayItem(sensorItem.Name, sensorItem.ParentId, sensorItem.ParentInstance, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -228,7 +223,6 @@ namespace InfoPanel.Views.Components
                     Height = 100,
                 };
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 

--- a/InfoPanel/Views/Components/Sensors/LibreSensors.xaml.cs
+++ b/InfoPanel/Views/Components/Sensors/LibreSensors.xaml.cs
@@ -161,7 +161,6 @@ namespace InfoPanel.Views.Components
                 };
 
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -207,7 +206,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new GraphDisplayItem(sensorItem.Name, GraphDisplayItem.GraphType.LINE, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -217,7 +215,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new BarDisplayItem(sensorItem.Name, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -227,7 +224,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new DonutDisplayItem(sensorItem.Name, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -237,7 +233,6 @@ namespace InfoPanel.Views.Components
             {
                 var item = new GaugeDisplayItem(sensorItem.Name, sensorItem.SensorId);
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -251,7 +246,6 @@ namespace InfoPanel.Views.Components
                     Height = 100,
                 };
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
     }

--- a/InfoPanel/Views/Components/Sensors/PluginSensors.xaml.cs
+++ b/InfoPanel/Views/Components/Sensors/PluginSensors.xaml.cs
@@ -157,7 +157,6 @@ namespace InfoPanel.Views.Components
                 };
 
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -223,7 +222,6 @@ namespace InfoPanel.Views.Components
                 item.PluginSensorId = sensorItem.SensorId;
                 item.SensorType = Enums.SensorType.Plugin;
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -235,7 +233,6 @@ namespace InfoPanel.Views.Components
                 item.PluginSensorId = sensorItem.SensorId;
                 item.SensorType = Enums.SensorType.Plugin;
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -247,7 +244,6 @@ namespace InfoPanel.Views.Components
                 item.PluginSensorId = sensorItem.SensorId;
                 item.SensorType = Enums.SensorType.Plugin;
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -259,7 +255,6 @@ namespace InfoPanel.Views.Components
                 item.PluginSensorId = sensorItem.SensorId;
                 item.SensorType = Enums.SensorType.Plugin;
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -275,7 +270,6 @@ namespace InfoPanel.Views.Components
                     SensorType = Enums.SensorType.Plugin
                 };
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -291,7 +285,6 @@ namespace InfoPanel.Views.Components
                     SensorType = Enums.SensorType.Plugin
                 };
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
 
@@ -304,7 +297,6 @@ namespace InfoPanel.Views.Components
                     item.TableFormat = format;
                 }
                 SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.SelectedItem = item;
             }
         }
     }

--- a/InfoPanel/Views/Converters/LockColorConverter.cs
+++ b/InfoPanel/Views/Converters/LockColorConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace InfoPanel.Views.Converters
+{
+    internal class LockColorConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (value is bool isLocked && isLocked)
+                ? Brushes.Gray
+                : Brushes.DodgerBlue;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/InfoPanel/Views/Converters/LockSymbolConverter .cs
+++ b/InfoPanel/Views/Converters/LockSymbolConverter .cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace InfoPanel.Views.Converters
+{
+    internal class LockSymbolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (value is bool isLocked && isLocked)
+                ? "LockClosed24"
+                : "LockOpen24";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/InfoPanel/Views/DisplayWindow.xaml.cs
+++ b/InfoPanel/Views/DisplayWindow.xaml.cs
@@ -471,7 +471,7 @@ namespace InfoPanel.Views.Common
                 }
 
                 DisplayItem? clickedItem = null;
-                Rect clickedItemBounds = new Rect(0, 0, 0, 0);
+                Rect clickedItemBounds = new(0, 0, 0, 0);
 
                 var displayItems = SharedModel.Instance.DisplayItems?.ToList();
 
@@ -481,6 +481,33 @@ namespace InfoPanel.Views.Common
                     {
                         if (item.Hidden)
                         {
+                            continue;
+                        }
+
+
+                        if(item is GroupDisplayItem groupDisplayItem)
+                        {
+                            foreach (var groupItem in groupDisplayItem.DisplayItems)
+                            {
+                                if (groupItem.Hidden)
+                                {
+                                    continue;
+                                }
+
+                                var groupItemBounds = groupItem.EvaluateBounds();
+
+                                if (groupItemBounds.Width >= Profile.Width && groupItemBounds.Height >= Profile.Height && groupItemBounds.X == 0 && groupItemBounds.Y == 0)
+                                {
+                                    continue;
+                                }
+
+                                if (groupItemBounds.Contains(e.GetPosition(this)))
+                                {
+                                    clickedItem = groupItem;
+                                    clickedItemBounds = groupItemBounds;
+                                }
+                            }
+
                             continue;
                         }
 

--- a/InfoPanel/Views/Pages/DesignPage.xaml
+++ b/InfoPanel/Views/Pages/DesignPage.xaml
@@ -296,6 +296,9 @@
                         </Style>
                     </ContentControl.Style>
                     <ContentControl.Resources>
+                        <DataTemplate DataType="{x:Type models:GroupDisplayItem}">
+                            <components:GroupProperties GroupDisplayItem="{Binding}" />
+                        </DataTemplate>
                         <DataTemplate DataType="{x:Type models:GaugeDisplayItem}">
                             <components:CustomProperties GaugeDisplayItem="{Binding}" />
                         </DataTemplate>

--- a/InfoPanel/Views/Pages/DesignPage.xaml
+++ b/InfoPanel/Views/Pages/DesignPage.xaml
@@ -11,6 +11,7 @@
     Title="Design"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    DataContext="{Binding RelativeSource={RelativeSource self}}"
     mc:Ignorable="d">
 
     <Grid Margin="20,20,20,20" Grid.IsSharedSizeScope="True">
@@ -201,7 +202,7 @@
             IsExpanded="True">
 
             <Expander.Header>
-                <Grid>
+                <Grid Margin="0,0,20,0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="auto" />
@@ -209,6 +210,20 @@
                     <Label>
                         <TextBlock FontWeight="Medium" Text="{Binding Source={x:Static local:SharedModel.Instance}, Path=SelectedItem, Converter={StaticResource SelectedItemTextConverter}}" />
                     </Label>
+                    <Button
+                        Grid.Column="1"
+                        Width="20"
+                        Height="20"
+                        Margin="10,0,-10,0"
+                        Padding="0"
+                        VerticalAlignment="Center"
+                        Background="Transparent"
+                        BorderThickness="0"
+                        Command="{Binding UnselectCommand}"
+                        Cursor="Hand"
+                        Visibility="{Binding Source={x:Static local:SharedModel.Instance}, Path=SelectedItem, Converter={StaticResource NullToVisibilityConverter}}">
+                        <ui:SymbolIcon Symbol="Dismiss24" />
+                    </Button>
                 </Grid>
 
             </Expander.Header>

--- a/InfoPanel/Views/Pages/DesignPage.xaml.cs
+++ b/InfoPanel/Views/Pages/DesignPage.xaml.cs
@@ -1,4 +1,6 @@
 ﻿
+using CommunityToolkit.Mvvm.Input;
+using InfoPanel.Models;
 using InfoPanel.ViewModels;
 using System.Windows;
 
@@ -25,6 +27,15 @@ namespace InfoPanel.Views.Pages
         private void DesignPage_Unloaded(object sender, RoutedEventArgs e)
         {
             SharedModel.Instance.SelectedItem = null;
+        }
+
+        [RelayCommand]
+        private static void Unselect()
+        {
+            if (SharedModel.Instance.SelectedItem is DisplayItem selectedItem)
+            {
+                selectedItem.Selected = false;
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces significant enhancements to the `InfoPanel` project, focusing on adding support for grouped display items, improving item selection logic, and restructuring the `SharedModel` to handle hierarchical data. Key changes include the introduction of the `GroupDisplayItem` class, modifications to the drawing logic to support grouped items, and updates to serialization and deserialization processes.

### Group Display Item Support:
* Added a new `GroupDisplayItem` class in `InfoPanel/Models/GroupDisplayItem.cs`, allowing display items to be grouped hierarchically. This includes properties for managing child items and group-specific behaviors like expansion and cloning.
* Updated the `Kind` property in `DisplayItem` to recognize `GroupDisplayItem` instances and return "Group" as their kind.

### Drawing Logic Enhancements:
* Refactored the `Run` method in `PanelDraw.cs` to support drawing grouped items recursively and to handle the visual representation of selected items with rotation and bounding box clamping. [[1]](diffhunk://#diff-29a2d4c4a34a6a41a403853cc696efe2bca212aac6dbdfc2481a93e070224985L63-R146) [[2]](diffhunk://#diff-29a2d4c4a34a6a41a403853cc696efe2bca212aac6dbdfc2481a93e070224985L299-L357)

### Selection and Movement Logic Improvements:
* Enhanced the `SelectedItem` and `SelectedItems` properties in `SharedModel` to ensure proper handling of group selections and prevent invalid multi-selections. Added methods to notify changes in selection state.
* Implemented new methods in `SharedModel` to move display items between groups, to the top, or to the end of their respective collections. This includes handling transitions between groups and flat collections.

### Serialization and Deserialization Updates:
* Updated the `SaveDisplayItems` and `LoadDisplayItems` methods in `SharedModel` to include `GroupDisplayItem` in the list of recognized types for XML serialization and deserialization. [[1]](diffhunk://#diff-a30354f9a73038124bed6d6b734386a04bc4ef8e373ecbc53680860bd6a550f7L488-R704) [[2]](diffhunk://#diff-a30354f9a73038124bed6d6b734386a04bc4ef8e373ecbc53680860bd6a550f7L1362-R1578)

### Codebase Refinements:
* Changed `SharedModel` from a sealed class to a partial class, allowing for better modularity and potential future extensions.