### PR TITLE
Add persistent cache option for gauge images

### DIFF
--- a/InfoPanel/Models/GaugeDisplayItem.cs
+++ b/InfoPanel/Models/GaugeDisplayItem.cs
@@ -338,6 +338,7 @@ namespace InfoPanel.Models
             foreach (var imageDisplayItem in Images)
             {
                 imageDisplayItem.SetProfile(profile);
+                imageDisplayItem.PersistentCache = true; // Ensure gauge images never expire
             }
         }
 
@@ -352,6 +353,7 @@ namespace InfoPanel.Models
             {
                 var cloneImage = (ImageDisplayItem) imageDisplayItem.Clone();
                 cloneImage.Guid = Guid.NewGuid();
+                cloneImage.PersistentCache = true; // Ensure gauge images never expire
                 clone.Images.Add(cloneImage);
             }
 

--- a/InfoPanel/Models/ImageDisplayItem.cs
+++ b/InfoPanel/Models/ImageDisplayItem.cs
@@ -146,6 +146,17 @@ namespace InfoPanel.Models
             }
         }
 
+        private bool _persistentCache = false;
+        [System.Xml.Serialization.XmlIgnore]
+        public bool PersistentCache
+        {
+            get { return _persistentCache; }
+            set
+            {
+                SetProperty(ref _persistentCache, value);
+            }
+        }
+
         private int _scale = 100;
         public int Scale
         {

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -128,9 +128,8 @@ namespace InfoPanel
 
             var cachedImage = new LockedImage(path, imageDisplayItem);
 
-            ImageCache.Set(path, cachedImage, new MemoryCacheEntryOptions
+            var cacheOptions = new MemoryCacheEntryOptions
             {
-                SlidingExpiration = TimeSpan.FromSeconds(10),
                 PostEvictionCallbacks = {
                     new PostEvictionCallbackRegistration
                     {
@@ -144,9 +143,17 @@ namespace InfoPanel
                         }
                     }
                 }
-            });
+            };
 
-            Logger.Debug("Image '{Path}' loaded successfully", path);
+            // Only set expiration for non-persistent images
+            if (imageDisplayItem?.PersistentCache != true)
+            {
+                cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(10);
+            }
+
+            ImageCache.Set(path, cachedImage, cacheOptions);
+
+            Logger.Debug("Image '{Path}' loaded successfully (Persistent: {Persistent})", path, imageDisplayItem?.PersistentCache ?? false);
         }
 
         public static void InvalidateImage(ImageDisplayItem imageDisplayItem)

--- a/InfoPanel/Views/Components/Custom/CustomProperties.xaml.cs
+++ b/InfoPanel/Views/Components/Custom/CustomProperties.xaml.cs
@@ -99,7 +99,10 @@ namespace InfoPanel.Views.Components
                             {
                                 var fileName = Path.GetFileName(file);
                                 File.Copy(file, Path.Combine(imageFolder, fileName), true);
-                                var imageDisplayItem = new ImageDisplayItem(fileName, profile, fileName, true);
+                                var imageDisplayItem = new ImageDisplayItem(fileName, profile, fileName, true)
+                                {
+                                    PersistentCache = true // Gauge images should not expire
+                                };
 
                                 customDisplayItem.Images.Add(imageDisplayItem);
                             }


### PR DESCRIPTION
This pull request introduces improvements to the caching mechanism for gauge images in the InfoPanel application, ensuring that these images are persistently cached and do not expire. The changes add a `PersistentCache` property to `ImageDisplayItem` and update relevant logic to respect this setting when caching images.

**Gauge image caching improvements:**

* Added a `PersistentCache` property to the `ImageDisplayItem` class to allow certain images (such as gauge images) to be persistently cached. (`InfoPanel/Models/ImageDisplayItem.cs`, [InfoPanel/Models/ImageDisplayItem.csR149-R159](diffhunk://#diff-96eb9392ff22cb04b3287726611ad0b22304b6e51d049cd880ad246612c17474R149-R159))
* Updated the image cache initialization logic to apply expiration only to non-persistent images, so persistent images remain in cache indefinitely. (`InfoPanel/Utils/Cache.cs`, [[1]](diffhunk://#diff-31a21e9d65e89935c894d8a58d3f13fdc94b460d8dd0898d4a8c7705429086fcL131-L133) [[2]](diffhunk://#diff-31a21e9d65e89935c894d8a58d3f13fdc94b460d8dd0898d4a8c7705429086fcL147-R156)
* Set the `PersistentCache` property to `true` for gauge images in `GaugeDisplayItem.SetProfile` and during cloning to ensure these images never expire. (`InfoPanel/Models/GaugeDisplayItem.cs`, [[1]](diffhunk://#diff-88464f379e0f0a053dad12cd6daddf1d117425dc387a38d0e530d75752cd1f1eR341) [[2]](diffhunk://#diff-88464f379e0f0a053dad12cd6daddf1d117425dc387a38d0e530d75752cd1f1eR356)
* When adding new gauge images in the custom properties view, ensured that `PersistentCache` is set to `true` so they are always cached. (`InfoPanel/Views/Components/Custom/CustomProperties.xaml.cs`, [InfoPanel/Views/Components/Custom/CustomProperties.xaml.csL102-R105](diffhunk://#diff-c9150156b788dcc77827453e867176d36f2c94570a40952dd075f824a4474550L102-R105))