### PR TITLE
Add inline plugin configuration UI

### DIFF
--- a/InfoPanel.Plugins/PluginConfigProperty.cs
+++ b/InfoPanel.Plugins/PluginConfigProperty.cs
@@ -1,0 +1,30 @@
+namespace InfoPanel.Plugins
+{
+    public enum PluginConfigType
+    {
+        String,
+        Integer,
+        Double,
+        Boolean,
+        Choice
+    }
+
+    public class PluginConfigProperty
+    {
+        public required string Key { get; init; }
+        public required string DisplayName { get; init; }
+        public string? Description { get; init; }
+        public required PluginConfigType Type { get; init; }
+        public object? Value { get; set; }
+        public double? MinValue { get; init; }
+        public double? MaxValue { get; init; }
+        public double? Step { get; init; }
+        public string[]? Options { get; init; }
+    }
+
+    public interface IPluginConfigurable
+    {
+        IReadOnlyList<PluginConfigProperty> ConfigProperties { get; }
+        void ApplyConfig(string key, object? value);
+    }
+}

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -185,20 +185,6 @@ namespace InfoPanel.ViewModels
             Name = _wrapper.Name;
             Description = _wrapper.Description;
             ConfigFilePath = _wrapper.ConfigFilePath;
-
-            if (_wrapper.Plugin is IPluginConfigurable configurable)
-            {
-                var properties = configurable.ConfigProperties;
-                foreach (var prop in properties)
-                {
-                    var existing = ConfigProperties.FirstOrDefault(x => x.Key == prop.Key);
-                    if (existing != null)
-                    {
-                        existing.RefreshValue(prop.Value);
-                    }
-                }
-                HasConfigProperties = ConfigProperties.Count > 0;
-            }
         }
     }
 
@@ -281,7 +267,15 @@ namespace InfoPanel.ViewModels
         {
             try
             {
-                _configurable.ApplyConfig(Key, Value);
+                object? typedValue = Type switch
+                {
+                    PluginConfigType.Integer when int.TryParse(Value?.ToString(), out var i) => i,
+                    PluginConfigType.Double when double.TryParse(Value?.ToString(),
+                        System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out var d) => d,
+                    _ => Value
+                };
+                _configurable.ApplyConfig(Key, typedValue);
             }
             catch { }
         }

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -6,6 +6,7 @@ using InfoPanel.Plugins;
 using InfoPanel.Plugins.Loader;
 using InfoPanel.Utils;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.IO.Compression;
@@ -124,13 +125,18 @@ namespace InfoPanel.ViewModels
         private string _description;
         [ObservableProperty]
         private string? _configFilePath;
-      
+
         public ObservableCollection<PluginActionCommand> Actions { get; } = [];
+        public ObservableCollection<PluginConfigPropertyViewModel> ConfigProperties { get; } = [];
+
+        [ObservableProperty]
+        private bool _hasConfigProperties;
 
         [RelayCommand]
         public async Task Reload()
         {
             await PluginMonitor.Instance.ReloadPluginModule(_wrapper);
+            RefreshConfigProperties();
         }
 
         public PluginModuleViewModel(PluginWrapper wrapper)
@@ -151,6 +157,26 @@ namespace InfoPanel.ViewModels
                 var command = new RelayCommand(() => method.Invoke(wrapper.Plugin, null));
                 Actions.Add(new PluginActionCommand { DisplayName = displayName, Command = command });
             }
+
+            RefreshConfigProperties();
+        }
+
+        private void RefreshConfigProperties()
+        {
+            if (_wrapper.Plugin is IPluginConfigurable configurable)
+            {
+                var properties = configurable.ConfigProperties;
+                ConfigProperties.Clear();
+                foreach (var prop in properties)
+                {
+                    ConfigProperties.Add(new PluginConfigPropertyViewModel(configurable, prop));
+                }
+                HasConfigProperties = ConfigProperties.Count > 0;
+            }
+            else
+            {
+                HasConfigProperties = false;
+            }
         }
 
         public void Refresh()
@@ -159,6 +185,20 @@ namespace InfoPanel.ViewModels
             Name = _wrapper.Name;
             Description = _wrapper.Description;
             ConfigFilePath = _wrapper.ConfigFilePath;
+
+            if (_wrapper.Plugin is IPluginConfigurable configurable)
+            {
+                var properties = configurable.ConfigProperties;
+                foreach (var prop in properties)
+                {
+                    var existing = ConfigProperties.FirstOrDefault(x => x.Key == prop.Key);
+                    if (existing != null)
+                    {
+                        existing.RefreshValue(prop.Value);
+                    }
+                }
+                HasConfigProperties = ConfigProperties.Count > 0;
+            }
         }
     }
 
@@ -166,6 +206,94 @@ namespace InfoPanel.ViewModels
     {
         public required string DisplayName { get; set; }
         public required ICommand Command { get; set; }
+    }
+
+    public partial class PluginConfigPropertyViewModel : ObservableObject
+    {
+        private readonly IPluginConfigurable _configurable;
+        private readonly PluginConfigProperty _property;
+
+        public string Key => _property.Key;
+        public string DisplayName => _property.DisplayName;
+        public string? Description => _property.Description;
+        public PluginConfigType Type => _property.Type;
+        public double? MinValue => _property.MinValue;
+        public double? MaxValue => _property.MaxValue;
+        public double? Step => _property.Step;
+        public string[]? Options => _property.Options;
+
+        [ObservableProperty]
+        private object? _value;
+
+        public bool BoolValue
+        {
+            get => Value is true;
+            set { Value = value; OnPropertyChanged(); Apply(); }
+        }
+
+        public string StringValue
+        {
+            get => Value?.ToString() ?? "";
+            set { Value = value; OnPropertyChanged(); Apply(); }
+        }
+
+        public double NumericValue
+        {
+            get => Convert.ToDouble(Value ?? 0.0);
+            set
+            {
+                if (Type == PluginConfigType.Integer)
+                    Value = (int)Math.Round(value);
+                else
+                    Value = value;
+                OnPropertyChanged();
+                Apply();
+            }
+        }
+
+        public int SelectedIndex
+        {
+            get
+            {
+                if (Options == null || Value == null) return -1;
+                return Array.IndexOf(Options, Value.ToString());
+            }
+            set
+            {
+                if (Options != null && value >= 0 && value < Options.Length)
+                {
+                    Value = Options[value];
+                    OnPropertyChanged();
+                    Apply();
+                }
+            }
+        }
+
+        public PluginConfigPropertyViewModel(IPluginConfigurable configurable, PluginConfigProperty property)
+        {
+            _configurable = configurable;
+            _property = property;
+            _value = property.Value;
+        }
+
+        [RelayCommand]
+        private void Apply()
+        {
+            try
+            {
+                _configurable.ApplyConfig(Key, Value);
+            }
+            catch { }
+        }
+
+        public void RefreshValue(object? newValue)
+        {
+            Value = newValue;
+            OnPropertyChanged(nameof(BoolValue));
+            OnPropertyChanged(nameof(StringValue));
+            OnPropertyChanged(nameof(NumericValue));
+            OnPropertyChanged(nameof(SelectedIndex));
+        }
     }
 
     public partial class PluginViewModel : ObservableObject

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -169,6 +169,9 @@ namespace InfoPanel.ViewModels
         {
             if (!_wrapper.IsLoaded)
             {
+                ConfigProperties.Clear();
+                HasConfigProperties = false;
+                ConfigLoaded = false;
                 return;
             }
 
@@ -189,7 +192,9 @@ namespace InfoPanel.ViewModels
             }
             else
             {
+                ConfigProperties.Clear();
                 HasConfigProperties = false;
+                ConfigLoaded = false;
             }
         }
 
@@ -327,23 +332,48 @@ namespace InfoPanel.ViewModels
                         }
                         break;
                     case PluginConfigType.Double:
-                        if (double.TryParse(Value?.ToString(),
-                            System.Globalization.NumberStyles.Float,
-                            System.Globalization.CultureInfo.InvariantCulture, out var d))
+                        double d;
+                        switch (Value)
                         {
-                            if (MinValue.HasValue && MaxValue.HasValue)
-                                d = Math.Clamp(d, MinValue.Value, MaxValue.Value);
-                            else if (MinValue.HasValue)
-                                d = Math.Max(MinValue.Value, d);
-                            else if (MaxValue.HasValue)
-                                d = Math.Min(MaxValue.Value, d);
-                            typedValue = d;
+                            case double directDouble:
+                                d = directDouble;
+                                break;
+                            case float floatValue:
+                                d = floatValue;
+                                break;
+                            case int intValue:
+                                d = intValue;
+                                break;
+                            case long longValue:
+                                d = longValue;
+                                break;
+                            case string stringValue when double.TryParse(
+                                stringValue,
+                                System.Globalization.NumberStyles.Float,
+                                System.Globalization.CultureInfo.InvariantCulture,
+                                out var parsedFromString):
+                                d = parsedFromString;
+                                break;
+                            default:
+                                if (!double.TryParse(
+                                    Value?.ToString()?? "",
+                                    System.Globalization.NumberStyles.Float,
+                                    System.Globalization.CultureInfo.InvariantCulture,
+                                    out var parsedFromOther))
+                                {
+                                    Logger.Warning("Plugin config '{ConfigKey}': could not parse '{RawValue}' as double", Key, Value);
+                                    return;
+                                }
+                                d = parsedFromOther;
+                                break;
                         }
-                        else
-                        {
-                            Logger.Warning("Plugin config '{ConfigKey}': could not parse '{RawValue}' as double", Key, Value);
-                            return;
-                        }
+                        if (MinValue.HasValue && MaxValue.HasValue)
+                            d = Math.Clamp(d, MinValue.Value, MaxValue.Value);
+                        else if (MinValue.HasValue)
+                            d = Math.Max(MinValue.Value, d);
+                        else if (MaxValue.HasValue)
+                            d = Math.Min(MaxValue.Value, d);
+                        typedValue = d;
                         break;
                     default:
                         typedValue = Value;

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -201,6 +201,8 @@ namespace InfoPanel.ViewModels
 
     public partial class PluginConfigPropertyViewModel : ObservableObject
     {
+        private static readonly ILogger Logger = Log.ForContext<PluginConfigPropertyViewModel>();
+
         private readonly IPluginConfigurable _configurable;
         private readonly PluginConfigProperty _property;
 
@@ -278,13 +280,17 @@ namespace InfoPanel.ViewModels
                     case PluginConfigType.Integer:
                         if (int.TryParse(Value?.ToString(), out var i))
                         {
-                            if (MinValue.HasValue) i = Math.Max((int)MinValue.Value, i);
-                            if (MaxValue.HasValue) i = Math.Min((int)MaxValue.Value, i);
+                            if (MinValue.HasValue && MaxValue.HasValue)
+                                i = Math.Clamp(i, (int)Math.Ceiling(MinValue.Value), (int)Math.Floor(MaxValue.Value));
+                            else if (MinValue.HasValue)
+                                i = Math.Max((int)Math.Ceiling(MinValue.Value), i);
+                            else if (MaxValue.HasValue)
+                                i = Math.Min((int)Math.Floor(MaxValue.Value), i);
                             typedValue = i;
                         }
                         else
                         {
-                            Log.Warning("Plugin config '{Key}': could not parse '{Value}' as integer", Key, Value);
+                            Logger.Warning("Plugin config '{ConfigKey}': could not parse '{RawValue}' as integer", Key, Value);
                             return;
                         }
                         break;
@@ -293,13 +299,17 @@ namespace InfoPanel.ViewModels
                             System.Globalization.NumberStyles.Float,
                             System.Globalization.CultureInfo.InvariantCulture, out var d))
                         {
-                            if (MinValue.HasValue) d = Math.Max(MinValue.Value, d);
-                            if (MaxValue.HasValue) d = Math.Min(MaxValue.Value, d);
+                            if (MinValue.HasValue && MaxValue.HasValue)
+                                d = Math.Clamp(d, MinValue.Value, MaxValue.Value);
+                            else if (MinValue.HasValue)
+                                d = Math.Max(MinValue.Value, d);
+                            else if (MaxValue.HasValue)
+                                d = Math.Min(MaxValue.Value, d);
                             typedValue = d;
                         }
                         else
                         {
-                            Log.Warning("Plugin config '{Key}': could not parse '{Value}' as double", Key, Value);
+                            Logger.Warning("Plugin config '{ConfigKey}': could not parse '{RawValue}' as double", Key, Value);
                             return;
                         }
                         break;
@@ -325,7 +335,7 @@ namespace InfoPanel.ViewModels
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Plugin config '{Key}': ApplyConfig failed", Key);
+                Logger.Error(ex, "Plugin config '{ConfigKey}': ApplyConfig failed", Key);
             }
         }
 

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -171,6 +171,10 @@ namespace InfoPanel.ViewModels
                 {
                     ConfigProperties.Add(new PluginConfigPropertyViewModel(configurable, prop));
                 }
+                foreach (var vm in ConfigProperties)
+                {
+                    vm.SetSiblings(ConfigProperties);
+                }
                 HasConfigProperties = ConfigProperties.Count > 0;
             }
             else
@@ -276,9 +280,25 @@ namespace InfoPanel.ViewModels
                     _ => Value
                 };
                 _configurable.ApplyConfig(Key, typedValue);
+
+                // Re-read source properties to pick up cross-property changes (e.g. mutual exclusion)
+                foreach (var sourceProp in _configurable.ConfigProperties)
+                {
+                    if (sourceProp.Key != Key && _siblings != null)
+                    {
+                        var sibling = _siblings.FirstOrDefault(vm => vm.Key == sourceProp.Key);
+                        if (sibling != null && !Equals(sibling.Value, sourceProp.Value))
+                        {
+                            sibling.RefreshValue(sourceProp.Value);
+                        }
+                    }
+                }
             }
             catch { }
         }
+
+        private IEnumerable<PluginConfigPropertyViewModel>? _siblings;
+        internal void SetSiblings(IEnumerable<PluginConfigPropertyViewModel> siblings) => _siblings = siblings;
 
         public void RefreshValue(object? newValue)
         {

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -133,6 +133,9 @@ namespace InfoPanel.ViewModels
         [ObservableProperty]
         private bool _hasConfigProperties;
 
+        [ObservableProperty]
+        private bool _configLoaded = false;
+
         [RelayCommand]
         public async Task Reload()
         {
@@ -164,6 +167,11 @@ namespace InfoPanel.ViewModels
 
         private void RefreshConfigProperties()
         {
+            if (!_wrapper.IsLoaded)
+            {
+                return;
+            }
+
             if (_wrapper.Plugin is IPluginConfigurable configurable)
             {
                 var properties = configurable.ConfigProperties;
@@ -177,6 +185,7 @@ namespace InfoPanel.ViewModels
                     vm.SetSiblings(ConfigProperties);
                 }
                 HasConfigProperties = ConfigProperties.Count > 0;
+                ConfigLoaded = HasConfigProperties;
             }
             else
             {
@@ -190,6 +199,11 @@ namespace InfoPanel.ViewModels
             Name = _wrapper.Name;
             Description = _wrapper.Description;
             ConfigFilePath = _wrapper.ConfigFilePath;
+
+            if (!_configLoaded)
+            {
+                RefreshConfigProperties();
+            }
         }
     }
 

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using System.Windows.Threading;
+using Serilog;
 
 namespace InfoPanel.ViewModels
 {
@@ -271,14 +272,42 @@ namespace InfoPanel.ViewModels
         {
             try
             {
-                object? typedValue = Type switch
+                object? typedValue;
+                switch (Type)
                 {
-                    PluginConfigType.Integer when int.TryParse(Value?.ToString(), out var i) => i,
-                    PluginConfigType.Double when double.TryParse(Value?.ToString(),
-                        System.Globalization.NumberStyles.Float,
-                        System.Globalization.CultureInfo.InvariantCulture, out var d) => d,
-                    _ => Value
-                };
+                    case PluginConfigType.Integer:
+                        if (int.TryParse(Value?.ToString(), out var i))
+                        {
+                            if (MinValue.HasValue) i = Math.Max((int)MinValue.Value, i);
+                            if (MaxValue.HasValue) i = Math.Min((int)MaxValue.Value, i);
+                            typedValue = i;
+                        }
+                        else
+                        {
+                            Log.Warning("Plugin config '{Key}': could not parse '{Value}' as integer", Key, Value);
+                            return;
+                        }
+                        break;
+                    case PluginConfigType.Double:
+                        if (double.TryParse(Value?.ToString(),
+                            System.Globalization.NumberStyles.Float,
+                            System.Globalization.CultureInfo.InvariantCulture, out var d))
+                        {
+                            if (MinValue.HasValue) d = Math.Max(MinValue.Value, d);
+                            if (MaxValue.HasValue) d = Math.Min(MaxValue.Value, d);
+                            typedValue = d;
+                        }
+                        else
+                        {
+                            Log.Warning("Plugin config '{Key}': could not parse '{Value}' as double", Key, Value);
+                            return;
+                        }
+                        break;
+                    default:
+                        typedValue = Value;
+                        break;
+                }
+
                 _configurable.ApplyConfig(Key, typedValue);
 
                 // Re-read source properties to pick up cross-property changes (e.g. mutual exclusion)
@@ -294,7 +323,10 @@ namespace InfoPanel.ViewModels
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Plugin config '{Key}': ApplyConfig failed", Key);
+            }
         }
 
         private IEnumerable<PluginConfigPropertyViewModel>? _siblings;

--- a/InfoPanel/ViewModels/PluginsViewModel.cs
+++ b/InfoPanel/ViewModels/PluginsViewModel.cs
@@ -236,9 +236,27 @@ namespace InfoPanel.ViewModels
             set
             {
                 if (Type == PluginConfigType.Integer)
-                    Value = (int)Math.Round(value);
+                {
+                    var i = (int)Math.Round(value);
+                    if (MinValue.HasValue && MaxValue.HasValue)
+                        i = Math.Clamp(i, (int)Math.Ceiling(MinValue.Value), (int)Math.Floor(MaxValue.Value));
+                    else if (MinValue.HasValue)
+                        i = Math.Max((int)Math.Ceiling(MinValue.Value), i);
+                    else if (MaxValue.HasValue)
+                        i = Math.Min((int)Math.Floor(MaxValue.Value), i);
+                    Value = i;
+                }
                 else
-                    Value = value;
+                {
+                    var d = value;
+                    if (MinValue.HasValue && MaxValue.HasValue)
+                        d = Math.Clamp(d, MinValue.Value, MaxValue.Value);
+                    else if (MinValue.HasValue)
+                        d = Math.Max(MinValue.Value, d);
+                    else if (MaxValue.HasValue)
+                        d = Math.Min(MaxValue.Value, d);
+                    Value = d;
+                }
                 OnPropertyChanged();
                 Apply();
             }

--- a/InfoPanel/Views/Components/PluginProperties.xaml
+++ b/InfoPanel/Views/Components/PluginProperties.xaml
@@ -43,12 +43,10 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}" />
-                        <ui:NumberBox
+                        <TextBox
                             Grid.Column="1"
                             FontSize="12"
-                            MaxDecimalPlaces="0"
-                            SmallChange="{Binding Step, TargetNullValue=1}"
-                            Value="{Binding NumericValue}" />
+                            Text="{Binding StringValue, UpdateSourceTrigger=LostFocus}" />
                     </Grid>
                 </DataTemplate>
             </converters:PluginConfigTemplateSelector.IntegerTemplate>
@@ -63,12 +61,10 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}" />
-                        <ui:NumberBox
+                        <TextBox
                             Grid.Column="1"
                             FontSize="12"
-                            MaxDecimalPlaces="2"
-                            SmallChange="{Binding Step, TargetNullValue=0.1}"
-                            Value="{Binding NumericValue}" />
+                            Text="{Binding StringValue, UpdateSourceTrigger=LostFocus}" />
                     </Grid>
                 </DataTemplate>
             </converters:PluginConfigTemplateSelector.DoubleTemplate>

--- a/InfoPanel/Views/Components/PluginProperties.xaml
+++ b/InfoPanel/Views/Components/PluginProperties.xaml
@@ -263,6 +263,7 @@
 
                             <ItemsControl
                                 Margin="0,0,0,0"
+                                IsEnabled="{Binding ConfigLoaded}"
                                 ItemsSource="{Binding ConfigProperties}"
                                 ItemTemplateSelector="{StaticResource PluginConfigTemplateSelector}" />
 

--- a/InfoPanel/Views/Components/PluginProperties.xaml
+++ b/InfoPanel/Views/Components/PluginProperties.xaml
@@ -25,7 +25,7 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}"
-                            ToolTip="{Binding Description}" />
+                            ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
                         <TextBox
                             Grid.Column="1"
                             FontSize="12"
@@ -44,7 +44,7 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}"
-                            ToolTip="{Binding Description}" />
+                            ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
                         <TextBox
                             Grid.Column="1"
                             FontSize="12"
@@ -63,7 +63,7 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}"
-                            ToolTip="{Binding Description}" />
+                            ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
                         <TextBox
                             Grid.Column="1"
                             FontSize="12"
@@ -82,7 +82,7 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}"
-                            ToolTip="{Binding Description}" />
+                            ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
                         <ui:ToggleSwitch
                             Grid.Column="1"
                             IsChecked="{Binding BoolValue}" />
@@ -100,7 +100,7 @@
                             VerticalAlignment="Center"
                             FontSize="12"
                             Text="{Binding DisplayName}"
-                            ToolTip="{Binding Description}" />
+                            ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
                         <ComboBox
                             Grid.Column="1"
                             FontSize="12"

--- a/InfoPanel/Views/Components/PluginProperties.xaml
+++ b/InfoPanel/Views/Components/PluginProperties.xaml
@@ -6,11 +6,110 @@
     xmlns:local="clr-namespace:InfoPanel.Views.Components"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:converters="clr-namespace:InfoPanel.Views.Converters"
     xmlns:viewmodels="clr-namespace:InfoPanel.ViewModels"
     d:DataContext="{d:DesignInstance Type=viewmodels:PluginViewModel}"
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
+    <UserControl.Resources>
+        <converters:PluginConfigTemplateSelector x:Key="PluginConfigTemplateSelector">
+            <converters:PluginConfigTemplateSelector.StringTemplate>
+                <DataTemplate DataType="{x:Type viewmodels:PluginConfigPropertyViewModel}">
+                    <Grid Margin="0,6,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Text="{Binding DisplayName}" />
+                        <TextBox
+                            Grid.Column="1"
+                            FontSize="12"
+                            Text="{Binding StringValue, UpdateSourceTrigger=LostFocus}" />
+                    </Grid>
+                </DataTemplate>
+            </converters:PluginConfigTemplateSelector.StringTemplate>
+            <converters:PluginConfigTemplateSelector.IntegerTemplate>
+                <DataTemplate DataType="{x:Type viewmodels:PluginConfigPropertyViewModel}">
+                    <Grid Margin="0,6,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Text="{Binding DisplayName}" />
+                        <ui:NumberBox
+                            Grid.Column="1"
+                            FontSize="12"
+                            MaxDecimalPlaces="0"
+                            SmallChange="{Binding Step, TargetNullValue=1}"
+                            Value="{Binding NumericValue}" />
+                    </Grid>
+                </DataTemplate>
+            </converters:PluginConfigTemplateSelector.IntegerTemplate>
+            <converters:PluginConfigTemplateSelector.DoubleTemplate>
+                <DataTemplate DataType="{x:Type viewmodels:PluginConfigPropertyViewModel}">
+                    <Grid Margin="0,6,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Text="{Binding DisplayName}" />
+                        <ui:NumberBox
+                            Grid.Column="1"
+                            FontSize="12"
+                            MaxDecimalPlaces="2"
+                            SmallChange="{Binding Step, TargetNullValue=0.1}"
+                            Value="{Binding NumericValue}" />
+                    </Grid>
+                </DataTemplate>
+            </converters:PluginConfigTemplateSelector.DoubleTemplate>
+            <converters:PluginConfigTemplateSelector.BooleanTemplate>
+                <DataTemplate DataType="{x:Type viewmodels:PluginConfigPropertyViewModel}">
+                    <Grid Margin="0,6,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Text="{Binding DisplayName}" />
+                        <ui:ToggleSwitch
+                            Grid.Column="1"
+                            IsChecked="{Binding BoolValue}" />
+                    </Grid>
+                </DataTemplate>
+            </converters:PluginConfigTemplateSelector.BooleanTemplate>
+            <converters:PluginConfigTemplateSelector.ChoiceTemplate>
+                <DataTemplate DataType="{x:Type viewmodels:PluginConfigPropertyViewModel}">
+                    <Grid Margin="0,6,0,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="150" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Text="{Binding DisplayName}" />
+                        <ComboBox
+                            Grid.Column="1"
+                            FontSize="12"
+                            ItemsSource="{Binding Options}"
+                            SelectedIndex="{Binding SelectedIndex}" />
+                    </Grid>
+                </DataTemplate>
+            </converters:PluginConfigTemplateSelector.ChoiceTemplate>
+        </converters:PluginConfigTemplateSelector>
+    </UserControl.Resources>
     <Grid>
         <ui:CardExpander Margin="0,10,0,0" IsEnabled="{Binding ControlEnabled}">
             <ui:CardExpander.Header>
@@ -90,35 +189,25 @@
                 ItemsSource="{Binding Plugins}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <ui:CardControl Margin="0,10,0,0">
-                            <ui:CardControl.Header>
-                                <Grid>
+                        <ui:CardExpander Margin="0,10,0,0" IsExpanded="{Binding HasConfigProperties, Mode=OneTime}">
+                            <ui:CardExpander.Header>
+                                <Grid Margin="0,0,20,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="auto" />
                                     </Grid.ColumnDefinitions>
                                     <StackPanel>
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                            </Grid.ColumnDefinitions>
-                                            <TextBlock
-                                                FontSize="13"
-                                                FontWeight="Medium"
-                                                Text="{Binding Name}" />
-                                        </Grid>
+                                        <TextBlock
+                                            FontSize="13"
+                                            FontWeight="Medium"
+                                            Text="{Binding Name}" />
 
-                                        <Grid Margin="0,5,0,0">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="auto" />
-                                            </Grid.ColumnDefinitions>
-                                            <TextBlock
-                                                VerticalAlignment="Center"
-                                                FontSize="12"
-                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}"
-                                                Text="{Binding Description}" />
-                                        </Grid>
+                                        <TextBlock
+                                            Margin="0,5,0,0"
+                                            VerticalAlignment="Center"
+                                            FontSize="12"
+                                            Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                            Text="{Binding Description}" />
 
                                         <ItemsControl
                                             Margin="0,10,0,0"
@@ -140,7 +229,7 @@
                                         </ItemsControl>
                                     </StackPanel>
 
-                                    <StackPanel Grid.Column="2" VerticalAlignment="Center">
+                                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
                                         <ui:Anchor
                                             Width="150"
                                             VerticalAlignment="Center"
@@ -157,9 +246,14 @@
                                             Visibility="{Binding ConfigFilePath, Converter={StaticResource NullToVisibilityConverter}}" />
                                     </StackPanel>
                                 </Grid>
+                            </ui:CardExpander.Header>
 
-                            </ui:CardControl.Header>
-                        </ui:CardControl>
+                            <ItemsControl
+                                Margin="0,0,0,0"
+                                ItemsSource="{Binding ConfigProperties}"
+                                ItemTemplateSelector="{StaticResource PluginConfigTemplateSelector}" />
+
+                        </ui:CardExpander>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>

--- a/InfoPanel/Views/Components/PluginProperties.xaml
+++ b/InfoPanel/Views/Components/PluginProperties.xaml
@@ -45,10 +45,16 @@
                             FontSize="12"
                             Text="{Binding DisplayName}"
                             ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
-                        <TextBox
+                        <ui:NumberBox
                             Grid.Column="1"
                             FontSize="12"
-                            Text="{Binding StringValue, UpdateSourceTrigger=LostFocus}" />
+                            MaxDecimalPlaces="0"
+                            Minimum="{Binding MinValue}"
+                            Maximum="{Binding MaxValue}"
+                            SmallChange="{Binding Step, TargetNullValue=1}"
+                            Text="{Binding NumericValue}"
+                            TextChanged="NumberBox_TextChanged"
+                            Value="{Binding NumericValue, Mode=OneWay}" />
                     </Grid>
                 </DataTemplate>
             </converters:PluginConfigTemplateSelector.IntegerTemplate>
@@ -64,10 +70,16 @@
                             FontSize="12"
                             Text="{Binding DisplayName}"
                             ToolTip="{Binding Description, TargetNullValue={x:Null}}" />
-                        <TextBox
+                        <ui:NumberBox
                             Grid.Column="1"
                             FontSize="12"
-                            Text="{Binding StringValue, UpdateSourceTrigger=LostFocus}" />
+                            MaxDecimalPlaces="2"
+                            Minimum="{Binding MinValue}"
+                            Maximum="{Binding MaxValue}"
+                            SmallChange="{Binding Step, TargetNullValue=0.1}"
+                            Text="{Binding NumericValue}"
+                            TextChanged="NumberBox_TextChanged"
+                            Value="{Binding NumericValue, Mode=OneWay}" />
                     </Grid>
                 </DataTemplate>
             </converters:PluginConfigTemplateSelector.DoubleTemplate>

--- a/InfoPanel/Views/Components/PluginProperties.xaml
+++ b/InfoPanel/Views/Components/PluginProperties.xaml
@@ -24,7 +24,8 @@
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="12"
-                            Text="{Binding DisplayName}" />
+                            Text="{Binding DisplayName}"
+                            ToolTip="{Binding Description}" />
                         <TextBox
                             Grid.Column="1"
                             FontSize="12"
@@ -42,7 +43,8 @@
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="12"
-                            Text="{Binding DisplayName}" />
+                            Text="{Binding DisplayName}"
+                            ToolTip="{Binding Description}" />
                         <TextBox
                             Grid.Column="1"
                             FontSize="12"
@@ -60,7 +62,8 @@
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="12"
-                            Text="{Binding DisplayName}" />
+                            Text="{Binding DisplayName}"
+                            ToolTip="{Binding Description}" />
                         <TextBox
                             Grid.Column="1"
                             FontSize="12"
@@ -78,7 +81,8 @@
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="12"
-                            Text="{Binding DisplayName}" />
+                            Text="{Binding DisplayName}"
+                            ToolTip="{Binding Description}" />
                         <ui:ToggleSwitch
                             Grid.Column="1"
                             IsChecked="{Binding BoolValue}" />
@@ -95,7 +99,8 @@
                         <TextBlock
                             VerticalAlignment="Center"
                             FontSize="12"
-                            Text="{Binding DisplayName}" />
+                            Text="{Binding DisplayName}"
+                            ToolTip="{Binding Description}" />
                         <ComboBox
                             Grid.Column="1"
                             FontSize="12"

--- a/InfoPanel/Views/Components/PluginProperties.xaml.cs
+++ b/InfoPanel/Views/Components/PluginProperties.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using Wpf.Ui.Controls;
 
 namespace InfoPanel.Views.Components
 {
@@ -34,6 +35,20 @@ namespace InfoPanel.Views.Components
         public PluginProperties()
         {
             InitializeComponent();
+        }
+
+        private void NumberBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (sender is NumberBox numBox
+                && numBox.DataContext is PluginConfigPropertyViewModel vm
+                && double.TryParse(numBox.Text, out double newValue))
+            {
+                if (numBox.Value == newValue)
+                {
+                    // Spinner click — NumberBox already updated Value, push to VM
+                    vm.NumericValue = newValue;
+                }
+            }
         }
     }
 }

--- a/InfoPanel/Views/Components/PluginProperties.xaml.cs
+++ b/InfoPanel/Views/Components/PluginProperties.xaml.cs
@@ -41,13 +41,10 @@ namespace InfoPanel.Views.Components
         {
             if (sender is NumberBox numBox
                 && numBox.DataContext is PluginConfigPropertyViewModel vm
-                && double.TryParse(numBox.Text, out double newValue))
+                && numBox.Value is double newValue)
             {
-                if (numBox.Value == newValue)
-                {
-                    // Spinner click — NumberBox already updated Value, push to VM
-                    vm.NumericValue = newValue;
-                }
+                // NumberBox has a valid numeric value, push to VM
+                vm.NumericValue = newValue;
             }
         }
     }

--- a/InfoPanel/Views/Components/PluginProperties.xaml.cs
+++ b/InfoPanel/Views/Components/PluginProperties.xaml.cs
@@ -41,9 +41,10 @@ namespace InfoPanel.Views.Components
         {
             if (sender is NumberBox numBox
                 && numBox.DataContext is PluginConfigPropertyViewModel vm
-                && numBox.Value is double newValue)
+                && numBox.Value is double newValue
+                && newValue != vm.NumericValue)
             {
-                // NumberBox has a valid numeric value, push to VM
+                // Spinner click — NumberBox already updated Value, push to VM
                 vm.NumericValue = newValue;
             }
         }

--- a/InfoPanel/Views/Converters/PluginConfigTemplateSelector.cs
+++ b/InfoPanel/Views/Converters/PluginConfigTemplateSelector.cs
@@ -1,0 +1,33 @@
+using InfoPanel.Plugins;
+using InfoPanel.ViewModels;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace InfoPanel.Views.Converters
+{
+    public class PluginConfigTemplateSelector : DataTemplateSelector
+    {
+        public DataTemplate? StringTemplate { get; set; }
+        public DataTemplate? IntegerTemplate { get; set; }
+        public DataTemplate? DoubleTemplate { get; set; }
+        public DataTemplate? BooleanTemplate { get; set; }
+        public DataTemplate? ChoiceTemplate { get; set; }
+
+        public override DataTemplate? SelectTemplate(object item, DependencyObject container)
+        {
+            if (item is PluginConfigPropertyViewModel vm)
+            {
+                return vm.Type switch
+                {
+                    PluginConfigType.String => StringTemplate,
+                    PluginConfigType.Integer => IntegerTemplate,
+                    PluginConfigType.Double => DoubleTemplate,
+                    PluginConfigType.Boolean => BooleanTemplate,
+                    PluginConfigType.Choice => ChoiceTemplate,
+                    _ => StringTemplate
+                };
+            }
+            return base.SelectTemplate(item, container);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IPluginConfigurable` interface and `PluginConfigProperty` descriptor to `InfoPanel.Plugins`, allowing plugins to expose live-configurable settings without requiring the user to edit INI files
- Add inline config UI in the Plugins page: expands under each plugin module with type-specific controls (TextBox for string/number, ToggleSwitch for boolean, ComboBox for choice)
- Add `PluginConfigTemplateSelector` to pick the right XAML template per property type
- Plugin modules now use `CardExpander` (auto-expands when config properties exist) instead of `CardControl`

## Details
Plugins implement `IPluginConfigurable` to declare their settings:
```csharp
public IReadOnlyList<PluginConfigProperty> ConfigProperties => [
    new() { Key = "Style", DisplayName = "Style", Type = PluginConfigType.Choice,
            Value = _config.Style.ToString(), Options = styleOptions },
    new() { Key = "Brightness", DisplayName = "Brightness", Type = PluginConfigType.Double,
            Value = (double)_config.Brightness, MinValue = 0.1, MaxValue = 2.0, Step = 0.1 },
];

public void ApplyConfig(string key, object? value) { /* live update */ }
```

Changes are applied on LostFocus (text fields) or immediately (toggles, dropdowns). Values are parsed with InvariantCulture before passing to `ApplyConfig`. The 1-second timer refresh no longer overwrites config property values mid-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)