### PR TITLE
Revert TuringPanel to TuringSmartScreenLib driver

### DIFF
--- a/InfoPanel/Services/TuringPanelUsbDeviceTask.cs
+++ b/InfoPanel/Services/TuringPanelUsbDeviceTask.cs
@@ -1,7 +1,7 @@
 using InfoPanel.Extensions;
 using InfoPanel.Models;
+using InfoPanel.TuringPanel;
 using InfoPanel.Utils;
-using LcdDriver.TuringSmartScreen;
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
 using Serilog;
@@ -21,6 +21,8 @@ namespace InfoPanel.Services
         private readonly TuringPanelDevice _device;
         private readonly int _panelWidth;
         private readonly int _panelHeight;
+        private static readonly int _maxSize = 1024 * 1024; // 1MB
+        private DateTime _downgradeRenderingUntil = DateTime.MinValue;
 
         public TuringPanelDevice Device => _device;
 
@@ -44,23 +46,69 @@ namespace InfoPanel.Services
             if (ConfigModel.Instance.GetProfile(profileGuid) is Profile profile)
             {
                 var rotation = _device.Rotation;
-                using var bitmap = PanelDrawTask.RenderSK(profile, false);
+                using var bitmap = PanelDrawTask.RenderSK(profile, false,
+                    colorType: DateTime.Now > _downgradeRenderingUntil ? SKColorType.Rgba8888 : SKColorType.Argb4444);
 
                 using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
 
+                var options = new SKPngEncoderOptions(
+                        filterFlags: SKPngEncoderFilterFlags.NoFilters,
+                        zLibLevel: 3
+                        );
+
                 using var pixmap = resizedBitmap.PeekPixels();
-                using var data = pixmap.Encode(SKEncodedImageFormat.Jpeg, _device.JpegQuality);
+                using var data = pixmap.Encode(options);
 
                 if (data == null || data.IsEmpty)
                 {
-                    Logger.Error("TuringPanelDevice {Device}: Failed to encode bitmap to JPEG", _device);
+                    Logger.Error("TuringPanelDevice {Device}: Failed to encode bitmap to PNG", _device);
                     return null;
                 }
 
-                return data.ToArray();
+                var result = data.ToArray();
+
+                if (resizedBitmap.ColorType != SKColorType.Argb4444 && result.Length > _maxSize)
+                {
+                    Logger.Warning("TuringPanelDevice {Device}: Downgrading rendering to ARGB4444 due to size constraints. Size: {Size} bytes, max: {MaxSize} bytes", 
+                        _device, result.Length, _maxSize);
+                    DateTime now = DateTime.Now;
+                    DateTime targetTime = now.AddSeconds(10);
+                    _downgradeRenderingUntil = targetTime;
+                    return null;
+                }
+                else if (result.Length > _maxSize)
+                {
+                    result = DownscaleUpscaleAndEncode(resizedBitmap);
+                }
+
+                return result;
             }
 
             return null;
+        }
+
+        private static byte[]? DownscaleUpscaleAndEncode(SKBitmap original, float scale = 0.5f)
+        {
+            int downWidth = (int)(original.Width * scale);
+            int downHeight = (int)(original.Height * scale);
+
+            using var downscaled = original.Resize(new SKImageInfo(downWidth, downHeight), SKSamplingOptions.Default);
+            using var upscaled = downscaled.Resize(new SKImageInfo(original.Width, original.Height), SKSamplingOptions.Default);
+
+            var options = new SKPngEncoderOptions(
+                      filterFlags: SKPngEncoderFilterFlags.NoFilters,
+                      zLibLevel: 3
+                      );
+
+            using var pixmap = upscaled.PeekPixels();
+            using var data = pixmap.Encode(options);
+
+            if (data == null || data.IsEmpty)
+            {
+                Logger.Error("Failed to encode bitmap to PNG");
+                return null;
+            }
+            return data.ToArray();
         }
 
         private async Task<UsbRegistry?> FindTargetDeviceAsync()
@@ -73,7 +121,7 @@ namespace InfoPanel.Services
 
             foreach (UsbRegistry deviceReg in UsbDevice.AllDevices)
             {
-                if (deviceReg.Vid == _device.ModelInfo.VendorId && deviceReg.Pid == _device.ModelInfo.ProductId)
+                if (deviceReg.Vid == _device.ModelInfo.VendorId && deviceReg.Pid == _device.ModelInfo.ProductId) // VENDOR_ID and PRODUCT_ID from TuringDevice
                 {
                     var deviceId = deviceReg.DeviceProperties["DeviceID"] as string;
 
@@ -97,7 +145,7 @@ namespace InfoPanel.Services
         protected override async Task DoWorkAsync(CancellationToken token)
         {
             await Task.Delay(300, token);
-
+            
             try
             {
                 var usbRegistry = await FindTargetDeviceAsync();
@@ -109,56 +157,42 @@ namespace InfoPanel.Services
                     return;
                 }
 
-                if (!usbRegistry.Open(out var usbDevice))
+                using var device = new TuringDevice();
+                
+                try
                 {
-                    Logger.Error("TuringPanelDevice {Device}: Failed to open USB device", _device);
-                    _device.UpdateRuntimeProperties(errorMessage: "Failed to open USB device");
+                    device.Initialize(usbRegistry);
+                }
+                catch (TuringDeviceException ex)
+                {
+                    Logger.Error("TuringPanelDevice {Device}: Failed to initialize - {Error}", _device, ex.Message);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
                     return;
                 }
-
-                using var screenDevice = new ScreenDevice(usbDevice);
-
+                
                 Logger.Information("TuringPanelDevice {Device}: Initialized successfully", _device);
                 _device.UpdateRuntimeProperties(isRunning: true);
 
                 try
                 {
-                    // Sync — bail if device firmware isn't ready
-                    if (!screenDevice.Sync())
-                    {
-                        Logger.Warning("TuringPanelDevice {Device}: Sync failed (1st attempt), device not ready", _device);
-                        _device.UpdateRuntimeProperties(errorMessage: "Device not ready (sync failed)");
-                        return;
-                    }
+                    // Delay for sync
+                    device.SendSyncCommand();
                     Thread.Sleep(200);
-
-                    if (!screenDevice.Sync())
-                    {
-                        Logger.Warning("TuringPanelDevice {Device}: Sync failed (2nd attempt), device not ready", _device);
-                        _device.UpdateRuntimeProperties(errorMessage: "Device not ready (sync failed)");
-                        return;
-                    }
-                    Thread.Sleep(200);
-
-                    // Stop any video playback to prevent flickering
-                    screenDevice.StopMedia();
+                    device.SendSyncCommand();
                     Thread.Sleep(200);
 
                     // Set brightness
                     var brightness = _device.Brightness;
-                    screenDevice.SetBrightness((byte)brightness);
+                    device.SendBrightnessCommand((byte)brightness);
 
-                    if (!screenDevice.Sync())
-                    {
-                        Logger.Warning("TuringPanelDevice {Device}: Sync failed after brightness set, device not ready", _device);
-                        _device.UpdateRuntimeProperties(errorMessage: "Device not ready (sync failed)");
-                        return;
-                    }
+                    device.SendSyncCommand();
                     Thread.Sleep(200);
 
                     FpsCounter fpsCounter = new(60);
                     byte[]? _latestFrame = null;
                     AutoResetEvent _frameAvailable = new(false);
+
+                    var frameBufferPool = new ConcurrentBag<byte[]>();
 
                     var renderCts = CancellationTokenSource.CreateLinkedTokenSource(token);
                     var renderToken = renderCts.Token;
@@ -179,7 +213,7 @@ namespace InfoPanel.Services
                                 _frameAvailable.Set();
                             }
 
-                            var targetFrameTime = 1000 / Math.Max(1, _device.TargetFrameRate);
+                            var targetFrameTime = 1000 / ConfigModel.Instance.Settings.TargetFrameRate;
                             var desiredFrameTime = Math.Max((int)(fpsCounter.FrameTime), targetFrameTime);
                             var adaptiveFrameTime = 0;
 
@@ -209,14 +243,9 @@ namespace InfoPanel.Services
                                 if (brightness != _device.Brightness)
                                 {
                                     brightness = _device.Brightness;
-                                    screenDevice.SetBrightness((byte)brightness);
-                                    if (!screenDevice.Sync())
-                                    {
-                                        Logger.Warning("TuringPanelDevice {Device}: Sync failed during brightness update", _device);
-                                        _device.UpdateRuntimeProperties(errorMessage: "Sync failed");
-                                        break;
-                                    }
-                                    Thread.Sleep(200);
+                                    device.SendBrightnessCommand((byte)brightness);
+                                    device.SendSyncCommand();
+                    Thread.Sleep(200);
                                 }
 
                                 if (_frameAvailable.WaitOne(100))
@@ -225,12 +254,7 @@ namespace InfoPanel.Services
                                     if (frame != null)
                                     {
                                         stopwatch2.Restart();
-                                        if (!screenDevice.DrawJpeg(frame))
-                                        {
-                                            Logger.Warning("TuringPanelDevice {Device}: DrawJpeg failed", _device);
-                                            _device.UpdateRuntimeProperties(errorMessage: "Draw failed");
-                                            break;
-                                        }
+                                        device.SendPngBytes(frame);
 
                                         fpsCounter.Update(stopwatch2.ElapsedMilliseconds);
                                         _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
@@ -263,7 +287,7 @@ namespace InfoPanel.Services
                 {
                     try
                     {
-                        screenDevice.SetBrightness(0);
+                        device.SendBrightnessCommand(0);
                     }
                     catch (Exception ex)
                     {
@@ -273,7 +297,7 @@ namespace InfoPanel.Services
             }
             catch (Exception e)
             {
-                Logger.Warning(e, "TuringPanelDevice {Device}: Init error", _device);
+                Logger.Error(e, "TuringPanelDevice {Device}: Init error", _device);
                 _device.UpdateRuntimeProperties(errorMessage: e.Message);
             }
             finally


### PR DESCRIPTION
## Summary
Reverts `TuringPanelUsbDeviceTask.cs` to use the working `TuringSmartScreenLib` driver instead of the new `LcdDriver.TuringSmartScreen` driver introduced in commit 2a7dd40.

Fixes #125

## Problem
The new `LcdDriver.TuringSmartScreen` driver causes Turing panels (VID 1CBE, PID 0088) to get stuck on a static image. The device initializes and the UI shows it as running, but no frames are sent to the display.

## Fix
Restored `TuringPanelUsbDeviceTask.cs` to the pre-rewrite version (commit 2194e3c) that uses `InfoPanel.TuringPanel` / `TuringSmartScreenLib` for device communication. Tested and confirmed working on Turing Smart Screen 8.8" Rev 1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)