### PR TITLE
Evict GPU texture frames for animated images

### DIFF
--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -632,6 +632,18 @@ namespace InfoPanel.Models
                     {
                         using var image = SKImage.FromBitmap(resizedBitmap);
                         bitmapFrame.Image = image.ToTextureImage(grContext);
+
+                        // Evict other GPU texture frames for animated images to prevent VRAM accumulation
+                        if (Frames > 1 && bitmapFrame.Image != null)
+                        {
+                            for (int i = 0; i < SKBitmapCache.Length; i++)
+                            {
+                                if (i != frame)
+                                {
+                                    SKBitmapCache[i].Invalidate();
+                                }
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
This pull request introduces an important improvement to GPU memory management for animated images in the `LockedImage` model. Specifically, it ensures that only the current frame's GPU texture is retained, preventing excessive VRAM usage when handling multi-frame (animated) images.

Memory management for animated images:

* In `LockedImage.cs`, after creating a new GPU texture for the current frame, the code now evicts GPU textures for all other frames by invalidating their cache entries, reducing unnecessary VRAM accumulation for animated images.