### PR TITLE
Add new BeadaPanel models and update Model5S dimensions

### DIFF
--- a/InfoPanel/BeadaPanel/BeadaPanelModelDatabase.cs
+++ b/InfoPanel/BeadaPanel/BeadaPanelModelDatabase.cs
@@ -16,14 +16,21 @@ namespace InfoPanel.BeadaPanel
             [BeadaPanelModel.Model4] = new BeadaPanelModelInfo { Name = "4", Width = 480, Height = 800, WidthMM = 56, HeightMM = 94 },
             [BeadaPanelModel.Model3C] = new BeadaPanelModelInfo { Name = "3C", Width = 480, Height = 320, WidthMM = 62, HeightMM = 40 },
             [BeadaPanelModel.Model4C] = new BeadaPanelModelInfo { Name = "4C", Width = 800, Height = 480, WidthMM = 94, HeightMM = 56 },
+            [BeadaPanelModel.Model5C] = new BeadaPanelModelInfo { Name = "5C", Width = 800, Height = 480, WidthMM = 108, HeightMM = 65 },
             [BeadaPanelModel.Model5] = new BeadaPanelModelInfo { Name = "5", Width = 800, Height = 480, WidthMM = 108, HeightMM = 65 },
             [BeadaPanelModel.Model5T] = new BeadaPanelModelInfo { Name = "5T", Width = 800, Height = 480, WidthMM = 108, HeightMM = 65 },
-            [BeadaPanelModel.Model5S] = new BeadaPanelModelInfo { Name = "5S", Width = 854, Height = 480, WidthMM = 110, HeightMM = 62 },
+            [BeadaPanelModel.Model5S] = new BeadaPanelModelInfo { Name = "5S", Width = 480, Height = 854, WidthMM = 62, HeightMM = 110 },
             [BeadaPanelModel.Model6] = new BeadaPanelModelInfo { Name = "6", Width = 480, Height = 1280, WidthMM = 60, HeightMM = 161 },
             [BeadaPanelModel.Model6C] = new BeadaPanelModelInfo { Name = "6C", Width = 1280, Height = 480, WidthMM = 161, HeightMM = 60 },
             [BeadaPanelModel.Model6S] = new BeadaPanelModelInfo { Name = "6S", Width = 1280, Height = 480, WidthMM = 161, HeightMM = 60 },
             [BeadaPanelModel.Model7C] = new BeadaPanelModelInfo { Name = "7C", Width = 800, Height = 480, WidthMM = 62, HeightMM = 110 },
-            [BeadaPanelModel.Model7S] = new BeadaPanelModelInfo { Name = "7S", Width = 1280, Height = 400, WidthMM = 190, HeightMM = 59 }
+            [BeadaPanelModel.Model7S] = new BeadaPanelModelInfo { Name = "7S", Width = 1280, Height = 400, WidthMM = 190, HeightMM = 59 },
+            [BeadaPanelModel.Model8] = new BeadaPanelModelInfo { Name = "8", Width = 480, Height = 1920, WidthMM = 54, HeightMM = 219 },
+            [BeadaPanelModel.ModelY] = new BeadaPanelModelInfo { Name = "Y", Width = 480, Height = 1920, WidthMM = 54, HeightMM = 219 },
+            [BeadaPanelModel.Model11] = new BeadaPanelModelInfo { Name = "11", Width = 440, Height = 1920, WidthMM = 58, HeightMM = 253 },
+            [BeadaPanelModel.ModelX] = new BeadaPanelModelInfo { Name = "X", Width = 440, Height = 1920, WidthMM = 58, HeightMM = 253 },
+            [BeadaPanelModel.Model9] = new BeadaPanelModelInfo { Name = "9", Width = 462, Height = 1920, WidthMM = 55, HeightMM = 226 },
+            [BeadaPanelModel.ModelZ] = new BeadaPanelModelInfo { Name = "Z", Width = 462, Height = 1920, WidthMM = 55, HeightMM = 226 }
         };
     }
 }

--- a/InfoPanel/BeadaPanel/BeadaPanelModelType.cs
+++ b/InfoPanel/BeadaPanel/BeadaPanelModelType.cs
@@ -23,6 +23,12 @@ namespace InfoPanel.BeadaPanel
         Model2 = 17,
         Model2W = 18,
         Model7S = 19,
-        Model5S = 20
+        Model5S = 20,
+        Model8 = 21,
+        Model11 = 22,
+        Model9 = 23,
+        ModelY = 24,
+        ModelX = 25,
+        ModelZ = 26,
     }
 }


### PR DESCRIPTION

This pull request updates the Beada panel model definitions by adding several new models and correcting the display parameters for an existing model. The changes ensure that the application can recognize and handle a broader range of panel types with accurate specifications.

**New panel models added:**

* Added new entries for `Model8`, `ModelY`, `Model11`, `ModelX`, `Model9`, and `ModelZ` to both the `BeadaPanelModel` enum and the `BeadaPanelModelDatabase` mapping, allowing support for these additional panel types. [[1]](diffhunk://#diff-331e1ea5969c5e461bd3924c8d202d5ec9372fab19c30262998bde0f01c2f6f1L26-R32) [[2]](diffhunk://#diff-80aa914573fca0389764e4b3ad18bb0285effae1ae898de0a65fab2535f22a09R19-R33)

**Corrections to existing panel model parameters:**

* Updated the resolution and physical dimensions for `Model5S` in `BeadaPanelModelDatabase` to correct width, height, and millimeter values, ensuring accurate handling of this panel type.