### PR TITLE
Synchronization fixes

### DIFF
--- a/InfoPanel.Plugins.Loader/InfoPanel.Plugins.Loader.csproj
+++ b/InfoPanel.Plugins.Loader/InfoPanel.Plugins.Loader.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
+    <PackageReference Include="AsyncKeyedLock" Version="8.0.0" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>

--- a/InfoPanel.Plugins.Loader/InfoPanel.Plugins.Loader.csproj
+++ b/InfoPanel.Plugins.Loader/InfoPanel.Plugins.Loader.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
     <PackageReference Include="ini-parser-netstandard" Version="2.5.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />
   </ItemGroup>

--- a/InfoPanel.Plugins.Loader/packages.lock.json
+++ b/InfoPanel.Plugins.Loader/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "AsyncKeyedLock": {
+        "type": "Direct",
+        "requested": "[7.1.8, )",
+        "resolved": "7.1.8",
+        "contentHash": "LhDLwna+oO0lDA/xRK2JMeZ6XN4AN6VnZXaTC+pO95sd+uJUFqfdK1H5hS09upX4IrpErVSKW+uKgxctcnYe7w==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
+        }
+      },
       "ini-parser-netstandard": {
         "type": "Direct",
         "requested": "[2.5.3, )",
@@ -13,6 +22,11 @@
         "requested": "[4.3.0, )",
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.6.3",
+        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA=="
       },
       "infopanel.plugins": {
         "type": "Project"

--- a/InfoPanel.Plugins.Loader/packages.lock.json
+++ b/InfoPanel.Plugins.Loader/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "AsyncKeyedLock": {
         "type": "Direct",
-        "requested": "[7.1.8, )",
-        "resolved": "7.1.8",
-        "contentHash": "LhDLwna+oO0lDA/xRK2JMeZ6XN4AN6VnZXaTC+pO95sd+uJUFqfdK1H5hS09upX4IrpErVSKW+uKgxctcnYe7w==",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "7OvOXY8M4lUDi12P6P1/WbD5AgpCpMjY2zn6USSiaQW45YRoM11MruCqQXdbbDmMIHt3v2v1YCUqIJK44YYeyg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.6.3"
         }

--- a/InfoPanel.Plugins.Simulator/packages.lock.json
+++ b/InfoPanel.Plugins.Simulator/packages.lock.json
@@ -2,6 +2,14 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "AsyncKeyedLock": {
+        "type": "Transitive",
+        "resolved": "7.1.8",
+        "contentHash": "LhDLwna+oO0lDA/xRK2JMeZ6XN4AN6VnZXaTC+pO95sd+uJUFqfdK1H5hS09upX4IrpErVSKW+uKgxctcnYe7w==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
+        }
+      },
       "ini-parser-netstandard": {
         "type": "Transitive",
         "resolved": "2.5.3",
@@ -12,12 +20,18 @@
         "resolved": "4.3.0",
         "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
       },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.6.3",
+        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA=="
+      },
       "infopanel.plugins": {
         "type": "Project"
       },
       "infopanel.plugins.loader": {
         "type": "Project",
         "dependencies": {
+          "AsyncKeyedLock": "[7.1.8, )",
           "InfoPanel.Plugins": "[1.0.0, )",
           "Serilog": "[4.3.0, )",
           "ini-parser-netstandard": "[2.5.3, )"

--- a/InfoPanel.Plugins.Simulator/packages.lock.json
+++ b/InfoPanel.Plugins.Simulator/packages.lock.json
@@ -4,8 +4,8 @@
     "net8.0": {
       "AsyncKeyedLock": {
         "type": "Transitive",
-        "resolved": "7.1.8",
-        "contentHash": "LhDLwna+oO0lDA/xRK2JMeZ6XN4AN6VnZXaTC+pO95sd+uJUFqfdK1H5hS09upX4IrpErVSKW+uKgxctcnYe7w==",
+        "resolved": "8.0.0",
+        "contentHash": "7OvOXY8M4lUDi12P6P1/WbD5AgpCpMjY2zn6USSiaQW45YRoM11MruCqQXdbbDmMIHt3v2v1YCUqIJK44YYeyg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.6.3"
         }
@@ -31,7 +31,7 @@
       "infopanel.plugins.loader": {
         "type": "Project",
         "dependencies": {
-          "AsyncKeyedLock": "[7.1.8, )",
+          "AsyncKeyedLock": "[8.0.0, )",
           "InfoPanel.Plugins": "[1.0.0, )",
           "Serilog": "[4.3.0, )",
           "ini-parser-netstandard": "[2.5.3, )"

--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -195,7 +195,7 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="AsyncKeyedLock" Version="7.1.7" />
+		<PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
 		<PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />

--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -195,6 +195,7 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
+		<PackageReference Include="AsyncKeyedLock" Version="7.1.7" />
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
 		<PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />

--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -195,7 +195,7 @@
 
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
+		<PackageReference Include="AsyncKeyedLock" Version="8.0.0" />
 		<PackageReference Include="AutoMapper" Version="14.0.0" />
 		<PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -171,7 +171,6 @@ namespace InfoPanel
                     {
                         Log.Error(e, "Failed to invalidate image from cache '{Path}'", path);
                     }
-                    ImageCache.Remove(path);
                 }
             }
         }

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -1,11 +1,10 @@
-﻿using InfoPanel.Extensions;
+﻿using AsyncKeyedLock;
+using InfoPanel.Extensions;
 using InfoPanel.Models;
 using InfoPanel.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Serilog;
 using System;
-using System.Collections.Concurrent;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,7 +19,7 @@ namespace InfoPanel
         });
 
         private static readonly Timer _expirationTimer;
-        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = [];
+        private static readonly AsyncKeyedLocker<string> _locks = new();
 
         static Cache()
         {
@@ -79,22 +78,22 @@ namespace InfoPanel
                 return null;
             }
 
-            var semaphore = _locks.GetOrAdd(path, _ => new SemaphoreSlim(1, 1));
-
             // Try to acquire lock WITHOUT waiting (0ms timeout)
-            if (!semaphore.Wait(0))
+            var semLock = _locks.LockOrNull(path, 0);
+
+            if (semLock == null)
             {
                 // Another thread is initializing - return null immediately
                 return null;
             }
 
             // Start async initialization without blocking
-            _ = Task.Run(() => InitializeImageSafe(path, imageDisplayItem, semaphore));
+            _ = Task.Run(() => InitializeImageSafe(path, imageDisplayItem, semLock));
 
             return null; // Return null immediately while initializing
         }
 
-        private static void InitializeImageSafe(string path, ImageDisplayItem? imageDisplayItem, SemaphoreSlim semaphore)
+        private static void InitializeImageSafe(string path, ImageDisplayItem? imageDisplayItem, IDisposable semLock)
         {
             try
             {
@@ -106,15 +105,7 @@ namespace InfoPanel
             }
             finally
             {
-                semaphore.Release();
-
-                // Safely clean up semaphore - check if we can remove it atomically
-                if (_locks.TryGetValue(path, out var currentSemaphore) &&
-                    ReferenceEquals(currentSemaphore, semaphore) &&
-                    semaphore.CurrentCount == 1)
-                {
-                    _locks.TryRemove(path, out _);
-                }
+                semLock.Dispose();
             }
         }
 
@@ -170,20 +161,17 @@ namespace InfoPanel
         {
             if (!string.IsNullOrEmpty(path))
             {
-                var semaphore = _locks.GetOrAdd(path, _ => new SemaphoreSlim(1, 1));
-
-                try
+                using (_locks.Lock(path))
                 {
-                    semaphore.Wait();
+                    try
+                    {
+                        ImageCache.Remove(path);
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error(e, "Failed to invalidate image from cache '{Path}'", path);
+                    }
                     ImageCache.Remove(path);
-                }
-                catch (Exception e)
-                {
-                    Log.Error(e, "Failed to acquire lock for invalidating image '{Path}'", path);
-                }
-                finally
-                {
-                    semaphore.Release();
                 }
             }
         }

--- a/InfoPanel/packages.lock.json
+++ b/InfoPanel/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net8.0-windows10.0.19041": {
+      "AsyncKeyedLock": {
+        "type": "Direct",
+        "requested": "[7.1.7, )",
+        "resolved": "7.1.7",
+        "contentHash": "plakgzY2HSEhDadxaqhKUnz/DRkUtS/H8RU7/3h/0lElESuhR+SCKLy4nB6dm1fqRoi7fWXYdd6xWd6jtfh74Q==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.6.3"
+        }
+      },
       "AutoMapper": {
         "type": "Direct",
         "requested": "[14.0.0, )",
@@ -275,7 +284,7 @@
         "type": "Direct",
         "requested": "[2.12.2, )",
         "resolved": "2.12.2",
-        "contentHash": "glpAb3VrwfdAofp6PIyAzL0ZeTV7XUJ8muu0oZoTeyU5jtk2sMJ6QAMRRuFbovcaj+SBJiEUGklxIWOqQoxshA==",
+        "contentHash": "9DKDHekRTucqAr5e7ySRby1uLBpE30pfElgXkTQu8NY+trOFOe6ZF10tz6DuPPWOHH7QUAEsRIzBZjOiD6VX/A==",
         "dependencies": {
           "Microsoft.Win32.Registry": "5.0.0",
           "System.Diagnostics.EventLog": "8.0.1",
@@ -1025,6 +1034,11 @@
         "type": "Transitive",
         "resolved": "9.0.9",
         "contentHash": "Kk/RON7Kasudn3dn7dTQYRagNMbaysIuXzmWCndRcaKEbiJqhViUxIPvjyX76aTs19l+9qmYjQL8lN6Spsn4/g=="
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.6.3",
+        "contentHash": "7sCiwilJLYbTZELaKnc7RecBBXWXA+xMLQWZKWawBxYjp6DBlSE3v9/UcvKBvr1vv2tTOhipiogM8rRmxlhrVA=="
       },
       "System.ValueTuple": {
         "type": "Transitive",

--- a/InfoPanel/packages.lock.json
+++ b/InfoPanel/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0-windows10.0.19041": {
       "AsyncKeyedLock": {
         "type": "Direct",
-        "requested": "[7.1.7, )",
-        "resolved": "7.1.7",
-        "contentHash": "plakgzY2HSEhDadxaqhKUnz/DRkUtS/H8RU7/3h/0lElESuhR+SCKLy4nB6dm1fqRoi7fWXYdd6xWd6jtfh74Q==",
+        "requested": "[7.1.8, )",
+        "resolved": "7.1.8",
+        "contentHash": "LhDLwna+oO0lDA/xRK2JMeZ6XN4AN6VnZXaTC+pO95sd+uJUFqfdK1H5hS09upX4IrpErVSKW+uKgxctcnYe7w==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.6.3"
         }
@@ -284,7 +284,7 @@
         "type": "Direct",
         "requested": "[2.12.2, )",
         "resolved": "2.12.2",
-        "contentHash": "9DKDHekRTucqAr5e7ySRby1uLBpE30pfElgXkTQu8NY+trOFOe6ZF10tz6DuPPWOHH7QUAEsRIzBZjOiD6VX/A==",
+        "contentHash": "glpAb3VrwfdAofp6PIyAzL0ZeTV7XUJ8muu0oZoTeyU5jtk2sMJ6QAMRRuFbovcaj+SBJiEUGklxIWOqQoxshA==",
         "dependencies": {
           "Microsoft.Win32.Registry": "5.0.0",
           "System.Diagnostics.EventLog": "8.0.1",
@@ -1131,6 +1131,7 @@
       "infopanel.plugins.loader": {
         "type": "Project",
         "dependencies": {
+          "AsyncKeyedLock": "[7.1.8, )",
           "InfoPanel.Plugins": "[1.0.0, )",
           "Serilog": "[4.3.0, )",
           "ini-parser-netstandard": "[2.5.3, )"

--- a/InfoPanel/packages.lock.json
+++ b/InfoPanel/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0-windows10.0.19041": {
       "AsyncKeyedLock": {
         "type": "Direct",
-        "requested": "[7.1.8, )",
-        "resolved": "7.1.8",
-        "contentHash": "LhDLwna+oO0lDA/xRK2JMeZ6XN4AN6VnZXaTC+pO95sd+uJUFqfdK1H5hS09upX4IrpErVSKW+uKgxctcnYe7w==",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "7OvOXY8M4lUDi12P6P1/WbD5AgpCpMjY2zn6USSiaQW45YRoM11MruCqQXdbbDmMIHt3v2v1YCUqIJK44YYeyg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.6.3"
         }
@@ -1136,7 +1136,7 @@
       "infopanel.plugins.loader": {
         "type": "Project",
         "dependencies": {
-          "AsyncKeyedLock": "[7.1.8, )",
+          "AsyncKeyedLock": "[8.0.0, )",
           "InfoPanel.Plugins": "[1.0.0, )",
           "Serilog": "[4.3.0, )",
           "ini-parser-netstandard": "[2.5.3, )"


### PR DESCRIPTION
Fixes race condition.

- Thread A starts processing for path X.
- Thread A finishes processing at the same time as Thread B starts processing for path X
- Thread A and B both obtain the semaphore from the dictionary at the same time. Thread A removes it from dictionary while Thread B starts processing path X.
- Thread C starts processing for path X. The semaphore was removed from the dictionary by thread A, so threads B and C run in parallel both processing path X.

Also fixes an issue where InvalidateImage never cleans up the dictionary.