### PR TITLE
Disable OpenGL on non-NVIDIA GPUs to prevent crash

### DIFF
--- a/InfoPanel/Utils/GpuHelper.cs
+++ b/InfoPanel/Utils/GpuHelper.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace InfoPanel.Utils
+{
+    public static class GpuHelper
+    {
+        private static bool? _isNvidia;
+
+        /// <summary>
+        /// True if NVIDIA GPU is present (OpenGL supported).
+        /// Used for XAML binding via x:Static.
+        /// </summary>
+        public static bool IsOpenGLSupported => IsNvidiaGpu();
+
+        /// <summary>
+        /// Checks if an NVIDIA GPU is present. OpenGL rendering in InfoPanel uses
+        /// WGL_NV_DX_interop which is NVIDIA-only. On AMD/Intel GPUs, enabling
+        /// OpenGL causes an AccessViolationException crash.
+        /// </summary>
+        public static bool IsNvidiaGpu()
+        {
+            if (_isNvidia.HasValue) return _isNvidia.Value;
+
+            try
+            {
+                for (int i = 0; i <= 3; i++)
+                {
+                    using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(
+                        $@"SYSTEM\CurrentControlSet\Control\Class\{{4d36e968-e325-11ce-bfc1-08002be10318}}\{i:D4}");
+                    var provider = key?.GetValue("ProviderName") as string;
+                    if (provider != null && provider.Contains("NVIDIA", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _isNvidia = true;
+                        return true;
+                    }
+                }
+            }
+            catch { }
+
+            _isNvidia = false;
+            return false;
+        }
+    }
+}

--- a/InfoPanel/Views/Components/DisplayItems.xaml
+++ b/InfoPanel/Views/Components/DisplayItems.xaml
@@ -10,6 +10,7 @@
     xmlns:local="clr-namespace:InfoPanel.Views.Components"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:models="clr-namespace:InfoPanel.Models"
+    xmlns:utils="clr-namespace:InfoPanel.Utils"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     mc:Ignorable="d">
@@ -171,7 +172,8 @@
                     <ToggleButton
                         Margin="10,0,0,0"
                         IsChecked="{Binding Source={x:Static app:SharedModel.Instance}, Path=SelectedProfile.OpenGL}"
-                        ToolTip="OpenGL">
+                        IsEnabled="{x:Static utils:GpuHelper.IsOpenGLSupported}"
+                        ToolTip="OpenGL (NVIDIA GPU required)">
                         <ui:SymbolIcon Symbol="FastAcceleration20" />
                     </ToggleButton>
 

--- a/InfoPanel/Views/Pages/ProfilesPage.xaml
+++ b/InfoPanel/Views/Pages/ProfilesPage.xaml
@@ -9,6 +9,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
     xmlns:models="clr-namespace:InfoPanel.Models"
+    xmlns:utils="clr-namespace:InfoPanel.Utils"
     xmlns:pages="clr-namespace:InfoPanel.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="DesignPage"
@@ -512,15 +513,24 @@
                                                 </Grid.ColumnDefinitions>
 
                                                 <Grid Grid.Column="0" IsEnabled="{Binding Active}">
-                                                    <ui:CardControl>
-                                                        <ui:CardControl.Header>
-                                                            <TextBlock
-                                                                FontSize="12"
-                                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                                Text="Use OpenGL (GPU) rendering" />
-                                                        </ui:CardControl.Header>
-                                                        <ui:ToggleSwitch Margin="0,-5,0,-5" IsChecked="{Binding OpenGL}" />
-                                                    </ui:CardControl>
+                                                    <StackPanel>
+                                                        <ui:CardControl IsEnabled="{x:Static utils:GpuHelper.IsOpenGLSupported}">
+                                                            <ui:CardControl.Header>
+                                                                <StackPanel>
+                                                                    <TextBlock
+                                                                        FontSize="12"
+                                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                                        Text="Use OpenGL (GPU) rendering" />
+                                                                    <TextBlock
+                                                                        FontSize="11"
+                                                                        Foreground="Orange"
+                                                                        Text="Requires NVIDIA GPU"
+                                                                        Visibility="{Binding IsEnabled, RelativeSource={RelativeSource AncestorType=ui:CardControl}, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                                                </StackPanel>
+                                                            </ui:CardControl.Header>
+                                                            <ui:ToggleSwitch Margin="0,-5,0,-5" IsChecked="{Binding OpenGL}" />
+                                                        </ui:CardControl>
+                                                    </StackPanel>
                                                 </Grid>
 
                                                 <Grid Grid.Column="1" Margin="10,0,0,0">


### PR DESCRIPTION
## Summary
Disables the OpenGL toggle on non-NVIDIA GPUs to prevent an unrecoverable `AccessViolationException` crash.

Fixes #122.

## Problem
OpenTK.Wpf uses `WGL_NV_DX_interop` for DirectX/OpenGL interop, which is an NVIDIA-only OpenGL extension. On AMD and Intel GPUs, this extension does not exist. When a user enables OpenGL on a profile, `DXRegisterObjectNV` is called with an invalid function pointer, causing an `AccessViolationException` that immediately terminates the process. Since this is a corrupted state exception, it cannot be caught by try/catch.

## Fix
- Added `GpuHelper.IsOpenGLSupported` which checks the GPU vendor via registry
- OpenGL toggle in Profiles page is disabled with "Requires NVIDIA GPU" notice when non-NVIDIA
- OpenGL toggle button in Design page is disabled with updated tooltip
- No changes to the rendering pipeline

## Note
This is a temporary workaround. The proper fix would be one of:
1. Fix upstream in OpenTK.Wpf to support AMD/Intel via an alternative interop path (e.g. `WGL_AMD_gpu_association` or software fallback)
2. Migrate to a different GPU-accelerated rendering approach that works across all GPU vendors

## Changes
- `GpuHelper.cs` (new): Static utility to detect NVIDIA GPU via registry
- `ProfilesPage.xaml`: OpenGL card disabled on non-NVIDIA, warning text shown
- `DisplayItems.xaml`: OpenGL toggle button disabled on non-NVIDIA, tooltip updated