### PR TITLE
Support 8in 16:10 panel.

### DIFF
--- a/InfoPanel/Services/TuringPanelTask.cs
+++ b/InfoPanel/Services/TuringPanelTask.cs
@@ -33,22 +33,9 @@ namespace InfoPanel.Services
 
             if (modelInfo != null)
             {
-                BackgroundTask deviceTask;
-                switch (modelInfo.Model)
-                {
-                    case TuringPanelModel.REV_8INCH_USB:
-                        deviceTask = new TuringPanelUsbDeviceTask(device);
-                        break;
-                    case TuringPanelModel.TURING_3_5:
-                    case TuringPanelModel.REV_2INCH:
-                    case TuringPanelModel.REV_5INCH:
-                    case TuringPanelModel.REV_8INCH:
-                        deviceTask = new TuringPanelSerialTask(device);
-                        break;
-                    default:
-                        Logger.Error("TuringPanel: Unsupported model {Model} for device {DeviceId}", modelInfo.Model, device.Id);
-                        return;
-                }
+                BackgroundTask deviceTask = modelInfo.IsUsbDevice 
+                    ? new TuringPanelUsbDeviceTask(device) 
+                    : new TuringPanelSerialTask(device);
 
                 if (_deviceTasks.TryAdd(device.Id, deviceTask))
                 {

--- a/InfoPanel/Services/TuringPanelUsbDeviceTask.cs
+++ b/InfoPanel/Services/TuringPanelUsbDeviceTask.cs
@@ -19,8 +19,6 @@ namespace InfoPanel.Services
     {
         private static readonly ILogger Logger = Log.ForContext<TuringPanelUsbDeviceTask>();
         private readonly TuringPanelDevice _device;
-        private readonly int _panelWidth = 480;
-        private readonly int _panelHeight = 1920;
         private static int _maxSize = 1024 * 1024; // 1MB
         private DateTime _downgradeRenderingUntil = DateTime.MinValue;
 
@@ -41,7 +39,7 @@ namespace InfoPanel.Services
                 using var bitmap = PanelDrawTask.RenderSK(profile, false,
                     colorType: DateTime.Now > _downgradeRenderingUntil ? SKColorType.Rgba8888 : SKColorType.Argb4444);
 
-                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
+                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _device.ModelInfo.Width, _device.ModelInfo.Height, rotation);
 
                 var options = new SKPngEncoderOptions(
                         filterFlags: SKPngEncoderFilterFlags.NoFilters,
@@ -107,7 +105,7 @@ namespace InfoPanel.Services
         {
             foreach (UsbRegistry deviceReg in UsbDevice.AllDevices)
             {
-                if (deviceReg.Vid == 0x1cbe && deviceReg.Pid == 0x0088) // VENDOR_ID and PRODUCT_ID from TuringDevice
+                if (deviceReg.Vid == _device.ModelInfo.VendorId && deviceReg.Pid == _device.ModelInfo.ProductId)
                 {
                     var deviceId = deviceReg.DeviceProperties["DeviceID"] as string;
 

--- a/InfoPanel/TuringPanel/TuringPanelHelper.cs
+++ b/InfoPanel/TuringPanel/TuringPanelHelper.cs
@@ -46,6 +46,10 @@ namespace InfoPanel.TuringPanel
                             devices.Add(device);
                         }
                     }
+                    else
+                    {
+                        Log.Information("Unknown USB device {VID} {PID} {Name}", deviceReg.Vid, deviceReg.Pid, deviceReg.FullName);
+                    }
                 }
 
                 return devices;

--- a/InfoPanel/TuringPanel/TuringPanelModel.cs
+++ b/InfoPanel/TuringPanel/TuringPanelModel.cs
@@ -14,6 +14,7 @@
         REV_8INCH,
 
         // Turing Rev "C" with USB interface
-        REV_8INCH_USB,
+        REV_88INCH_USB,
+        REV_80INCH_USB,
     }
 }

--- a/InfoPanel/TuringPanel/TuringPanelModelDatabase.cs
+++ b/InfoPanel/TuringPanel/TuringPanelModelDatabase.cs
@@ -16,7 +16,8 @@ namespace InfoPanel.TuringPanel
             [TuringPanelModel.REV_2INCH] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_2INCH, Name = "Turing Smart Screen 2.1\"", Width = 480, Height = 480, VendorId = 0x1d6b, ProductId = 0x0121 },
             [TuringPanelModel.REV_5INCH] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_5INCH, Name = "Turing Smart Screen 5\"", Width = 800, Height = 480, VendorId = 0x1d6b, ProductId = 0x0106 },
             [TuringPanelModel.REV_8INCH] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_8INCH, Name = "Turing Smart Screen 8\" Rev 1.0", Width = 480, Height = 1920, VendorId = 0x0525, ProductId = 0xa4a7 },
-            [TuringPanelModel.REV_8INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_8INCH_USB, Name = "Turing Smart Screen 8\" Rev 1.1", Width = 480, Height = 1920, VendorId = 0x1cbe, ProductId = 0x0088, IsUsbDevice = true }
+            [TuringPanelModel.REV_88INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_88INCH_USB, Name = "Turing Smart Screen 8.8\" Rev 1.1", Width = 480, Height = 1920, VendorId = 0x1cbe, ProductId = 0x0088, IsUsbDevice = true },
+            [TuringPanelModel.REV_80INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_80INCH_USB, Name = "Turing Smart Screen 8\"", Width = 800, Height = 1280, VendorId = 0x1cbe, ProductId = 0x0080, IsUsbDevice = true }
         };
 
         public static bool TryGetModelInfo(int vendorId, int productId, bool isUsbDevice, out TuringPanelModelInfo modelInfo)


### PR DESCRIPTION
Rename `REV_8INCH_USB` to `REV_88INCH_USB` and `REV_80INCH_USB` to disambiguate the two screens.

Log unidentified USB devices when searching.