### PR TITLE
Feature/1.4.x/plugin image support

### DIFF
--- a/InfoPanel.Plugins.Graphics/IPluginImageProvider.cs
+++ b/InfoPanel.Plugins.Graphics/IPluginImageProvider.cs
@@ -1,0 +1,21 @@
+namespace InfoPanel.Plugins.Graphics
+{
+    /// <summary>
+    /// Implement this interface alongside IPlugin to declare image outputs
+    /// and receive writers backed by shared memory.
+    /// </summary>
+    public interface IPluginImageProvider
+    {
+        /// <summary>
+        /// Declares the image outputs this plugin produces.
+        /// Called during initialization to set up shared memory buffers.
+        /// </summary>
+        IReadOnlyList<PluginImageDescriptor> ImageDescriptors { get; }
+
+        /// <summary>
+        /// Called by the host after shared memory buffers are created.
+        /// Plugin stores the writers and draws on them during Update.
+        /// </summary>
+        void OnImageBuffersReady(IReadOnlyDictionary<string, IPluginImageWriter> writers);
+    }
+}

--- a/InfoPanel.Plugins.Graphics/IPluginImageWriter.cs
+++ b/InfoPanel.Plugins.Graphics/IPluginImageWriter.cs
@@ -1,0 +1,25 @@
+using SkiaSharp;
+
+namespace InfoPanel.Plugins.Graphics
+{
+    /// <summary>
+    /// Provided by the host. Plugin draws on Bitmap, calls Invalidate() when done.
+    /// The bitmap is backed by shared memory for zero-copy transfer.
+    /// </summary>
+    public interface IPluginImageWriter : IDisposable
+    {
+        /// <summary>
+        /// The bitmap to draw on. Backed by shared memory (inactive buffer).
+        /// </summary>
+        SKBitmap Bitmap { get; }
+
+        int Width { get; }
+        int Height { get; }
+
+        /// <summary>
+        /// Atomically swaps the double buffer, making the current frame visible to consumers.
+        /// After calling this, Bitmap points to the new inactive buffer for the next frame.
+        /// </summary>
+        void Invalidate();
+    }
+}

--- a/InfoPanel.Plugins.Graphics/IPluginImageWriter.cs
+++ b/InfoPanel.Plugins.Graphics/IPluginImageWriter.cs
@@ -21,5 +21,11 @@ namespace InfoPanel.Plugins.Graphics
         /// After calling this, Bitmap points to the new inactive buffer for the next frame.
         /// </summary>
         void Invalidate();
+
+        /// <summary>
+        /// Resizes the image buffer. Creates a new shared memory region with the new dimensions.
+        /// After this call, Bitmap points to a new buffer with the specified size.
+        /// </summary>
+        void Resize(int width, int height);
     }
 }

--- a/InfoPanel.Plugins.Graphics/InfoPanel.Plugins.Graphics.csproj
+++ b/InfoPanel.Plugins.Graphics/InfoPanel.Plugins.Graphics.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="3.119.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InfoPanel.Plugins\InfoPanel.Plugins.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/InfoPanel.Plugins.Graphics/PluginImageDescriptor.cs
+++ b/InfoPanel.Plugins.Graphics/PluginImageDescriptor.cs
@@ -1,0 +1,21 @@
+namespace InfoPanel.Plugins.Graphics
+{
+    /// <summary>
+    /// Describes an image output produced by a plugin.
+    /// </summary>
+    public class PluginImageDescriptor
+    {
+        public string Id { get; }
+        public string Name { get; }
+        public int Width { get; }
+        public int Height { get; }
+
+        public PluginImageDescriptor(string id, string name, int width, int height)
+        {
+            Id = id;
+            Name = name;
+            Width = width;
+            Height = height;
+        }
+    }
+}

--- a/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
+++ b/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
@@ -33,6 +33,7 @@ namespace InfoPanel.Plugins.Graphics
         private int _writeIndex;
         private int _version;
         private readonly string _mmfBaseName;
+        private readonly object _sync = new();
 
         private const int HeaderSize = 16;
 
@@ -71,17 +72,20 @@ namespace InfoPanel.Plugins.Graphics
 
         public void Invalidate()
         {
-            unsafe
+            lock (_sync)
             {
-                // Atomically swap active index to the buffer we just wrote
-                Interlocked.Exchange(ref *(int*)_basePtr, _writeIndex);
-            }
+                unsafe
+                {
+                    // Atomically swap active index to the buffer we just wrote
+                    Interlocked.Exchange(ref *(int*)_basePtr, _writeIndex);
+                }
 
-            // Switch to the other buffer for the next frame
-            _writeIndex = 1 - _writeIndex;
-            var old = Bitmap;
-            Bitmap = CreateBitmapForBuffer(_writeIndex);
-            old?.Dispose();
+                // Switch to the other buffer for the next frame
+                _writeIndex = 1 - _writeIndex;
+                var old = Bitmap;
+                Bitmap = CreateBitmapForBuffer(_writeIndex);
+                old?.Dispose();
+            }
         }
 
         public void Resize(int newWidth, int newHeight)
@@ -90,41 +94,44 @@ namespace InfoPanel.Plugins.Graphics
             if (newWidth <= 0 || newHeight <= 0)
                 throw new ArgumentException("Width and height must be positive.");
 
-            // Dispose old resources
-            Bitmap?.Dispose();
-            unsafe
+            lock (_sync)
             {
-                if (_basePtr != null)
-                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                // Dispose old resources
+                Bitmap?.Dispose();
+                unsafe
+                {
+                    if (_basePtr != null)
+                        _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
+                _accessor.Dispose();
+                _mmf.Dispose();
+
+                // Create new MMF with versioned name
+                _version++;
+                MmfName = $"{_mmfBaseName}.v{_version}";
+                Width = newWidth;
+                Height = newHeight;
+                _pixelBufferSize = newWidth * newHeight * 4;
+                _writeIndex = 1;
+
+                var mmfSize = ComputeMmfSize(newWidth, newHeight);
+                _mmf = MemoryMappedFile.CreateOrOpen(MmfName, mmfSize);
+                _accessor = _mmf.CreateViewAccessor(0, mmfSize);
+
+                unsafe
+                {
+                    byte* ptr = null;
+                    _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                    _basePtr = ptr;
+
+                    *(int*)(_basePtr + 0) = 0;
+                    *(int*)(_basePtr + 4) = newWidth;
+                    *(int*)(_basePtr + 8) = newHeight;
+                    *(int*)(_basePtr + 12) = 0;
+                }
+
+                Bitmap = CreateBitmapForBuffer(_writeIndex);
             }
-            _accessor.Dispose();
-            _mmf.Dispose();
-
-            // Create new MMF with versioned name
-            _version++;
-            MmfName = $"{_mmfBaseName}.v{_version}";
-            Width = newWidth;
-            Height = newHeight;
-            _pixelBufferSize = newWidth * newHeight * 4;
-            _writeIndex = 1;
-
-            var mmfSize = ComputeMmfSize(newWidth, newHeight);
-            _mmf = MemoryMappedFile.CreateOrOpen(MmfName, mmfSize);
-            _accessor = _mmf.CreateViewAccessor(0, mmfSize);
-
-            unsafe
-            {
-                byte* ptr = null;
-                _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
-                _basePtr = ptr;
-
-                *(int*)(_basePtr + 0) = 0;
-                *(int*)(_basePtr + 4) = newWidth;
-                *(int*)(_basePtr + 8) = newHeight;
-                *(int*)(_basePtr + 12) = 0;
-            }
-
-            Bitmap = CreateBitmapForBuffer(_writeIndex);
 
             Resized?.Invoke(this);
         }
@@ -145,16 +152,19 @@ namespace InfoPanel.Plugins.Graphics
 
         public void Dispose()
         {
-            Bitmap?.Dispose();
-            unsafe
+            lock (_sync)
             {
-                if (_basePtr != null)
+                Bitmap?.Dispose();
+                unsafe
                 {
-                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                    if (_basePtr != null)
+                    {
+                        _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                    }
                 }
+                _accessor.Dispose();
+                _mmf.Dispose();
             }
-            _accessor.Dispose();
-            _mmf.Dispose();
             GC.SuppressFinalize(this);
         }
 

--- a/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
+++ b/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
@@ -65,7 +65,9 @@ namespace InfoPanel.Plugins.Graphics
 
             // Switch to the other buffer for the next frame
             _writeIndex = 1 - _writeIndex;
+            var old = Bitmap;
             Bitmap = CreateBitmapForBuffer(_writeIndex);
+            old?.Dispose();
         }
 
         private SKBitmap CreateBitmapForBuffer(int bufferIndex)
@@ -84,6 +86,7 @@ namespace InfoPanel.Plugins.Graphics
 
         public void Dispose()
         {
+            Bitmap?.Dispose();
             unsafe
             {
                 if (_basePtr != null)

--- a/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
+++ b/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
@@ -1,0 +1,107 @@
+using System.IO.MemoryMappedFiles;
+using System.Runtime.InteropServices;
+using SkiaSharp;
+
+namespace InfoPanel.Plugins.Graphics
+{
+    /// <summary>
+    /// MMF-backed image writer using double buffering.
+    ///
+    /// MMF layout:
+    ///   Offset 0:   4 bytes  — active buffer index (0 or 1)
+    ///   Offset 4:   4 bytes  — width
+    ///   Offset 8:   4 bytes  — height
+    ///   Offset 12:  4 bytes  — reserved
+    ///   Offset 16:  W*H*4    — buffer 0 (RGBA pixels)
+    ///   Offset 16+B: W*H*4   — buffer 1 (RGBA pixels)
+    /// </summary>
+    public class PluginImageWriter : IPluginImageWriter
+    {
+        public SKBitmap Bitmap { get; private set; }
+        public int Width { get; }
+        public int Height { get; }
+
+        private readonly MemoryMappedFile _mmf;
+        private readonly MemoryMappedViewAccessor _accessor;
+        private readonly unsafe byte* _basePtr;
+        private readonly int _pixelBufferSize;
+        private int _writeIndex;
+
+        private const int HeaderSize = 16;
+
+        public PluginImageWriter(MemoryMappedFile mmf, MemoryMappedViewAccessor accessor, int width, int height)
+        {
+            _mmf = mmf;
+            _accessor = accessor;
+            Width = width;
+            Height = height;
+            _pixelBufferSize = width * height * 4;
+            _writeIndex = 1; // Start writing to buffer 1, buffer 0 is initially active (empty)
+
+            unsafe
+            {
+                byte* ptr = null;
+                _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                _basePtr = ptr;
+
+                // Write header
+                *(int*)(_basePtr + 0) = 0;      // Active buffer index = 0
+                *(int*)(_basePtr + 4) = width;
+                *(int*)(_basePtr + 8) = height;
+                *(int*)(_basePtr + 12) = 0;      // Reserved
+            }
+
+            // Point bitmap at the write buffer (buffer 1)
+            Bitmap = CreateBitmapForBuffer(_writeIndex);
+        }
+
+        public void Invalidate()
+        {
+            unsafe
+            {
+                // Atomically swap active index to the buffer we just wrote
+                Interlocked.Exchange(ref *(int*)_basePtr, _writeIndex);
+            }
+
+            // Switch to the other buffer for the next frame
+            _writeIndex = 1 - _writeIndex;
+            Bitmap = CreateBitmapForBuffer(_writeIndex);
+        }
+
+        private SKBitmap CreateBitmapForBuffer(int bufferIndex)
+        {
+            var info = new SKImageInfo(Width, Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+            var bitmap = new SKBitmap();
+
+            unsafe
+            {
+                var bufferPtr = (IntPtr)(_basePtr + HeaderSize + (bufferIndex * _pixelBufferSize));
+                bitmap.InstallPixels(info, bufferPtr, info.RowBytes);
+            }
+
+            return bitmap;
+        }
+
+        public void Dispose()
+        {
+            unsafe
+            {
+                if (_basePtr != null)
+                {
+                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                }
+            }
+            _accessor.Dispose();
+            _mmf.Dispose();
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Computes the total MMF size needed for the given dimensions.
+        /// </summary>
+        public static long ComputeMmfSize(int width, int height)
+        {
+            return HeaderSize + ((long)width * height * 4 * 2); // Header + 2 buffers
+        }
+    }
+}

--- a/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
+++ b/InfoPanel.Plugins.Graphics/PluginImageWriter.cs
@@ -18,19 +18,33 @@ namespace InfoPanel.Plugins.Graphics
     public class PluginImageWriter : IPluginImageWriter
     {
         public SKBitmap Bitmap { get; private set; }
-        public int Width { get; }
-        public int Height { get; }
+        public int Width { get; private set; }
+        public int Height { get; private set; }
 
-        private readonly MemoryMappedFile _mmf;
-        private readonly MemoryMappedViewAccessor _accessor;
-        private readonly unsafe byte* _basePtr;
-        private readonly int _pixelBufferSize;
+        /// <summary>
+        /// Current MMF name. Changes on resize (versioned).
+        /// </summary>
+        public string MmfName { get; private set; }
+
+        private MemoryMappedFile _mmf;
+        private MemoryMappedViewAccessor _accessor;
+        private unsafe byte* _basePtr;
+        private int _pixelBufferSize;
         private int _writeIndex;
+        private int _version;
+        private readonly string _mmfBaseName;
 
         private const int HeaderSize = 16;
 
-        public PluginImageWriter(MemoryMappedFile mmf, MemoryMappedViewAccessor accessor, int width, int height)
+        /// <summary>
+        /// Raised after a successful resize. Host subscribes to notify the main app.
+        /// </summary>
+        public event Action<PluginImageWriter>? Resized;
+
+        public PluginImageWriter(string mmfName, MemoryMappedFile mmf, MemoryMappedViewAccessor accessor, int width, int height)
         {
+            _mmfBaseName = mmfName;
+            MmfName = mmfName;
             _mmf = mmf;
             _accessor = accessor;
             Width = width;
@@ -68,6 +82,51 @@ namespace InfoPanel.Plugins.Graphics
             var old = Bitmap;
             Bitmap = CreateBitmapForBuffer(_writeIndex);
             old?.Dispose();
+        }
+
+        public void Resize(int newWidth, int newHeight)
+        {
+            if (newWidth == Width && newHeight == Height) return;
+            if (newWidth <= 0 || newHeight <= 0)
+                throw new ArgumentException("Width and height must be positive.");
+
+            // Dispose old resources
+            Bitmap?.Dispose();
+            unsafe
+            {
+                if (_basePtr != null)
+                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            }
+            _accessor.Dispose();
+            _mmf.Dispose();
+
+            // Create new MMF with versioned name
+            _version++;
+            MmfName = $"{_mmfBaseName}.v{_version}";
+            Width = newWidth;
+            Height = newHeight;
+            _pixelBufferSize = newWidth * newHeight * 4;
+            _writeIndex = 1;
+
+            var mmfSize = ComputeMmfSize(newWidth, newHeight);
+            _mmf = MemoryMappedFile.CreateOrOpen(MmfName, mmfSize);
+            _accessor = _mmf.CreateViewAccessor(0, mmfSize);
+
+            unsafe
+            {
+                byte* ptr = null;
+                _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                _basePtr = ptr;
+
+                *(int*)(_basePtr + 0) = 0;
+                *(int*)(_basePtr + 4) = newWidth;
+                *(int*)(_basePtr + 8) = newHeight;
+                *(int*)(_basePtr + 12) = 0;
+            }
+
+            Bitmap = CreateBitmapForBuffer(_writeIndex);
+
+            Resized?.Invoke(this);
         }
 
         private SKBitmap CreateBitmapForBuffer(int bufferIndex)

--- a/InfoPanel.Plugins.Host/HostService.cs
+++ b/InfoPanel.Plugins.Host/HostService.cs
@@ -18,7 +18,7 @@ namespace InfoPanel.Plugins.Host
         private readonly List<PluginWrapper> _wrappers = [];
         private readonly SensorSnapshotManager _snapshotManager = new();
         private readonly List<PluginImageWriter> _imageWriters = [];
-    private readonly Dictionary<PluginImageWriter, (string PluginId, string ImageId)> _writerMappings = [];
+        private readonly Dictionary<PluginImageWriter, (string PluginId, string ImageId)> _writerMappings = [];
         private CancellationTokenSource? _updateCts;
         private Task? _updateTask;
         private Task? _perfUpdateTask;

--- a/InfoPanel.Plugins.Host/HostService.cs
+++ b/InfoPanel.Plugins.Host/HostService.cs
@@ -144,7 +144,7 @@ namespace InfoPanel.Plugins.Host
                     {
                         var imagesContainer = new ContainerDto
                         {
-                            Id = "images",
+                            Id = $"__images_{wrapper.Id}",
                             Name = "Images",
                             IsEphemeralPath = false,
                             Entries = metadata.ImageDescriptors.Select(img => new EntryDto

--- a/InfoPanel.Plugins.Host/HostService.cs
+++ b/InfoPanel.Plugins.Host/HostService.cs
@@ -18,6 +18,7 @@ namespace InfoPanel.Plugins.Host
         private readonly List<PluginWrapper> _wrappers = [];
         private readonly SensorSnapshotManager _snapshotManager = new();
         private readonly List<PluginImageWriter> _imageWriters = [];
+    private readonly Dictionary<PluginImageWriter, (string PluginId, string ImageId)> _writerMappings = [];
         private CancellationTokenSource? _updateCts;
         private Task? _updateTask;
         private Task? _perfUpdateTask;
@@ -102,8 +103,10 @@ namespace InfoPanel.Plugins.Host
 
                             var mmf = MemoryMappedFile.CreateOrOpen(mmfName, mmfSize);
                             var accessor = mmf.CreateViewAccessor(0, mmfSize);
-                            var writer = new PluginImageWriter(mmf, accessor, imgDescriptor.Width, imgDescriptor.Height);
+                            var writer = new PluginImageWriter(mmfName, mmf, accessor, imgDescriptor.Width, imgDescriptor.Height);
                             _imageWriters.Add(writer);
+                            _writerMappings[writer] = (wrapper.Id, imgDescriptor.Id);
+                            writer.Resized += OnWriterResized;
 
                             writers[imgDescriptor.Id] = writer;
 
@@ -365,9 +368,11 @@ namespace InfoPanel.Plugins.Host
             // Dispose image writers (releases MMF handles)
             foreach (var writer in _imageWriters)
             {
+                writer.Resized -= OnWriterResized;
                 try { writer.Dispose(); } catch { }
             }
             _imageWriters.Clear();
+            _writerMappings.Clear();
 
             // Signal the host process to exit gracefully by disposing the JsonRpc connection.
             // This causes jsonRpc.Completion in Program.cs to complete naturally.
@@ -585,6 +590,38 @@ namespace InfoPanel.Plugins.Host
             catch (Exception ex)
             {
                 Logger.Error(ex, "Failed to notify plugin error");
+            }
+        }
+
+        private void OnWriterResized(PluginImageWriter writer)
+        {
+            if (!_writerMappings.TryGetValue(writer, out var mapping)) return;
+
+            var descriptor = new ImageDescriptorDto
+            {
+                Id = mapping.ImageId,
+                Name = mapping.ImageId,
+                Width = writer.Width,
+                Height = writer.Height,
+                MmfName = writer.MmfName,
+                BufferSize = PluginImageWriter.ComputeMmfSize(writer.Width, writer.Height)
+            };
+
+            Logger.Information("Image resized: {PluginId}/{ImageId} -> {W}x{H} (MMF: {MmfName})",
+                mapping.PluginId, mapping.ImageId, writer.Width, writer.Height, writer.MmfName);
+
+            NotifyImageResize(mapping.PluginId, descriptor);
+        }
+
+        private void NotifyImageResize(string pluginId, ImageDescriptorDto descriptor)
+        {
+            try
+            {
+                _jsonRpc?.NotifyAsync(nameof(IPluginClientCallback.OnImageResize), pluginId, descriptor);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to notify image resize");
             }
         }
 

--- a/InfoPanel.Plugins.Host/HostService.cs
+++ b/InfoPanel.Plugins.Host/HostService.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.IO.MemoryMappedFiles;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
+using InfoPanel.Plugins.Graphics;
 using InfoPanel.Plugins.Ipc;
 using InfoPanel.Plugins.Loader;
 using Serilog;
@@ -15,6 +17,7 @@ namespace InfoPanel.Plugins.Host
         private JsonRpc? _jsonRpc;
         private readonly List<PluginWrapper> _wrappers = [];
         private readonly SensorSnapshotManager _snapshotManager = new();
+        private readonly List<PluginImageWriter> _imageWriters = [];
         private CancellationTokenSource? _updateCts;
         private Task? _updateTask;
         private Task? _perfUpdateTask;
@@ -87,6 +90,40 @@ namespace InfoPanel.Plugins.Host
                             ? configurable.ConfigProperties.Select(ConvertConfigPropertyToDto).ToList()
                             : []
                     };
+                    // Detect image provider and set up shared memory buffers
+                    if (plugin is IPluginImageProvider imageProvider)
+                    {
+                        var writers = new Dictionary<string, IPluginImageWriter>();
+
+                        foreach (var imgDescriptor in imageProvider.ImageDescriptors)
+                        {
+                            var mmfName = $"InfoPanel.Image.{Environment.ProcessId}.{wrapper.Id}.{imgDescriptor.Id}";
+                            var mmfSize = PluginImageWriter.ComputeMmfSize(imgDescriptor.Width, imgDescriptor.Height);
+
+                            var mmf = MemoryMappedFile.CreateOrOpen(mmfName, mmfSize);
+                            var accessor = mmf.CreateViewAccessor(0, mmfSize);
+                            var writer = new PluginImageWriter(mmf, accessor, imgDescriptor.Width, imgDescriptor.Height);
+                            _imageWriters.Add(writer);
+
+                            writers[imgDescriptor.Id] = writer;
+
+                            metadata.ImageDescriptors.Add(new ImageDescriptorDto
+                            {
+                                Id = imgDescriptor.Id,
+                                Name = imgDescriptor.Name,
+                                Width = imgDescriptor.Width,
+                                Height = imgDescriptor.Height,
+                                MmfName = mmfName,
+                                BufferSize = mmfSize
+                            });
+
+                            Logger.Information("Created MMF {MmfName} for image {ImageId} ({W}x{H})",
+                                mmfName, imgDescriptor.Id, imgDescriptor.Width, imgDescriptor.Height);
+                        }
+
+                        imageProvider.OnImageBuffersReady(writers);
+                    }
+
                     metadataList.Add(metadata);
 
                     // Convert containers to DTOs
@@ -102,6 +139,25 @@ namespace InfoPanel.Plugins.Host
                         };
                         containerDtos.Add(containerDto);
                     }
+                    // Add image descriptors as text entries so they appear as selectable sensors
+                    if (metadata.ImageDescriptors.Count > 0)
+                    {
+                        var imagesContainer = new ContainerDto
+                        {
+                            Id = "images",
+                            Name = "Images",
+                            IsEphemeralPath = false,
+                            Entries = metadata.ImageDescriptors.Select(img => new EntryDto
+                            {
+                                Id = img.Id,
+                                Name = img.Name,
+                                Type = "text",
+                                TextValue = $"plugin-image://{wrapper.Id}/{img.Id}"
+                            }).ToList()
+                        };
+                        containerDtos.Add(imagesContainer);
+                    }
+
                     containersByPluginId[wrapper.Id] = containerDtos;
                 }
                 catch (Exception ex)
@@ -305,6 +361,13 @@ namespace InfoPanel.Plugins.Host
                     Logger.Error(ex, "Error stopping plugin {PluginName}", wrapper.Name);
                 }
             }
+
+            // Dispose image writers (releases MMF handles)
+            foreach (var writer in _imageWriters)
+            {
+                try { writer.Dispose(); } catch { }
+            }
+            _imageWriters.Clear();
 
             // Signal the host process to exit gracefully by disposing the JsonRpc connection.
             // This causes jsonRpc.Completion in Program.cs to complete naturally.

--- a/InfoPanel.Plugins.Host/InfoPanel.Plugins.Host.csproj
+++ b/InfoPanel.Plugins.Host/InfoPanel.Plugins.Host.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\InfoPanel.Plugins\InfoPanel.Plugins.csproj" />
+    <ProjectReference Include="..\InfoPanel.Plugins.Graphics\InfoPanel.Plugins.Graphics.csproj" />
     <ProjectReference Include="..\InfoPanel.Plugins.Loader\InfoPanel.Plugins.Loader.csproj" />
     <ProjectReference Include="..\InfoPanel.Plugins.Ipc\InfoPanel.Plugins.Ipc.csproj" />
   </ItemGroup>

--- a/InfoPanel.Plugins.Ipc/Dtos.cs
+++ b/InfoPanel.Plugins.Ipc/Dtos.cs
@@ -12,6 +12,17 @@ namespace InfoPanel.Plugins.Ipc
         public List<PluginActionDto> Actions { get; set; } = [];
         public bool IsConfigurable { get; set; }
         public List<PluginConfigPropertyDto> ConfigProperties { get; set; } = [];
+        public List<ImageDescriptorDto> ImageDescriptors { get; set; } = [];
+    }
+
+    public class ImageDescriptorDto
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public string MmfName { get; set; } = "";
+        public long BufferSize { get; set; }
     }
 
     public class PluginActionDto

--- a/InfoPanel.Plugins.Ipc/IPluginClientCallback.cs
+++ b/InfoPanel.Plugins.Ipc/IPluginClientCallback.cs
@@ -6,5 +6,6 @@ namespace InfoPanel.Plugins.Ipc
         void OnSensorUpdate(List<SensorUpdateBatchDto> updates);
         void OnPluginError(string pluginId, string errorMessage);
         void OnPerformanceUpdate(List<PluginPerformanceDto> performances);
+        void OnImageResize(string pluginId, ImageDescriptorDto descriptor);
     }
 }

--- a/InfoPanel.Plugins.Loader/PluginLoadContext.cs
+++ b/InfoPanel.Plugins.Loader/PluginLoadContext.cs
@@ -7,8 +7,23 @@ namespace InfoPanel.Plugins.Loader
     {
         private readonly AssemblyDependencyResolver _resolver = new(pluginPath);
 
+        // Assemblies that must be shared with the host process to enable cross-context
+        // interop (e.g. IPluginImageWriter.Bitmap returns SKBitmap — the type must be
+        // the same instance in both the host and the plugin).
+        private static readonly HashSet<string> SharedAssemblies = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "InfoPanel.Plugins.Graphics",
+            "SkiaSharp",
+        };
+
         protected override Assembly? Load(AssemblyName assemblyName)
         {
+            if (assemblyName.Name != null && SharedAssemblies.Contains(assemblyName.Name))
+            {
+                // Fall back to the default (host) context so types are shared
+                return null;
+            }
+
             var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
             if (assemblyPath != null)
             {

--- a/InfoPanel.sln
+++ b/InfoPanel.sln
@@ -17,6 +17,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfoPanel.Plugins.Ipc", "In
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfoPanel.Plugins.Host", "InfoPanel.Plugins.Host\InfoPanel.Plugins.Host.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InfoPanel.Plugins.Graphics", "InfoPanel.Plugins.Graphics\InfoPanel.Plugins.Graphics.csproj", "{C3D4E5F6-A7B8-9012-CDEF-123456789012}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -51,6 +53,10 @@ Global
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|x64.Build.0 = Debug|x64
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x64.ActiveCfg = Release|x64
 		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|x64.Build.0 = Release|x64
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|x64.ActiveCfg = Debug|x64
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|x64.Build.0 = Debug|x64
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|x64.ActiveCfg = Release|x64
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/InfoPanel/Models/HttpImageDisplayItem.cs
+++ b/InfoPanel/Models/HttpImageDisplayItem.cs
@@ -167,28 +167,33 @@ namespace InfoPanel.Models
 
         public override SKSize EvaluateSize()
         {
-            var result = base.EvaluateSize();
+            var result = new SKSize(Width, Height);
 
             if (result.Width == 0 || result.Height == 0)
             {
-                var sensorReading = GetValue();
-
-                if (sensorReading.HasValue && sensorReading.Value.ValueText != null && sensorReading.Value.ValueText.IsUrl())
+                var cachedImage = InfoPanel.Cache.GetLocalImage(this, false);
+                if (cachedImage != null)
                 {
-                    var cachedImage = InfoPanel.Cache.GetLocalImage(this);
-                    if (cachedImage != null)
+                    if (result.Width == 0)
                     {
-                        if (result.Width == 0)
-                        {
-                            result.Width = cachedImage.Width * Scale / 100.0f;
-                        }
+                        result.Width = cachedImage.Width;
+                    }
 
-                        if (result.Height == 0)
-                        {
-                            result.Height = cachedImage.Height * Scale / 100.0f;
-                        }
+                    if (result.Height == 0)
+                    {
+                        result.Height = cachedImage.Height;
                     }
                 }
+            }
+
+            if (result.Width != 0)
+            {
+                result.Width *= Scale / 100.0f;
+            }
+
+            if (result.Height != 0)
+            {
+                result.Height *= Scale / 100.0f;
             }
 
             return result;

--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -1,6 +1,7 @@
 ﻿using FlyleafLib;
 using FlyleafLib.MediaPlayer;
 using InfoPanel.Extensions;
+using InfoPanel.Monitors.PluginProxies;
 using InfoPanel.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using SkiaSharp;
@@ -25,7 +26,7 @@ namespace InfoPanel.Models
         
         public enum ImageType
         {
-            SK, SVG, FFMPEG
+            SK, SVG, FFMPEG, PLUGIN
         }
 
         public readonly string ImagePath;
@@ -113,12 +114,28 @@ namespace InfoPanel.Models
         private readonly long[]? _cumulativeFrameTimes;
         private int _lastRenderedFrame = -1;
 
+        private readonly ProxyPluginImage? _pluginImage;
+
         private readonly object Lock = new();
         private bool IsDisposed = false;
 
         private readonly Stopwatch Stopwatch = new();
 
         public bool Loaded { get; private set; } = false;
+
+        /// <summary>
+        /// Creates a LockedImage backed by a plugin image proxy (shared memory).
+        /// </summary>
+        internal LockedImage(string imagePath, ProxyPluginImage pluginImage)
+        {
+            ImagePath = imagePath;
+            _pluginImage = pluginImage;
+            Type = ImageType.PLUGIN;
+            Width = pluginImage.Width;
+            Height = pluginImage.Height;
+            Frames = 1;
+            Loaded = true;
+        }
 
         public LockedImage(string imagePath, ImageDisplayItem? sourceImageDisplayItem)
         {
@@ -629,6 +646,25 @@ namespace InfoPanel.Models
 
             lock (Lock)
             {
+                if (Type == ImageType.PLUGIN)
+                {
+                    if (_pluginImage != null)
+                    {
+                        using var bitmap = _pluginImage.GetCurrentFrame();
+                        if (bitmap != null)
+                        {
+                            using var resized = bitmap.Resize(new SKImageInfo(targetWidth, targetHeight), new SKSamplingOptions(SKCubicResampler.Mitchell));
+                            if (resized != null)
+                            {
+                                using var image = SKImage.FromBitmap(resized);
+                                access(image);
+                            }
+                        }
+                    }
+
+                    return;
+                }
+
                 if (Type == ImageType.FFMPEG)
                 {
                     if (_backgroundVideoPlayer != null)

--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -650,13 +650,16 @@ namespace InfoPanel.Models
                 {
                     if (_pluginImage != null)
                     {
-                        using var bitmap = _pluginImage.GetCurrentFrame();
-                        if (bitmap != null)
+                        using var snapshot = _pluginImage.GetCurrentFrame();
+                        if (snapshot != null)
                         {
-                            using var resized = bitmap.Resize(new SKImageInfo(targetWidth, targetHeight), new SKSamplingOptions(SKCubicResampler.Mitchell));
-                            if (resized != null)
+                            var resizeInfo = new SKImageInfo(targetWidth, targetHeight);
+                            using var surface = SKSurface.Create(resizeInfo);
+                            if (surface != null)
                             {
-                                using var image = SKImage.FromBitmap(resized);
+                                surface.Canvas.DrawImage(snapshot, new SKRect(0, 0, targetWidth, targetHeight),
+                                    new SKSamplingOptions(SKCubicResampler.Mitchell));
+                                using var image = surface.Snapshot();
                                 access(image);
                             }
                         }

--- a/InfoPanel/Monitors/PluginHostConnection.cs
+++ b/InfoPanel/Monitors/PluginHostConnection.cs
@@ -40,6 +40,7 @@ namespace InfoPanel.Monitors
         // Proxy data indexed by plugin ID -> container ID -> entry ID
         private readonly ConcurrentDictionary<string, Dictionary<string, ProxyPluginContainer>> _proxyContainers = new();
         private readonly ConcurrentDictionary<string, Dictionary<string, IPluginData>> _proxyEntries = new();
+        private readonly ConcurrentDictionary<string, List<ProxyPluginImage>> _proxyImages = new();
         private readonly ConcurrentDictionary<string, long> _performanceData = new();
         private volatile PerformanceCounter? _privateWorkingSetCounter;
         private volatile ProcessMetrics? _cachedMetrics;
@@ -223,6 +224,35 @@ namespace InfoPanel.Monitors
             return [];
         }
 
+        public List<ProxyPluginImage> GetProxyImages(string pluginId)
+        {
+            if (_proxyImages.TryGetValue(pluginId, out var images))
+                return images;
+            return [];
+        }
+
+        public List<ProxyPluginImage> GetAllProxyImages()
+        {
+            var result = new List<ProxyPluginImage>();
+            foreach (var images in _proxyImages.Values)
+                result.AddRange(images);
+            return result;
+        }
+
+        /// <summary>
+        /// Invalidates all plugin image cache entries for this connection.
+        /// Must be called before disposing so new entries can be created on reconnect.
+        /// </summary>
+        public void InvalidateImageCaches()
+        {
+            foreach (var kvp in _proxyImages)
+            {
+                var pluginId = kvp.Key;
+                var imageIds = kvp.Value.Select(img => img.ImageId);
+                Cache.InvalidatePluginImages(pluginId, imageIds);
+            }
+        }
+
         public bool HasMetricsCounter => _privateWorkingSetCounter != null;
 
         public ProcessMetrics? ProcessMetrics => _cachedMetrics;
@@ -314,6 +344,29 @@ namespace InfoPanel.Monitors
 
                 _proxyContainers[pluginId] = containers;
                 _proxyEntries[pluginId] = entries;
+            }
+
+            // Build proxy images from metadata
+            foreach (var pluginMeta in plugins)
+            {
+                if (pluginMeta.ImageDescriptors.Count > 0)
+                {
+                    var images = new List<ProxyPluginImage>();
+                    foreach (var imgDesc in pluginMeta.ImageDescriptors)
+                    {
+                        try
+                        {
+                            var proxyImage = new ProxyPluginImage(pluginMeta.Id, imgDesc);
+                            images.Add(proxyImage);
+                            Logger.Information("Created proxy image for {PluginId}/{ImageId}", pluginMeta.Id, imgDesc.Id);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex, "Failed to create proxy image for {PluginId}/{ImageId}", pluginMeta.Id, imgDesc.Id);
+                        }
+                    }
+                    _proxyImages[pluginMeta.Id] = images;
+                }
             }
 
             _pluginsLoadedTcs.TrySetResult();
@@ -526,6 +579,19 @@ namespace InfoPanel.Monitors
         {
             _privateWorkingSetCounter?.Dispose();
             _privateWorkingSetCounter = null;
+
+            // Invalidate image caches before disposing proxies
+            InvalidateImageCaches();
+
+            // Dispose image proxies
+            foreach (var images in _proxyImages.Values)
+            {
+                foreach (var image in images)
+                {
+                    try { image.Dispose(); } catch { }
+                }
+            }
+            _proxyImages.Clear();
 
             _jsonRpc?.Dispose();
             _jsonRpc = null;

--- a/InfoPanel/Monitors/PluginHostConnection.cs
+++ b/InfoPanel/Monitors/PluginHostConnection.cs
@@ -429,6 +429,36 @@ namespace InfoPanel.Monitors
             }
         }
 
+        public void OnImageResize(string pluginId, ImageDescriptorDto descriptor)
+        {
+            Logger.Information("Image resize received: {PluginId}/{ImageId} -> {W}x{H} (MMF: {MmfName})",
+                pluginId, descriptor.Id, descriptor.Width, descriptor.Height, descriptor.MmfName);
+
+            if (!_proxyImages.TryGetValue(pluginId, out var images)) return;
+
+            // Replace proxy FIRST so that any cache recreation picks up the new one
+            var oldIndex = images.FindIndex(img => img.ImageId == descriptor.Id);
+            if (oldIndex >= 0)
+            {
+                var oldProxy = images[oldIndex];
+                try
+                {
+                    var newProxy = new ProxyPluginImage(pluginId, descriptor);
+                    images[oldIndex] = newProxy;
+
+                    // Invalidate cache AFTER proxy is replaced
+                    Cache.InvalidatePluginImages(pluginId, [descriptor.Id]);
+
+                    oldProxy.Dispose();
+                    Logger.Information("Replaced proxy image for {PluginId}/{ImageId}", pluginId, descriptor.Id);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Failed to create replacement proxy image for {PluginId}/{ImageId}", pluginId, descriptor.Id);
+                }
+            }
+        }
+
         #endregion
 
         private static ProxyPluginSensor CreateProxySensor(EntryDto dto)

--- a/InfoPanel/Monitors/PluginMonitor.cs
+++ b/InfoPanel/Monitors/PluginMonitor.cs
@@ -1,3 +1,4 @@
+using InfoPanel.Monitors.PluginProxies;
 using InfoPanel.Plugins;
 using InfoPanel.Plugins.Ipc;
 using InfoPanel.Plugins.Loader;
@@ -242,6 +243,34 @@ namespace InfoPanel.Monitors
         {
             List<PluginReading> OrderedList = [.. SENSORHASH.Values.OrderBy(x => x.IndexOrder)];
             return OrderedList;
+        }
+
+        /// <summary>
+        /// Gets a plugin image proxy by plugin ID and image ID.
+        /// Returns null if not found.
+        /// </summary>
+        public ProxyPluginImage? GetImageProxy(string pluginId, string imageId)
+        {
+            foreach (var conn in ProcessManager.GetAllConnections())
+            {
+                var images = conn.GetProxyImages(pluginId);
+                var match = images.FirstOrDefault(i => i.ImageId == imageId);
+                if (match != null) return match;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gets all plugin image proxies across all connections.
+        /// </summary>
+        public List<ProxyPluginImage> GetAllImageProxies()
+        {
+            var result = new List<ProxyPluginImage>();
+            foreach (var conn in ProcessManager.GetAllConnections())
+            {
+                result.AddRange(conn.GetAllProxyImages());
+            }
+            return result;
         }
 
         public record struct PluginReading

--- a/InfoPanel/Monitors/PluginProcessManager.cs
+++ b/InfoPanel/Monitors/PluginProcessManager.cs
@@ -200,6 +200,11 @@ namespace InfoPanel.Monitors
             return connection;
         }
 
+        public IEnumerable<PluginHostConnection> GetAllConnections()
+        {
+            return _connections.Values;
+        }
+
         public bool IsHostRunning(string filePath)
         {
             return _connections.TryGetValue(filePath, out var conn) && conn.IsProcessRunning && conn.IsConnected;

--- a/InfoPanel/Monitors/PluginProxies/ProxyPluginImage.cs
+++ b/InfoPanel/Monitors/PluginProxies/ProxyPluginImage.cs
@@ -61,11 +61,10 @@ namespace InfoPanel.Monitors.PluginProxies
         }
 
         /// <summary>
-        /// Wraps the active buffer from shared memory as an SKBitmap (zero-copy).
-        /// The returned bitmap is only valid until the next Invalidate() call from the plugin.
-        /// Caller should use it immediately and NOT cache the reference.
+        /// Copies the active buffer from shared memory into a self-contained SKImage.
+        /// The returned image is safe to use and dispose independently of buffer swaps.
         /// </summary>
-        public SKBitmap? GetCurrentFrame()
+        public SKImage? GetCurrentFrame()
         {
             unsafe
             {
@@ -78,9 +77,7 @@ namespace InfoPanel.Monitors.PluginProxies
 
                 var offset = HeaderSize + (activeIndex * _pixelBufferSize);
                 var info = new SKImageInfo(w, h, SKColorType.Rgba8888, SKAlphaType.Premul);
-                var bitmap = new SKBitmap();
-                bitmap.InstallPixels(info, (IntPtr)(_basePtr + offset), info.RowBytes);
-                return bitmap;
+                return SKImage.FromPixelCopy(info, (IntPtr)(_basePtr + offset), info.RowBytes);
             }
         }
 

--- a/InfoPanel/Monitors/PluginProxies/ProxyPluginImage.cs
+++ b/InfoPanel/Monitors/PluginProxies/ProxyPluginImage.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO.MemoryMappedFiles;
+using System.Threading;
+using InfoPanel.Plugins.Ipc;
+using Serilog;
+using SkiaSharp;
+
+namespace InfoPanel.Monitors.PluginProxies
+{
+    /// <summary>
+    /// Read-only consumer of a plugin image via shared memory (MMF).
+    /// Opens the MMF created by the host process and reads the active buffer at render time.
+    /// </summary>
+    internal class ProxyPluginImage : IDisposable
+    {
+        private static readonly ILogger Logger = Log.ForContext<ProxyPluginImage>();
+
+        public string PluginId { get; }
+        public string ImageId { get; }
+        public string ImageName { get; }
+        public int Width { get; }
+        public int Height { get; }
+
+        private MemoryMappedFile? _mmf;
+        private MemoryMappedViewAccessor? _accessor;
+        private unsafe byte* _basePtr;
+        private readonly int _pixelBufferSize;
+        private bool _disposed;
+
+        private const int HeaderSize = 16;
+
+        public ProxyPluginImage(string pluginId, ImageDescriptorDto descriptor)
+        {
+            PluginId = pluginId;
+            ImageId = descriptor.Id;
+            ImageName = descriptor.Name;
+            Width = descriptor.Width;
+            Height = descriptor.Height;
+            _pixelBufferSize = Width * Height * 4;
+
+            try
+            {
+                _mmf = MemoryMappedFile.OpenExisting(descriptor.MmfName, MemoryMappedFileRights.Read);
+                _accessor = _mmf.CreateViewAccessor(0, descriptor.BufferSize, MemoryMappedFileAccess.Read);
+
+                unsafe
+                {
+                    byte* ptr = null;
+                    _accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+                    _basePtr = ptr;
+                }
+
+                Logger.Information("Opened MMF {MmfName} for plugin image {PluginId}/{ImageId}",
+                    descriptor.MmfName, pluginId, descriptor.Id);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to open MMF {MmfName} for plugin image {PluginId}/{ImageId}",
+                    descriptor.MmfName, pluginId, descriptor.Id);
+            }
+        }
+
+        /// <summary>
+        /// Wraps the active buffer from shared memory as an SKBitmap (zero-copy).
+        /// The returned bitmap is only valid until the next Invalidate() call from the plugin.
+        /// Caller should use it immediately and NOT cache the reference.
+        /// </summary>
+        public SKBitmap? GetCurrentFrame()
+        {
+            unsafe
+            {
+                if (_basePtr == null) return null;
+
+                int activeIndex = Volatile.Read(ref *(int*)_basePtr);
+                int w = *(int*)(_basePtr + 4);
+                int h = *(int*)(_basePtr + 8);
+                if (w == 0 || h == 0) return null;
+
+                var offset = HeaderSize + (activeIndex * _pixelBufferSize);
+                var info = new SKImageInfo(w, h, SKColorType.Rgba8888, SKAlphaType.Premul);
+                var bitmap = new SKBitmap();
+                bitmap.InstallPixels(info, (IntPtr)(_basePtr + offset), info.RowBytes);
+                return bitmap;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            unsafe
+            {
+                if (_basePtr != null && _accessor != null)
+                {
+                    _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+                    _basePtr = null;
+                }
+            }
+
+            _accessor?.Dispose();
+            _accessor = null;
+            _mmf?.Dispose();
+            _mmf = null;
+
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -235,6 +235,15 @@ namespace InfoPanel
                 return cachedImage;
             }
 
+            using var semLock = _locks.LockOrNull(cacheKey, 0);
+            if (semLock == null) return null; // Another thread is initializing
+
+            // Double-check after lock
+            if (ImageCache.TryGetValue(cacheKey, out cachedImage))
+            {
+                return cachedImage;
+            }
+
             var proxy = PluginMonitor.Instance.GetImageProxy(pluginId, imageId);
             if (proxy == null) return null;
 
@@ -271,7 +280,10 @@ namespace InfoPanel
             foreach (var imageId in imageIds)
             {
                 var cacheKey = $"plugin-image://{pluginId}/{imageId}";
-                ImageCache.Remove(cacheKey);
+                using (_locks.Lock(cacheKey))
+                {
+                    ImageCache.Remove(cacheKey);
+                }
                 Logger.Debug("Invalidated plugin image cache: {CacheKey}", cacheKey);
             }
         }

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -1,10 +1,13 @@
 ﻿using AsyncKeyedLock;
 using InfoPanel.Extensions;
 using InfoPanel.Models;
+using InfoPanel.Monitors;
+using InfoPanel.Monitors.PluginProxies;
 using InfoPanel.Utils;
 using Microsoft.Extensions.Caching.Memory;
 using Serilog;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,6 +38,8 @@ namespace InfoPanel
             _ = ImageCache.Get("__dummy_key_for_expiration__");
         }
 
+        private const string PluginImageScheme = "plugin-image://";
+
         public static LockedImage? GetLocalImage(ImageDisplayItem imageDisplayItem, bool initialiseIfMissing = true)
         {
             LockedImage? result = null;
@@ -42,9 +47,18 @@ namespace InfoPanel
             {
                 var sensorReading = httpImageDisplayItem.GetValue();
 
-                if (sensorReading.HasValue && !string.IsNullOrEmpty(sensorReading.Value.ValueText) && sensorReading.Value.ValueText.IsUrl())
+                if (sensorReading.HasValue && !string.IsNullOrEmpty(sensorReading.Value.ValueText))
                 {
-                    result = GetLocalImage(sensorReading.Value.ValueText, initialiseIfMissing, imageDisplayItem);
+                    var valueText = sensorReading.Value.ValueText;
+
+                    if (valueText.StartsWith(PluginImageScheme, StringComparison.Ordinal))
+                    {
+                        result = GetPluginImageFromUri(valueText);
+                    }
+                    else if (valueText.IsUrl())
+                    {
+                        result = GetLocalImage(valueText, initialiseIfMissing, imageDisplayItem);
+                    }
                 }
             }
             else
@@ -58,6 +72,22 @@ namespace InfoPanel
             result?.AddImageDisplayItem(imageDisplayItem);
 
             return result;
+        }
+
+        /// <summary>
+        /// Parses a plugin-image://{pluginId}/{imageId} URI and returns the cached LockedImage.
+        /// </summary>
+        private static LockedImage? GetPluginImageFromUri(string uri)
+        {
+            // Parse "plugin-image://pluginId/imageId"
+            var path = uri[PluginImageScheme.Length..];
+            var slashIndex = path.IndexOf('/');
+            if (slashIndex < 0) return null;
+
+            var pluginId = path[..slashIndex];
+            var imageId = path[(slashIndex + 1)..];
+
+            return GetPluginImage(pluginId, imageId);
         }
 
         private static LockedImage? GetLocalImage(string path, bool initialiseIfMissing = true, ImageDisplayItem? imageDisplayItem = null)
@@ -148,9 +178,13 @@ namespace InfoPanel
             if (imageDisplayItem is HttpImageDisplayItem httpImageDisplayItem)
             {
                 var sensorReading = httpImageDisplayItem.GetValue();
-                if (sensorReading.HasValue && !string.IsNullOrEmpty(sensorReading.Value.ValueText) && sensorReading.Value.ValueText.IsUrl())
+                if (sensorReading.HasValue && !string.IsNullOrEmpty(sensorReading.Value.ValueText))
                 {
-                    ImageCache.TryGetValue(sensorReading.Value.ValueText, out _);
+                    var valueText = sensorReading.Value.ValueText;
+                    if (valueText.StartsWith(PluginImageScheme, StringComparison.Ordinal) || valueText.IsUrl())
+                    {
+                        ImageCache.TryGetValue(valueText, out _);
+                    }
                 }
             }
             else if (!string.IsNullOrEmpty(imageDisplayItem.CalculatedPath))
@@ -184,6 +218,61 @@ namespace InfoPanel
                         Log.Error(e, "Failed to invalidate image from cache '{Path}'", path);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets or creates a LockedImage backed by a plugin image proxy (shared memory).
+        /// Uses a persistent cache entry since the image is always live.
+        /// Cache key format: plugin-image://{pluginId}/{imageId}
+        /// </summary>
+        public static LockedImage? GetPluginImage(string pluginId, string imageId)
+        {
+            var cacheKey = $"plugin-image://{pluginId}/{imageId}";
+
+            if (ImageCache.TryGetValue(cacheKey, out LockedImage? cachedImage))
+            {
+                return cachedImage;
+            }
+
+            var proxy = PluginMonitor.Instance.GetImageProxy(pluginId, imageId);
+            if (proxy == null) return null;
+
+            var lockedImage = new LockedImage(cacheKey, proxy);
+
+            var cacheOptions = new MemoryCacheEntryOptions
+            {
+                PostEvictionCallbacks = {
+                    new PostEvictionCallbackRegistration
+                    {
+                        EvictionCallback = (key, value, reason, state) =>
+                        {
+                            Logger.Debug("Plugin image cache entry '{Key}' evicted due to {Reason}", key, reason);
+                            // Don't dispose — the ProxyPluginImage lifecycle is managed by PluginHostConnection
+                        }
+                    }
+                }
+            };
+            // No sliding expiration — persistent cache for plugin images
+
+            ImageCache.Set(cacheKey, lockedImage, cacheOptions);
+
+            Logger.Information("Plugin image cached: {CacheKey} ({W}x{H})", cacheKey, proxy.Width, proxy.Height);
+
+            return lockedImage;
+        }
+
+        /// <summary>
+        /// Invalidates plugin image cache entries for specific image IDs.
+        /// Called when a plugin host disconnects or is reloaded.
+        /// </summary>
+        public static void InvalidatePluginImages(string pluginId, IEnumerable<string> imageIds)
+        {
+            foreach (var imageId in imageIds)
+            {
+                var cacheKey = $"plugin-image://{pluginId}/{imageId}";
+                ImageCache.Remove(cacheKey);
+                Logger.Debug("Invalidated plugin image cache: {CacheKey}", cacheKey);
             }
         }
     }

--- a/InfoPanel/Views/Controls/MyImage.cs
+++ b/InfoPanel/Views/Controls/MyImage.cs
@@ -128,7 +128,7 @@ namespace InfoPanel.Views.Controls
                                 }, true, "MyImage");
                             }
 
-                            if (image.Frames <= 1 && sender is Timer timer)
+                            if (image.Frames <= 1 && image.Type != LockedImage.ImageType.PLUGIN && sender is Timer timer)
                             {
                                 timer.Stop();
                             }

--- a/InfoPanel/packages.lock.json
+++ b/InfoPanel/packages.lock.json
@@ -1228,10 +1228,18 @@
       "infopanel.plugins": {
         "type": "Project"
       },
+      "infopanel.plugins.graphics": {
+        "type": "Project",
+        "dependencies": {
+          "InfoPanel.Plugins": "[1.0.0, )",
+          "SkiaSharp": "[3.119.1, )"
+        }
+      },
       "infopanel.plugins.host": {
         "type": "Project",
         "dependencies": {
           "InfoPanel.Plugins": "[1.0.0, )",
+          "InfoPanel.Plugins.Graphics": "[1.0.0, )",
           "InfoPanel.Plugins.Ipc": "[1.0.0, )",
           "InfoPanel.Plugins.Loader": "[1.0.0, )",
           "Serilog": "[4.3.0, )",


### PR DESCRIPTION
This pull request introduces a new graphics plugin framework for InfoPanel, enabling plugins to declare image outputs and draw directly onto shared memory buffers for efficient, zero-copy transfer. The changes add new interfaces and implementations for image providers and writers, update the host service to manage image buffers, and ensure proper cross-context interop for graphics types. The solution and project files are updated to include the new graphics project and dependencies.

Graphics plugin framework integration:

* Added the `InfoPanel.Plugins.Graphics` project with interfaces for image providers (`IPluginImageProvider`), image writers (`IPluginImageWriter`), and image descriptors (`PluginImageDescriptor`), as well as a shared memory-backed implementation (`PluginImageWriter`). This allows plugins to declare image outputs and draw on shared memory buffers using SkiaSharp. [[1]](diffhunk://#diff-25a55aab242d093b90fd39335ad9f59000b0314a1fd2b87b550a59096328c121R1-R19) [[2]](diffhunk://#diff-c86ca45cf3455379b9e97d0b2002c82d2d5714f190513e799dff39c019c9fc9dR1-R21) [[3]](diffhunk://#diff-c50bbcde03e10b66f4a516de6c0571c55f407c6d682b68fdb087c73c0802ad77R1-R31) [[4]](diffhunk://#diff-11cf845bcc63be925fbdbde28cabe601ce059b621c847658e15308b37ca10e57R1-R21) [[5]](diffhunk://#diff-17ac8d07ac8ddf083f0b3637bdb5b4556524b77186de534c0211d336b935e9beR1-R179)
* Updated the solution and host project files to reference the new graphics project and SkiaSharp dependency. [[1]](diffhunk://#diff-ea7b90ac8bc7b5748c31e81580b38a692a8b37d0d3e2d0aff1c768c1be0f5e0bR20-R21) [[2]](diffhunk://#diff-ea7b90ac8bc7b5748c31e81580b38a692a8b37d0d3e2d0aff1c768c1be0f5e0bR56-R59) [[3]](diffhunk://#diff-7219c7b221fa6bd8b903041bf55034b4a171f47f1e2f3e31d0323d19e6efd892R21)

Host service enhancements for image management:

* Modified `HostService` to detect plugins implementing `IPluginImageProvider`, create and manage shared memory buffers, and expose image descriptors to clients. Image buffers are disposed during shutdown, and resize events are handled and notified. [[1]](diffhunk://#diff-cbccc05df65863e0b720f397853ade54f072c09346e0bce077e4931ae152913fR2-R5) [[2]](diffhunk://#diff-cbccc05df65863e0b720f397853ade54f072c09346e0bce077e4931ae152913fR20-R21) [[3]](diffhunk://#diff-cbccc05df65863e0b720f397853ade54f072c09346e0bce077e4931ae152913fR94-R129) [[4]](diffhunk://#diff-cbccc05df65863e0b720f397853ade54f072c09346e0bce077e4931ae152913fR145-R163) [[5]](diffhunk://#diff-cbccc05df65863e0b720f397853ade54f072c09346e0bce077e4931ae152913fR368-R376) [[6]](diffhunk://#diff-cbccc05df65863e0b720f397853ade54f072c09346e0bce077e4931ae152913fR596-R627)
* Updated DTOs and client callback interfaces to support image descriptors and resize notifications, enabling clients to receive updates when image buffers change size. [[1]](diffhunk://#diff-b8f5e57c92fa83e96050181479f1a92cd1e19cedaa8cae083810f77ccaef7415R15-R25) [[2]](diffhunk://#diff-55b9434932f033c0cc365b07edd72a4861d01a6f90b37a68f114a1f03e66a7b8R9)

Cross-context graphics interop:

* Updated `PluginLoadContext` to share assemblies for graphics types (e.g., SkiaSharp, InfoPanel.Plugins.Graphics) between host and plugin, ensuring that types like `SKBitmap` are compatible across contexts.