### PR TITLE
Fix panel window size limitations

### DIFF
--- a/InfoPanel/Views/DisplayWindow.xaml
+++ b/InfoPanel/Views/DisplayWindow.xaml
@@ -10,6 +10,8 @@
     Title="DisplayWindow"
     Width="{Binding Profile.Width, Mode=OneWay}"
     Height="{Binding Profile.Height, Mode=OneWay}"
+    MaxWidth="10000"
+    MaxHeight="10000"
     Background="Transparent"
     DataContext="{Binding RelativeSource={RelativeSource self}}"
     KeyUp="Window_KeyUp"

--- a/InfoPanel/Views/Pages/ProfilesPage.xaml
+++ b/InfoPanel/Views/Pages/ProfilesPage.xaml
@@ -269,7 +269,7 @@
                                                 FontSize="14"
                                                 LargeChange="10"
                                                 MaxDecimalPlaces="0"
-                                                Maximum="3840"
+                                                Maximum="10000"
                                                 Minimum="0"
                                                 SmallChange="1"
                                                 Text="{Binding Width}"
@@ -285,7 +285,7 @@
                                             <ui:NumberBox
                                                 FontSize="14"
                                                 MaxDecimalPlaces="0"
-                                                Maximum="3840"
+                                                Maximum="10000"
                                                 Minimum="0"
                                                 SmallChange="1"
                                                 Text="{Binding Height}"


### PR DESCRIPTION
This pull request enhances the flexibility and robustness of the `DisplayWindow` in the InfoPanel application, with a focus on allowing windows to be resized beyond typical screen bounds (up to 10,000x10,000 pixels), improving resource cleanup, and refining user interaction handling. The changes involve both UI (XAML) and backend (C#) updates, including custom window message handling and safer event management.

**Window Resizing and Limits:**

* Increased the `MaxWidth` and `MaxHeight` of `DisplayWindow` in `DisplayWindow.xaml` and the maximum values for width/height in the profile editor UI to 10,000, allowing users to resize windows far beyond standard screen sizes. [[1]](diffhunk://#diff-6b376181fe6634f7c81c3791bbbe931425d4c16989bf5f1796920a0467460023R13-R14) [[2]](diffhunk://#diff-ab3e7ac179d09facc7e546f427c186fa96e01279ccabd5bd6577acd94006e0a9L272-R272) [[3]](diffhunk://#diff-ab3e7ac179d09facc7e546f427c186fa96e01279ccabd5bd6577acd94006e0a9L288-R288)
* Added a custom `WndProc` hook to intercept the `WM_GETMINMAXINFO` message, overriding the maximum tracking size so the window can be resized up to 10,000x10,000 pixels, regardless of screen size.
* Disabled Windows Snap/Aero Snap by removing the maximize box style from the window, preventing accidental maximization and snap behavior.

**Resource Management and Cleanup:**

* Ensured proper unhooking of the `WndProc` and cleanup of timers, event handlers, and Skia elements when the window is closed, preventing resource leaks and potential crashes. [[1]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fR158-R164) [[2]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fL150-R174) [[3]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fR210-R221)

**User Interaction and Robustness:**

* Improved handling of programmatic versus user-initiated window size changes, preventing unintended state changes during initialization or DPI corrections. [[1]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fL232-R268) [[2]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fL400-R447)
* Added exception handling to `DragMove` calls to prevent crashes if the mouse button is released unexpectedly during a drag operation.

**Logging Consistency:**

* Standardized logging by replacing `Log.Debug` with `Logger.Debug` for consistency across the codebase. [[1]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fL456-R508) [[2]](diffhunk://#diff-61864aa9d0c91e65859fe0952a80c152681b3bf16a93d6d984cdb0353c47846fL515-R567)