### PR TITLE
Add localhost HTTP image refresh for real-time plugin streams

### DIFF
--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -118,6 +118,11 @@ namespace InfoPanel.Models
 
         private readonly Stopwatch Stopwatch = new();
 
+        // Localhost HTTP image refresh
+        private Timer? _localhostRefreshTimer;
+        private readonly object _localhostLock = new();
+        private SKBitmap? _localhostBitmap;
+
         public bool Loaded { get; private set; } = false;
 
         public LockedImage(string imagePath, ImageDisplayItem? sourceImageDisplayItem)
@@ -308,6 +313,35 @@ namespace InfoPanel.Models
             }
         }
 
+        public void StartLocalhostRefresh(string url)
+        {
+            _localhostRefreshTimer = new Timer(_ =>
+            {
+                try
+                {
+                    using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+                    using var response = client.Send(new HttpRequestMessage(HttpMethod.Get, url));
+                    if (response.IsSuccessStatusCode)
+                    {
+                        using var ms = new MemoryStream();
+                        response.Content.ReadAsStream().CopyTo(ms);
+                        ms.Position = 0;
+                        var newBitmap = SKBitmap.Decode(ms);
+                        if (newBitmap != null)
+                        {
+                            lock (_localhostLock)
+                            {
+                                var old = _localhostBitmap;
+                                _localhostBitmap = newBitmap;
+                                old?.Dispose();
+                            }
+                        }
+                    }
+                }
+                catch { }
+            }, null, 0, 100);
+        }
+
         public void AddImageDisplayItem(ImageDisplayItem item)
         {
             if (imageDisplayItems.TryAdd(item.Guid, item))
@@ -384,6 +418,20 @@ namespace InfoPanel.Models
 
         private SKBitmap? GetSKBitmapFromSK(int frame)
         {
+            // Localhost refresh: return a copy of the latest decoded bitmap
+            if (_localhostBitmap != null)
+            {
+                lock (_localhostLock)
+                {
+                    if (_localhostBitmap != null)
+                    {
+                        Width = _localhostBitmap.Width;
+                        Height = _localhostBitmap.Height;
+                        return _localhostBitmap.Copy();
+                    }
+                }
+            }
+
             if (_stream != null && _codec != null)
             {
                 var info = _codec.Info;
@@ -653,6 +701,12 @@ namespace InfoPanel.Models
 
                 var shouldDispose = false;
 
+                // Localhost streams refresh constantly, always re-decode
+                if (_localhostBitmap != null)
+                {
+                    bitmapFrame.Invalidate();
+                }
+
                 if (bitmapFrame.Image == null)
                 {
                     using var bitmap = GetSKBitmapFromSK(frame);
@@ -739,6 +793,9 @@ namespace InfoPanel.Models
 
                     _backgroundVideoPlayer?.Stop();
                     _backgroundVideoPlayer?.Dispose();
+
+                    _localhostRefreshTimer?.Dispose();
+                    lock (_localhostLock) { _localhostBitmap?.Dispose(); _localhostBitmap = null; }
 
                     _codec?.Dispose();
                     _stream?.Dispose();

--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -339,7 +339,7 @@ namespace InfoPanel.Models
                     }
                 }
                 catch { }
-            }, null, 0, 100);
+            }, null, 0, 33);
         }
 
         public void AddImageDisplayItem(ImageDisplayItem item)

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -138,9 +138,21 @@ namespace InfoPanel
                 cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(10);
             }
 
+            // Localhost HTTP images (e.g. plugin streams): start a background refresh timer
+            if (IsLocalhostUrl(path))
+            {
+                cachedImage.StartLocalhostRefresh(path);
+            }
+
             ImageCache.Set(path, cachedImage, cacheOptions);
 
             Logger.Debug("Image '{Path}' loaded successfully (Persistent: {Persistent})", path, imageDisplayItem?.PersistentCache ?? false);
+        }
+
+        private static bool IsLocalhostUrl(string path)
+        {
+            return path.StartsWith("http://localhost", StringComparison.OrdinalIgnoreCase)
+                || path.StartsWith("http://127.0.0.1", StringComparison.OrdinalIgnoreCase);
         }
 
         public static void TouchImage(ImageDisplayItem imageDisplayItem)


### PR DESCRIPTION
## Summary
- Adds a background refresh mechanism for localhost HTTP images in `LockedImage`, enabling real-time updates from plugin HTTP servers without relying on FlyleafLib's AVI streaming.
- Localhost URLs (`http://localhost` / `http://127.0.0.1`) are detected in `Cache.cs` and trigger a 33ms timer (~30fps) that fetches the latest JPEG frame and decodes it into an `SKBitmap`.
- The render loop copies the latest bitmap each frame, providing smooth real-time visualization.

## Why
Plugins like AudioSpectrum serve rendered frames via a local HTTP server. Previously, this used an AVI MJPEG stream played through FlyleafLib. This approach is fragile:
- FlyleafLib version changes can break AVI streaming (3.10.2 broke it)
- HttpListener fails in IPC plugin host processes on fixed ports
- AVI streaming adds unnecessary complexity (container format, video decoder) for what is essentially a JPEG refresh

The new approach is simpler and version-independent: fetch JPEG, decode to bitmap, display. No FlyleafLib involvement for localhost images.

## Changes
- `LockedImage.cs`: Added `_localhostBitmap`, `_localhostLock`, `_localhostRefreshTimer` fields and `StartLocalhostRefresh()` method. `GetSKBitmapFromSK()` returns a copy of the latest bitmap when available. Frame cache is invalidated each cycle for localhost streams.
- `Cache.cs`: Added `IsLocalhostUrl()` helper. Calls `StartLocalhostRefresh()` after caching localhost images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)