### PR TITLE
Fix group bug on displaying images in nested items

### DIFF
--- a/InfoPanel/Models/ChartDisplayItem.cs
+++ b/InfoPanel/Models/ChartDisplayItem.cs
@@ -318,6 +318,11 @@ namespace InfoPanel.Models
             var size = EvaluateSize();
             return new Rect(X, Y, size.Width, size.Height);
         }
+
+        public override void SetProfileGuid(Guid profileGuid)
+        {
+            ProfileGuid = profileGuid;
+        }
     }
 
     public class GraphDisplayItem : ChartDisplayItem

--- a/InfoPanel/Models/DisplayItem.cs
+++ b/InfoPanel/Models/DisplayItem.cs
@@ -128,6 +128,8 @@ public abstract partial class DisplayItem : ObservableObject, ICloneable
         }
     }
 
+    public abstract void SetProfileGuid(Guid profileGuid);
+
     public abstract string EvaluateText();
 
     public abstract string EvaluateColor();

--- a/InfoPanel/Models/GaugeDisplayItem.cs
+++ b/InfoPanel/Models/GaugeDisplayItem.cs
@@ -336,6 +336,16 @@ namespace InfoPanel.Models
             return (Name, "#000000");
         }
 
+        public override void SetProfileGuid(Guid profileGuid)
+        {
+            ProfileGuid = profileGuid;
+
+            foreach (var imageDisplayItem in Images)
+            {
+                imageDisplayItem.SetProfileGuid(profileGuid);
+            }
+        }
+
         public override object Clone()
         {
             var clone = (GaugeDisplayItem)MemberwiseClone();

--- a/InfoPanel/Models/GroupDisplayItem.cs
+++ b/InfoPanel/Models/GroupDisplayItem.cs
@@ -86,5 +86,14 @@ namespace InfoPanel.Models
         {
             throw new NotImplementedException();
         }
+
+        public override void SetProfileGuid(Guid profileGuid)
+        {
+            ProfileGuid = profileGuid;
+            foreach (var displayItem in DisplayItems)
+            {
+                displayItem.SetProfileGuid(profileGuid);
+            }
+        }
     }
 }

--- a/InfoPanel/Models/ImageDisplayItem.cs
+++ b/InfoPanel/Models/ImageDisplayItem.cs
@@ -203,5 +203,9 @@ namespace InfoPanel.Models
             clone.Guid = Guid.NewGuid();
             return clone;
         }
+        public override void SetProfileGuid(Guid profileGuid)
+        {
+            ProfileGuid = profileGuid;
+        }
     }
 }

--- a/InfoPanel/Models/SharedModel.cs
+++ b/InfoPanel/Models/SharedModel.cs
@@ -1679,15 +1679,7 @@ namespace InfoPanel
                     {
                         foreach (var displayItem in displayItems)
                         {
-                            displayItem.ProfileGuid = profile.Guid;
-
-                            if (displayItem is GaugeDisplayItem gaugeDisplayItem)
-                            {
-                                foreach (var imageDisplayItem in gaugeDisplayItem.Images)
-                                {
-                                    imageDisplayItem.ProfileGuid = profile.Guid;
-                                }
-                            }
+                            displayItem.SetProfileGuid(profile.Guid);
                         }
 
                         return displayItems;

--- a/InfoPanel/Models/TextDisplayItem.cs
+++ b/InfoPanel/Models/TextDisplayItem.cs
@@ -181,6 +181,11 @@ namespace InfoPanel.Models
             }
         }
 
+        public override void SetProfileGuid(Guid profileGuid)
+        {
+            ProfileGuid = profileGuid;
+        }
+
         public override object Clone()
         {
             var clone = (DisplayItem)MemberwiseClone();

--- a/InfoPanel/Views/Components/CommonProperties.xaml
+++ b/InfoPanel/Views/Components/CommonProperties.xaml
@@ -21,8 +21,8 @@
         <StackPanel
             Grid.Row="2"
             Margin="0,0,0,0"
-            IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSelectedItemMovable}"
-            Orientation="Vertical">
+            Orientation="Vertical"
+            Visibility="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSelectedItemMovable, Converter={StaticResource BooleanToVisibilityConverter}}">
             <ui:NumberBox
                 Margin="0,8,0,0"
                 FontSize="12"


### PR DESCRIPTION
This pull request refactors how the `ProfileGuid` is assigned to display items and updates a UI binding in `CommonProperties.xaml`. The most significant change introduces a new abstract method `SetProfileGuid` in the `DisplayItem` class, which is implemented in its derived classes to streamline the assignment of `ProfileGuid`. Additionally, the UI binding for the `IsSelectedItemMovable` property is updated to use a visibility converter.

### Refactoring of `ProfileGuid` assignment:

* **Abstract method addition**: Added the `SetProfileGuid` method as an abstract member in the `DisplayItem` base class, enforcing its implementation in all derived classes. (`InfoPanel/Models/DisplayItem.cs`, [InfoPanel/Models/DisplayItem.csR131-R132](diffhunk://#diff-3694f6b3c7392678398927aff99a2019cddf167f568cb43258dc0be1141dbabaR131-R132))
* **Implementations in derived classes**:
  - Implemented `SetProfileGuid` in `ChartDisplayItem`, `GaugeDisplayItem`, `GroupDisplayItem`, `ImageDisplayItem`, and `TextDisplayItem` to handle `ProfileGuid` assignment. (`InfoPanel/Models/ChartDisplayItem.cs`, [[1]](diffhunk://#diff-0ec187c60f44cc4b1c7c38dc2f8614ad65ad51a7b296fbd04eba396c46753530R321-R325); `InfoPanel/Models/GaugeDisplayItem.cs`, [[2]](diffhunk://#diff-88464f379e0f0a053dad12cd6daddf1d117425dc387a38d0e530d75752cd1f1eR339-R348); `InfoPanel/Models/GroupDisplayItem.cs`, [[3]](diffhunk://#diff-7cfccb6e399f1054486613ba5d5446490f6f09a750ce291e9e14e60254d204cdR89-R97); `InfoPanel/Models/ImageDisplayItem.cs`, [[4]](diffhunk://#diff-96eb9392ff22cb04b3287726611ad0b22304b6e51d049cd880ad246612c17474R206-R209); `InfoPanel/Models/TextDisplayItem.cs`, [[5]](diffhunk://#diff-4762652b2cd7e02528b0863e6e91a0f2e73e176bce589f4d6c1ae47d621d191bR184-R188)
* **Code simplification**: Updated `LoadDisplayItems` in `SharedModel` to use the new `SetProfileGuid` method, removing redundant logic for assigning `ProfileGuid` to nested items. (`InfoPanel/Models/SharedModel.cs`, [InfoPanel/Models/SharedModel.csL1682-R1682](diffhunk://#diff-a30354f9a73038124bed6d6b734386a04bc4ef8e373ecbc53680860bd6a550f7L1682-R1682))

### UI Binding Update:

* **Visibility binding**: Replaced the `IsEnabled` binding for `IsSelectedItemMovable` with a `Visibility` binding, using a `BooleanToVisibilityConverter` for better UI behavior. (`InfoPanel/Views/Components/CommonProperties.xaml`, [InfoPanel/Views/Components/CommonProperties.xamlL24-R25](diffhunk://#diff-6b093059ef866a3cc7f384e3dfd50ce0e8f069e55e071d16478f95d4b3cae32bL24-R25))