### PR TITLE
Add storage monitoring settings and UI

### DIFF
--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -199,6 +199,15 @@ namespace InfoPanel
                     await LibreMonitor.Instance.StartAsync();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.LibreHardwareMonitorStorage)
+                  || e.PropertyName == nameof(Settings.LibreHardwareMonitorStorageInterval))
+            {
+                if (Settings.LibreHardwareMonitor)
+                {
+                    await LibreMonitor.Instance.StopAsync();
+                    await LibreMonitor.Instance.StartAsync();
+                }
+            }
             else if (e.PropertyName == nameof(Settings.TuringPanelMultiDeviceMode))
             {
                 if (Settings.TuringPanelMultiDeviceMode)
@@ -400,6 +409,8 @@ namespace InfoPanel
                             Settings.GridLinesSpacing = settings.GridLinesSpacing;
 
                             Settings.LibreHardwareMonitor = settings.LibreHardwareMonitor;
+                            Settings.LibreHardwareMonitorStorage = settings.LibreHardwareMonitorStorage;
+                            Settings.LibreHardwareMonitorStorageInterval = settings.LibreHardwareMonitorStorageInterval;
                             Settings.WebServer = settings.WebServer;
                             Settings.WebServerListenIp = settings.WebServerListenIp;
                             Settings.WebServerListenPort = settings.WebServerListenPort;

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -47,6 +47,12 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _libreHardwareMonitor = true;
 
+        [ObservableProperty]
+        private bool _libreHardwareMonitorStorage = true;
+
+        [ObservableProperty]
+        private int _libreHardwareMonitorStorageInterval = 30;
+
         private readonly ObservableCollection<BeadaPanelDevice> _beadaPanelDevices = [];
 
         public ObservableCollection<BeadaPanelDevice> BeadaPanelDevices

--- a/InfoPanel/Monitors/LibreMonitor.cs
+++ b/InfoPanel/Monitors/LibreMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using LibreHardwareMonitor.Hardware;
+using LibreHardwareMonitor.Hardware.Storage;
 using Serilog;
 using System;
 using System.Collections.Concurrent;
@@ -44,6 +45,9 @@ namespace InfoPanel.Monitors
                 var stopwatch = new Stopwatch();
                 stopwatch.Start();
 
+                StorageDevice.ThrottleInterval = TimeSpan.FromSeconds(
+                    ConfigModel.Instance.Settings.LibreHardwareMonitorStorageInterval);
+
                 Computer computer = new()
                 {
                     IsCpuEnabled = true,
@@ -52,7 +56,7 @@ namespace InfoPanel.Monitors
                     IsMotherboardEnabled = true,
                     IsControllerEnabled = true,
                     IsNetworkEnabled = true,
-                    IsStorageEnabled = true,
+                    IsStorageEnabled = ConfigModel.Instance.Settings.LibreHardwareMonitorStorage,
                 };
 
                 computer.Open();

--- a/InfoPanel/Views/Pages/SettingsPage.xaml
+++ b/InfoPanel/Views/Pages/SettingsPage.xaml
@@ -359,6 +359,59 @@
                         Content="Check Status" />
                 </StackPanel>
             </ui:CardControl>
+
+            <StackPanel Margin="0,10,0,0" Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LibreHardwareMonitor, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <ui:CardControl>
+                    <ui:CardControl.Icon>
+                        <ui:SymbolIcon Symbol="Database20" />
+                    </ui:CardControl.Icon>
+                    <ui:CardControl.Header>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                <TextBlock FontSize="13" FontWeight="Medium" Text="Storage Monitoring" />
+                                <TextBlock Margin="0,5,0,0" FontSize="12"
+                                    Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                    Text="Enable storage/disk monitoring. Disable if not needed." />
+                            </StackPanel>
+                        </Grid>
+                    </ui:CardControl.Header>
+                    <ui:ToggleSwitch IsChecked="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LibreHardwareMonitorStorage}" />
+                </ui:CardControl>
+
+                <ui:CardControl Margin="0,10,0,0" Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LibreHardwareMonitorStorage, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <ui:CardControl.Icon>
+                        <ui:SymbolIcon Symbol="Timer20" />
+                    </ui:CardControl.Icon>
+                    <ui:CardControl.Header>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                <TextBlock FontSize="13" FontWeight="Medium" Text="Storage Polling Interval" />
+                                <TextBlock Margin="0,5,0,0" FontSize="12"
+                                    Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                    Text="How often to poll storage devices (seconds). Higher values reduce HDD activity." />
+                            </StackPanel>
+                        </Grid>
+                    </ui:CardControl.Header>
+                    <ui:NumberBox
+                        Width="150"
+                        FontSize="14"
+                        LargeChange="10"
+                        Maximum="300"
+                        MaxDecimalPlaces="0"
+                        Minimum="1"
+                        SmallChange="5"
+                        Text="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LibreHardwareMonitorStorageInterval}"
+                        Value="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LibreHardwareMonitorStorageInterval}" />
+                </ui:CardControl>
+            </StackPanel>
         </StackPanel>
 
         <StackPanel Grid.Row="1" Margin="0,40,0,0">


### PR DESCRIPTION
This pull request adds new options for storage device monitoring in the application's hardware monitoring feature, giving users more control over whether storage devices are monitored and how frequently they are polled. The changes include new settings, UI controls, and logic updates to support these options.

### Storage Monitoring Feature

* Added new settings `LibreHardwareMonitorStorage` (enable/disable storage monitoring) and `LibreHardwareMonitorStorageInterval` (polling interval in seconds) to the `Settings` class, with default values and observable properties.
* Updated the `DoWorkAsync` method in `LibreMonitor.cs` to enable or disable storage monitoring based on the new setting, and to set the polling interval for storage devices using the new value. [[1]](diffhunk://#diff-fb4f0192fb56e432bc720364cc728a5d40328b293b2bcd52ba662b9b6750fdd8L55-R59) [[2]](diffhunk://#diff-fb4f0192fb56e432bc720364cc728a5d40328b293b2bcd52ba662b9b6750fdd8R48-R50)

### UI Enhancements

* Added new controls to `SettingsPage.xaml` to allow users to toggle storage monitoring and adjust the polling interval, with visibility and value bindings to the new settings.

### Configuration Management

* Updated the configuration loading logic in `ConfigModel.cs` to persist and restore the new storage monitoring settings.
* Modified the property change handler to restart the hardware monitor when storage monitoring settings are changed, ensuring changes take effect immediately.

### Dependency Update

* Added a new import for `LibreHardwareMonitor.Hardware.Storage` in `LibreMonitor.cs` to support the updated storage monitoring logic.