### PR TITLE
Add per-sensor thousands separator toggle

### DIFF
--- a/InfoPanel/Models/SensorDisplayItem.cs
+++ b/InfoPanel/Models/SensorDisplayItem.cs
@@ -216,6 +216,16 @@ namespace InfoPanel.Models
             }
         }
 
+        private bool _showThousandsSeparator = false;
+        public bool ShowThousandsSeparator
+        {
+            get { return _showThousandsSeparator; }
+            set
+            {
+                SetProperty(ref _showThousandsSeparator, value);
+            }
+        }
+
         private double _additionModifier = 0;
         public double AdditionModifier
         {
@@ -467,6 +477,15 @@ namespace InfoPanel.Models
                 }
             }
 
+            if (ShowThousandsSeparator && double.TryParse(value,
+                System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out double parsedValue))
+            {
+                int decimalIndex = value.IndexOf('.');
+                int decimalPlaces = decimalIndex >= 0 ? value.Length - decimalIndex - 1 : 0;
+                value = parsedValue.ToString("N" + decimalPlaces, System.Globalization.CultureInfo.InvariantCulture);
+            }
 
             if (ShowUnit)
             {

--- a/InfoPanel/Views/Components/Text/SensorProperties.xaml
+++ b/InfoPanel/Views/Components/Text/SensorProperties.xaml
@@ -65,6 +65,14 @@
                             IsChecked="{Binding ShowUnit}">
                             <ui:SymbolIcon Symbol="TextAsterisk20" ToolTip="Show Unit" />
                         </ToggleButton>
+
+                        <ToggleButton
+                            Grid.Column="2"
+                            Margin="5,0,0,0"
+                            HorizontalAlignment="Right"
+                            IsChecked="{Binding ShowThousandsSeparator}">
+                            <ui:SymbolIcon Symbol="NumberRow20" ToolTip="Thousands Separator" />
+                        </ToggleButton>
                     </StackPanel>
                 </StackPanel>
 


### PR DESCRIPTION
## Summary
Adds a per-sensor `ShowThousandsSeparator` toggle that formats numeric values with comma grouping (e.g. "1,234" instead of "1234").

Inspired by PR #78 by @5kft, reimplemented as a per-sensor setting per @habibrehmansg's feedback.

## Changes
- `SensorDisplayItem.cs`: Added `ShowThousandsSeparator` bool property (default false). Applied in `EvaluateText()` after precision formatting, before unit suffix. Uses `InvariantCulture` "N" format for consistent comma+period output regardless of locale.
- `SensorProperties.xaml`: Added toggle button with `NumberRow20` icon in the existing toolbar row next to Show Name / Show Unit.

## Compatibility
- Defaults to `false`, so existing profiles are unaffected
- XML serialization is automatic (new property, no schema changes needed)
- Older InfoPanel versions silently ignore the unknown XML element
- `Clone()` via `MemberwiseClone()` copies the new field automatically
- Undo/redo captures it via existing XML snapshot mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)