### PR TITLE
Update FlyleafLib to v3.9.4 and add video player delay

### DIFF
--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -199,7 +199,7 @@
 		<PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Flurl.Http" Version="4.0.2" />
-		<PackageReference Include="FlyleafLib" Version="3.9.3" />
+		<PackageReference Include="FlyleafLib" Version="3.9.4" />
 		<PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
 		<PackageReference Include="HidSharp" Version="2.6.4" />
 		<PackageReference Include="ini-parser-netstandard" Version="2.5.3" />

--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -146,6 +146,8 @@ namespace InfoPanel.Models
                         _backgroundVideoPlayer.Audio.Volume = 0; // Start muted
                         _backgroundVideoPlayer.Open(ImagePath);
 
+                        Thread.Sleep(50);
+
                         Width = _backgroundVideoPlayer.Video.Width;
                         Height = _backgroundVideoPlayer.Video.Height;
                         Frames = _backgroundVideoPlayer.Video.FramesTotal;

--- a/InfoPanel/packages.lock.json
+++ b/InfoPanel/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "FlyleafLib": {
         "type": "Direct",
-        "requested": "[3.9.3, )",
-        "resolved": "3.9.3",
-        "contentHash": "VP5y4avbqskTBsoJOQBfp+/kCesl68ShlFY7vQGqW3k8qto8QMC9u8FkmsJtwzpEX5cJjdel2r0Z2H0A1w4/XQ==",
+        "requested": "[3.9.4, )",
+        "resolved": "3.9.4",
+        "contentHash": "7c8uhHs7iQXIZdZgRNwwnqY/7tnCd9KC7tylK9FI3MDVRfVo729UTB1xVd5oYF2kBdiMdNFT+hrFd4gTyTE/KQ==",
         "dependencies": {
           "Flyleaf.FFmpeg.Bindings": "7.1.1",
           "Vortice.D3DCompiler": "3.7.6-beta",


### PR DESCRIPTION
Upgraded FlyleafLib package from 3.9.3 to 3.9.4 for improved compatibility and bug fixes. Added a 50ms delay after opening the video in LockedImage to ensure proper initialization before accessing video properties.