### PR TITLE
Better Skia text handling

### DIFF
--- a/InfoPanel/Drawing/PanelDraw.cs
+++ b/InfoPanel/Drawing/PanelDraw.cs
@@ -231,7 +231,7 @@ namespace InfoPanel.Drawing
                                                     x + tWidth, y,
                                           i != 0 && textDisplayItem.RightAlign, textDisplayItem.CenterAlign, textDisplayItem.Bold,
                                           textDisplayItem.Italic, textDisplayItem.Underline,
-                                          textDisplayItem.Strikeout, length, 0);
+                                          textDisplayItem.Strikeout, textDisplayItem.Wrap, textDisplayItem.Ellipsis, length, 0);
                                             }
 
                                             var rows = Math.Min(table.Rows.Count, maxRows);
@@ -247,7 +247,7 @@ namespace InfoPanel.Drawing
                                                         x + tWidth, (int)(y + (fHeight * (j + (tableSensorDisplayItem.ShowHeader ? 1 : 0)))),
                                        i != 0 && textDisplayItem.RightAlign, textDisplayItem.CenterAlign, textDisplayItem.Bold,
                                        textDisplayItem.Italic, textDisplayItem.Underline,
-                                       textDisplayItem.Strikeout, length, 0);
+                                       textDisplayItem.Strikeout, textDisplayItem.Wrap, textDisplayItem.Ellipsis, length, 0);
                                                 }
                                             }
 
@@ -261,7 +261,7 @@ namespace InfoPanel.Drawing
                         }
 
                         g.DrawString(text, textDisplayItem.Font, textDisplayItem.FontStyle, fontSize, color, x, y, textDisplayItem.RightAlign, textDisplayItem.CenterAlign,
-                            textDisplayItem.Bold, textDisplayItem.Italic, textDisplayItem.Underline, textDisplayItem.Strikeout,
+                            textDisplayItem.Bold, textDisplayItem.Italic, textDisplayItem.Underline, textDisplayItem.Strikeout, textDisplayItem.Wrap, textDisplayItem.Ellipsis,
                             textDisplayItem.Width);
 
                         break;

--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -227,6 +227,7 @@
 		<PackageReference Include="System.IO.Ports" Version="9.0.2" />
 		<PackageReference Include="System.Management" Version="9.0.2" />
 		<PackageReference Include="TaskScheduler" Version="2.12.1" />
+		<PackageReference Include="Topten.RichTextKit" Version="0.4.167" />
 		<PackageReference Include="WPF-UI" Version="3.1.1" />
 		<PackageReference Include="WPF-UI.Tray" Version="3.1.1" />
 	</ItemGroup>

--- a/InfoPanel/Models/TableSensorDisplayItem.cs
+++ b/InfoPanel/Models/TableSensorDisplayItem.cs
@@ -54,14 +54,10 @@ namespace InfoPanel.Models
 
         public override SKSize EvaluateSize()
         {
-            var typeface = SkiaGraphics.CreateTypeface(Font, FontStyle, Bold, Italic);
-            using var font = new SKFont(typeface, size: FontSize * Profile.FontScale);
 
-            var metrics = font.Metrics;
+            var skiaGraphics = SkiaGraphics.FromEmpty(Profile.FontScale);
             var text = "A";
-
-            float width = font.MeasureText(text);
-            float height = metrics.Descent - metrics.Ascent;
+            var (_, height) = skiaGraphics.MeasureString(text, Font, FontStyle, FontSize, Bold, Italic, Underline, Strikeout, Wrap, Ellipsis, Width, Height);
 
             if (GetValue() is SensorReading sensorReading && sensorReading.ValueTable is DataTable table)
             {

--- a/InfoPanel/Models/TextDisplayItem.cs
+++ b/InfoPanel/Models/TextDisplayItem.cs
@@ -23,7 +23,7 @@ namespace InfoPanel.Models
         }
 
         [ObservableProperty]
-        private string _fontStyle;
+        private string _fontStyle = string.Empty;
 
         private int _fontSize = 20;
         public int FontSize
@@ -122,6 +122,12 @@ namespace InfoPanel.Models
         }
 
         [ObservableProperty]
+        private bool _wrap = true;
+
+        [ObservableProperty]
+        private bool _ellipsis = true;
+
+        [ObservableProperty]
         private int _width = 0;
 
         [ObservableProperty]
@@ -151,18 +157,10 @@ namespace InfoPanel.Models
 
         public override SKSize EvaluateSize()
         {
-            var typeface = SkiaGraphics.CreateTypeface(Font, FontStyle, Bold, Italic);
-            using var font = new SKFont(typeface, size: FontSize * Profile.FontScale);
-
+            var skiaGraphics = SkiaGraphics.FromEmpty(Profile.FontScale);
             var text = EvaluateText();
-            font.MeasureText(text, out var bounds);
-
-            var metrics = font.Metrics;
-
-            float width = bounds.Width;
-            float height = metrics.Descent - metrics.Ascent;
-
-            return new SKSize(Width == 0 ? width : Width, height);
+            var (width, height) = skiaGraphics.MeasureString(text, Font, FontStyle, FontSize, Bold, Italic, Underline, Strikeout, Wrap, Ellipsis, Width);
+            return new SKSize(width, height);
         }
 
         public override SKRect EvaluateBounds()

--- a/InfoPanel/Views/Components/Text/TextProperties.xaml
+++ b/InfoPanel/Views/Components/Text/TextProperties.xaml
@@ -40,6 +40,12 @@
                 <ToggleButton Margin="5,0,0,0" IsChecked="{Binding Uppercase}">
                     <ui:SymbolIcon Symbol="TextCaseUppercase20" ToolTip="Uppercase" />
                 </ToggleButton>
+                <ToggleButton Margin="5,0,0,0" IsChecked="{Binding Wrap}">
+                    <ui:SymbolIcon Symbol="TextWrap20" ToolTip="Wrap Text" />
+                </ToggleButton>
+                <ToggleButton Margin="5,0,0,0" IsChecked="{Binding Ellipsis}">
+                    <ui:SymbolIcon Symbol="TextWholeWord20" ToolTip="Ellipsis" />
+                </ToggleButton>
             </StackPanel>
 
             <StackPanel Margin="0,12,0,0">

--- a/InfoPanel/packages.lock.json
+++ b/InfoPanel/packages.lock.json
@@ -267,6 +267,19 @@
           "System.Security.AccessControl": "6.0.1"
         }
       },
+      "Topten.RichTextKit": {
+        "type": "Direct",
+        "requested": "[0.4.167, )",
+        "resolved": "0.4.167",
+        "contentHash": "fARM2vAZ4ZFAcNFqRLVrjQNjXzk/2yWWXTmTZ/aYUdXJE6ZT2616v3Ojux4cVcKPx2M930sY3plLKeWppGsJaA==",
+        "dependencies": {
+          "HarfBuzzSharp.NativeAssets.Linux": "2.8.2.3",
+          "SkiaSharp": "2.88.7",
+          "SkiaSharp.HarfBuzz": "2.88.7",
+          "SkiaSharp.NativeAssets.Linux": "2.88.7",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
       "WPF-UI": {
         "type": "Direct",
         "requested": "[3.1.1, )",
@@ -313,6 +326,14 @@
         "contentHash": "rwLpl+W6uqu0DuvzqNhTMuFcXfy1Vc0uq0YXgPEmtTSfeUSAye1FcARrm2YIPOSiCBwBOGu3cLvMX5Fp6OKe2g==",
         "dependencies": {
           "HarfBuzzSharp.NativeAssets.Win32": "8.3.0.1"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.8.2.3",
+        "contentHash": "Qu1yJSHEN7PD3+fqfkaClnORWN5e2xJ2Xoziz/GUi/oBT1Z+Dp2oZeiONKP6NFltboSOBkvH90QuOA6YN/U1zg==",
+        "dependencies": {
+          "HarfBuzzSharp": "2.8.2.3"
         }
       },
       "HarfBuzzSharp.NativeAssets.Win32": {
@@ -841,6 +862,14 @@
           "SkiaSharp": "3.116.1"
         }
       },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.88.7",
+        "contentHash": "i9VitS7/5D8Te3B1Gu7F6kakW9PYVnI3YC6MoR6NidreD9hDl1EIOQEBaa0eBsOsWNX5Bz92OVf6+7KbDrJvyg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.7"
+        }
+      },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",
         "resolved": "3.119.0",
@@ -922,6 +951,11 @@
           "System.IO.Pipelines": "9.0.2",
           "System.Text.Encodings.Web": "9.0.2"
         }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
       },
       "Vortice.D3DCompiler": {
         "type": "Transitive",
@@ -1034,6 +1068,14 @@
           "System.CodeDom": "9.0.2"
         }
       },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.8.2.3",
+        "contentHash": "Qu1yJSHEN7PD3+fqfkaClnORWN5e2xJ2Xoziz/GUi/oBT1Z+Dp2oZeiONKP6NFltboSOBkvH90QuOA6YN/U1zg==",
+        "dependencies": {
+          "HarfBuzzSharp": "2.8.2.3"
+        }
+      },
       "HarfBuzzSharp.NativeAssets.Win32": {
         "type": "Transitive",
         "resolved": "8.3.0.1",
@@ -1137,6 +1179,14 @@
         "type": "Transitive",
         "resolved": "9.0.2",
         "contentHash": "aQDPDCg6seSBRJvx45K8heC2Q1u8uKZ+u52RnREKh6MdHx+E1WlEOqs7u5MH5E3dP6Hw6BIYSdvoElRi8fBB3Q=="
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "2.88.7",
+        "contentHash": "i9VitS7/5D8Te3B1Gu7F6kakW9PYVnI3YC6MoR6NidreD9hDl1EIOQEBaa0eBsOsWNX5Bz92OVf6+7KbDrJvyg==",
+        "dependencies": {
+          "SkiaSharp": "2.88.7"
+        }
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",


### PR DESCRIPTION
This pull request introduces enhancements to text rendering in the `InfoPanel` project by integrating the `Topten.RichTextKit` library. The changes improve text layout capabilities, including support for wrapping, ellipsis, and alignment. Additionally, several refactorings were made to simplify and modernize the codebase.

### Text Rendering Enhancements:
* Added support for text wrapping and ellipsis in the `Draw` method of `PanelDraw.cs` by including the `Wrap` and `Ellipsis` properties in text rendering logic. [[1]](diffhunk://#diff-29a2d4c4a34a6a41a403853cc696efe2bca212aac6dbdfc2481a93e070224985L234-R234) [[2]](diffhunk://#diff-29a2d4c4a34a6a41a403853cc696efe2bca212aac6dbdfc2481a93e070224985L250-R250) [[3]](diffhunk://#diff-29a2d4c4a34a6a41a403853cc696efe2bca212aac6dbdfc2481a93e070224985L264-R264)
* Refactored the `DrawString` method in `SkiaGraphics.cs` to use `TextBlock` from `Topten.RichTextKit`, replacing manual text alignment and ellipsis handling with a more robust implementation.
* Updated `MeasureString` in `SkiaGraphics.cs` to leverage `TextBlock` for more accurate text measurement, supporting wrapping and ellipsis.

### Codebase Refactoring:
* Introduced a `FromEmpty` factory method in `SkiaGraphics.cs` to create instances without a canvas, simplifying text size evaluation.
* Replaced manual font metrics calculations in `EvaluateSize` methods of `TableSensorDisplayItem.cs` and `TextDisplayItem.cs` with calls to the refactored `MeasureString` method. [[1]](diffhunk://#diff-3f0ea48026f84ab6826de91a45f5896825958f6c98ddd0fd2980ebfd47751141L57-R60) [[2]](diffhunk://#diff-4762652b2cd7e02528b0863e6e91a0f2e73e176bce589f4d6c1ae47d621d191bL154-R163)

### UI Enhancements:
* Added toggle buttons for "Wrap Text" and "Ellipsis" options in the `TextProperties.xaml` UI, allowing users to configure these settings interactively.

### Dependency Updates:
* Added `Topten.RichTextKit` as a new dependency in `InfoPanel.csproj` and updated `packages.lock.json` to include its transitive dependencies. [[1]](diffhunk://#diff-9e028479d3c133f7820377e2ec3249b912c1c1afeefd8bbc507d1aae2a978f52R230) [[2]](diffhunk://#diff-b836202b3fd8b5244d7d5488f12fde0348b78eb4e609e0983b3e07b459ca9da0R270-R282) [[3]](diffhunk://#diff-b836202b3fd8b5244d7d5488f12fde0348b78eb4e609e0983b3e07b459ca9da0R331-R338)