### PR TITLE
Add Thermaltake 6" LCD panel support

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -403,6 +403,7 @@ namespace InfoPanel
                 await BeadaPanelTask.Instance.StopAsync(true);
                 await TuringPanelTask.Instance.StopAsync(true);
                 await ThermalrightPanelTask.Instance.StopAsync(true);
+                await ThermaltakePanelTask.Instance.StopAsync(true);
             });
         }
 
@@ -445,6 +446,11 @@ namespace InfoPanel
                 await ThermalrightPanelTask.Instance.StartAsync();
             }
 
+            if (ConfigModel.Instance.Settings.ThermaltakePanelMultiDeviceMode)
+            {
+                await ThermaltakePanelTask.Instance.StartAsync();
+            }
+
             if (ConfigModel.Instance.Settings.WebServer)
             {
                 await WebServerTask.Instance.StartAsync();
@@ -457,6 +463,7 @@ namespace InfoPanel
             await BeadaPanelTask.Instance.StopAsync();
             await TuringPanelTask.Instance.StopAsync();
             await ThermalrightPanelTask.Instance.StopAsync();
+            await ThermaltakePanelTask.Instance.StopAsync();
         }
 
         private void App_Exit(object sender, ExitEventArgs e)

--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -465,6 +465,17 @@ namespace InfoPanel
                     await ThermalrightPanelTask.Instance.StopAsync();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.ThermaltakePanelMultiDeviceMode))
+            {
+                if (Settings.ThermaltakePanelMultiDeviceMode)
+                {
+                    await ThermaltakePanelTask.Instance.StartAsync();
+                }
+                else
+                {
+                    await ThermaltakePanelTask.Instance.StopAsync();
+                }
+            }
 
             await SaveSettingsAsync();
         }
@@ -663,6 +674,15 @@ namespace InfoPanel
                             foreach (var device in settings.ThermalrightPanelDevices)
                             {
                                 Settings.ThermalrightPanelDevices.Add(device);
+                            }
+
+                            // Load Thermaltake panel settings
+                            Settings.ThermaltakePanelMultiDeviceMode = settings.ThermaltakePanelMultiDeviceMode;
+
+                            Settings.ThermaltakePanelDevices.Clear();
+                            foreach (var device in settings.ThermaltakePanelDevices)
+                            {
+                                Settings.ThermaltakePanelDevices.Add(device);
                             }
 
                             // Load hotkey bindings

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -83,6 +83,16 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _thermalrightPanelMultiDeviceMode = false;
 
+        private readonly ObservableCollection<ThermaltakePanelDevice> _thermaltakePanelDevices = [];
+
+        public ObservableCollection<ThermaltakePanelDevice> ThermaltakePanelDevices
+        {
+            get { return _thermaltakePanelDevices; }
+        }
+
+        [ObservableProperty]
+        private bool _thermaltakePanelMultiDeviceMode = false;
+
         private readonly ObservableCollection<HotkeyBinding> _hotkeyBindings = [];
 
         public ObservableCollection<HotkeyBinding> HotkeyBindings
@@ -123,6 +133,7 @@ namespace InfoPanel.Models
             BeadaPanelDevices.CollectionChanged += BeadaPanelDevices_CollectionChanged;
             TuringPanelDevices.CollectionChanged += TuringPanelDevices_CollectionChanged;
             ThermalrightPanelDevices.CollectionChanged += ThermalrightPanelDevices_CollectionChanged;
+            ThermaltakePanelDevices.CollectionChanged += ThermaltakePanelDevices_CollectionChanged;
         }
 
         private void BeadaPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -194,6 +205,27 @@ namespace InfoPanel.Models
             {
                 OnPropertyChanged(nameof(ThermalrightPanelDevices));
             }
+        }
+
+        private void ThermaltakePanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (ThermaltakePanelDevice device in e.OldItems)
+                    device.PropertyChanged -= ThermaltakeDevice_PropertyChanged;
+            }
+            if (e.NewItems != null)
+            {
+                foreach (ThermaltakePanelDevice device in e.NewItems)
+                    device.PropertyChanged += ThermaltakeDevice_PropertyChanged;
+            }
+            OnPropertyChanged(nameof(ThermaltakePanelDevices));
+        }
+
+        private void ThermaltakeDevice_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(ThermaltakePanelDevice.RuntimeProperties))
+                OnPropertyChanged(nameof(ThermaltakePanelDevices));
         }
     }
 }

--- a/InfoPanel/Models/ThermaltakePanelDevice.cs
+++ b/InfoPanel/Models/ThermaltakePanelDevice.cs
@@ -1,0 +1,151 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using InfoPanel.ThermaltakePanel;
+using InfoPanel.ViewModels;
+using Serilog;
+using System;
+using System.Linq;
+using System.Windows.Threading;
+
+namespace InfoPanel.Models
+{
+    public partial class ThermaltakePanelDevice : ObservableObject
+    {
+        private static readonly ILogger Logger = Log.ForContext<ThermaltakePanelDevice>();
+
+        [ObservableProperty]
+        private string _deviceId = string.Empty;
+
+        [ObservableProperty]
+        private string _deviceLocation = string.Empty;
+
+        [ObservableProperty]
+        private ThermaltakePanelModel _model = ThermaltakePanelModel.ToughLiquid6Inch;
+
+        partial void OnModelChanged(ThermaltakePanelModel value)
+        {
+            OnPropertyChanged(nameof(ModelInfo));
+            OnPropertyChanged(nameof(DisplayWidth));
+            OnPropertyChanged(nameof(DisplayHeight));
+        }
+
+        partial void OnDeviceLocationChanged(string value)
+        {
+            OnPropertyChanged(nameof(DevicePort));
+        }
+
+        public string DevicePort => DeviceLocation.Split('.').FirstOrDefault() ?? string.Empty;
+
+        [ObservableProperty]
+        private bool _enabled = false;
+
+        [ObservableProperty]
+        private Guid _profileGuid = Guid.Empty;
+
+        [ObservableProperty]
+        private LCD_ROTATION _rotation = LCD_ROTATION.RotateNone;
+
+        [ObservableProperty]
+        private int _brightness = 100;
+
+        [ObservableProperty]
+        private int _targetFrameRate = 15;
+
+        [ObservableProperty]
+        private int _jpegQuality = 85;
+
+        // Runtime properties (not persisted)
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private string _id = Guid.NewGuid().ToString();
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private ThermaltakePanelDeviceRuntimeProperties _runtimeProperties;
+
+        public ThermaltakePanelDevice()
+        {
+            _runtimeProperties = new();
+        }
+
+        public ThermaltakePanelModelInfo? ModelInfo =>
+            ThermaltakePanelModelDatabase.Models.TryGetValue(Model, out var info) ? info : null;
+
+        public int DisplayWidth => ModelInfo?.Width ?? 0;
+        public int DisplayHeight => ModelInfo?.Height ?? 0;
+
+        public bool IsMatching(string deviceId, string deviceLocation, ThermaltakePanelModel model)
+        {
+            bool matched = false;
+
+            if (DeviceId.Equals(deviceId) && DeviceLocation.Equals(deviceLocation) && Model.Equals(model))
+                matched = true;
+            else
+            {
+                string port = deviceLocation.Split('.').FirstOrDefault() ?? string.Empty;
+                if (DeviceId.Equals(deviceId) && DevicePort.Equals(port) && Model.Equals(model))
+                    matched = true;
+                else if (DeviceId.Equals(deviceId) && DevicePort.Equals(port))
+                    matched = true;
+                else if (DeviceId.Equals(deviceId) && DeviceLocation.Equals(deviceLocation))
+                    matched = true;
+            }
+
+            return matched;
+        }
+
+        private DateTime _lastUpdate = DateTime.MinValue;
+        private readonly TimeSpan _throttleInterval = TimeSpan.FromSeconds(1);
+
+        public void UpdateRuntimeProperties(bool? isRunning = null, int? frameRate = null, long? frameTime = null, string? errorMessage = null)
+        {
+            var now = DateTime.UtcNow;
+
+            if (isRunning != null || errorMessage != null)
+            {
+                _lastUpdate = now;
+                DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+                return;
+            }
+
+            if (now - _lastUpdate < _throttleInterval)
+                return;
+
+            _lastUpdate = now;
+            DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+        }
+
+        private void DispatchUpdate(bool? isRunning, int? frameRate, long? frameTime, string? errorMessage)
+        {
+            if (System.Windows.Application.Current?.Dispatcher is Dispatcher dispatcher)
+            {
+                dispatcher.BeginInvoke(() =>
+                {
+                    if (isRunning != null) RuntimeProperties.IsRunning = isRunning.Value;
+                    if (frameRate != null) RuntimeProperties.FrameRate = frameRate.Value;
+                    if (frameTime != null) RuntimeProperties.FrameTime = frameTime.Value;
+                    if (errorMessage != null) RuntimeProperties.ErrorMessage = errorMessage;
+                });
+            }
+        }
+
+        public override string ToString() => DeviceLocation;
+
+        public partial class ThermaltakePanelDeviceRuntimeProperties : ObservableObject
+        {
+            [ObservableProperty]
+            private bool _isRunning = false;
+
+            [ObservableProperty]
+            private string _name = "Thermaltake LCD";
+
+            [ObservableProperty]
+            private int _frameRate = 0;
+
+            [ObservableProperty]
+            private long _frameTime = 0;
+
+            [ObservableProperty]
+            private string _errorMessage = string.Empty;
+        }
+    }
+}

--- a/InfoPanel/Services/ThermaltakePanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermaltakePanelDeviceTask.cs
@@ -1,0 +1,252 @@
+using InfoPanel.Drawing;
+using InfoPanel.Extensions;
+using InfoPanel.Models;
+using InfoPanel.ThermaltakePanel;
+using InfoPanel.Utils;
+using Serilog;
+using SkiaSharp;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class ThermaltakePanelDeviceTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<ThermaltakePanelDeviceTask>();
+
+        private readonly ThermaltakePanelDevice _device;
+        private int _panelWidth;
+        private int _panelHeight;
+        private int _lastBrightness;
+
+        public ThermaltakePanelDeviceTask(ThermaltakePanelDevice device)
+        {
+            _device = device;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            var modelInfo = _device.ModelInfo;
+            if (modelInfo == null)
+            {
+                _device.UpdateRuntimeProperties(errorMessage: "Unknown model");
+                return;
+            }
+
+            _panelWidth = modelInfo.Width;
+            _panelHeight = modelInfo.Height;
+            _lastBrightness = _device.Brightness;
+
+            _device.UpdateRuntimeProperties(isRunning: false, errorMessage: string.Empty);
+            _device.RuntimeProperties.Name = $"{modelInfo.Name} ({_panelWidth}x{_panelHeight})";
+
+            // Retry loop with backoff
+            int retryCount = 0;
+            while (!token.IsCancellationRequested)
+            {
+                ThermaltakeHidDevice? hidDevice = null;
+                try
+                {
+                    Logger.Information("ThermaltakeDevice {Device}: Opening (attempt {Retry})", _device, retryCount + 1);
+                    hidDevice = ThermaltakeHidDevice.Open(modelInfo.VendorId, modelInfo.ProductId);
+
+                    if (hidDevice == null)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: "Device not found");
+                        await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    // Handshake
+                    Logger.Information("ThermaltakeDevice {Device}: Handshake", _device);
+                    if (!hidDevice.Handshake())
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: "Handshake failed");
+                        hidDevice.Dispose();
+                        await Task.Delay(2000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    retryCount = 0;
+
+                    // Render and send loop
+                    await RunRenderSendLoop(hidDevice, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "ThermaltakeDevice {Device}: Error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+                    retryCount++;
+                }
+                finally
+                {
+                    hidDevice?.Dispose();
+                    _device.UpdateRuntimeProperties(isRunning: false);
+                }
+
+                if (!token.IsCancellationRequested)
+                    await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+            }
+        }
+
+        private async Task RunRenderSendLoop(ThermaltakeHidDevice hidDevice, CancellationToken token)
+        {
+            FpsCounter fpsCounter = new(60);
+            byte[]? latestFrame = null;
+            AutoResetEvent frameAvailable = new(false);
+
+            var renderCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var renderToken = renderCts.Token;
+
+            _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
+
+            var renderTask = Task.Run(async () =>
+            {
+                Thread.CurrentThread.Name ??= $"Thermaltake-Render-{_device.DeviceLocation}";
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    while (!renderToken.IsCancellationRequested)
+                    {
+                        stopwatch.Restart();
+
+                        var frame = GenerateJpegBuffer();
+                        Interlocked.Exchange(ref latestFrame, frame);
+                        frameAvailable.Set();
+
+                        var targetFrameTime = 1000 / Math.Max(1, _device.TargetFrameRate);
+                        var elapsedMs = (int)stopwatch.ElapsedMilliseconds;
+                        var adaptiveFrameTime = targetFrameTime - elapsedMs;
+                        if (adaptiveFrameTime > 0)
+                            await Task.Delay(adaptiveFrameTime, token);
+                    }
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "ThermaltakeDevice {Device}: Render error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: e.Message);
+                    renderCts.Cancel();
+                }
+            }, renderToken);
+
+            var sendTask = Task.Run(() =>
+            {
+                Thread.CurrentThread.Name ??= $"Thermaltake-Send-{_device.DeviceLocation}";
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    while (!token.IsCancellationRequested)
+                    {
+                        if (frameAvailable.WaitOne(100))
+                        {
+                            var jpegData = Interlocked.Exchange(ref latestFrame, null);
+                            if (jpegData != null)
+                            {
+                                stopwatch.Restart();
+
+                                hidDevice.SendJpegFrame(jpegData);
+
+                                fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                                _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "ThermaltakeDevice {Device}: Send error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: e.Message);
+                }
+                finally
+                {
+                    renderCts.Cancel();
+                }
+            }, token);
+
+            await Task.WhenAll(renderTask, sendTask);
+
+            frameAvailable.Dispose();
+            renderCts.Dispose();
+        }
+
+        private byte[] GenerateJpegBuffer()
+        {
+            var profileGuid = _device.ProfileGuid;
+
+            if (ConfigModel.Instance.GetProfile(profileGuid) is Profile profile)
+            {
+                var rotation = _device.Rotation;
+
+                using var bitmap = PanelDrawTask.RenderSK(profile, false,
+                    colorType: SKColorType.Rgba8888,
+                    alphaType: SKAlphaType.Opaque);
+
+                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
+
+                SKBitmap encodeBitmap = resizedBitmap;
+                SKBitmap? dimmed = null;
+                try
+                {
+                    if (_device.Brightness < 100)
+                    {
+                        dimmed = ApplyBrightness(resizedBitmap);
+                        encodeBitmap = dimmed;
+                    }
+
+                int quality = _device.JpegQuality;
+                using var image = SKImage.FromBitmap(encodeBitmap);
+                using var data = image.Encode(SKEncodedImageFormat.Jpeg, quality);
+                return data.ToArray();
+                }
+                finally
+                {
+                    dimmed?.Dispose();
+                }
+            }
+
+            // No profile selected: return a black JPEG
+            return GenerateBlackJpeg();
+        }
+
+        private SKBitmap ApplyBrightness(SKBitmap source)
+        {
+            float scale = Math.Clamp(_device.Brightness, 0, 100) / 100f;
+            var result = new SKBitmap(source.Width, source.Height, source.ColorType, source.AlphaType);
+            using var canvas = new SKCanvas(result);
+            using var paint = new SKPaint();
+            paint.ColorFilter = SKColorFilter.CreateColorMatrix(
+            [
+                scale, 0,     0,     0, 0,
+                0,     scale, 0,     0, 0,
+                0,     0,     scale, 0, 0,
+                0,     0,     0,     1, 0
+            ]);
+            canvas.DrawBitmap(source, 0, 0, paint);
+            return result;
+        }
+
+        private byte[]? _cachedBlackJpeg;
+
+        private byte[] GenerateBlackJpeg()
+        {
+            if (_cachedBlackJpeg != null) return _cachedBlackJpeg;
+
+            using var bitmap = new SKBitmap(_panelWidth, _panelHeight, SKColorType.Rgba8888, SKAlphaType.Opaque);
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(SKColors.Black);
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Jpeg, 50);
+            _cachedBlackJpeg = data.ToArray();
+            return _cachedBlackJpeg;
+        }
+    }
+}

--- a/InfoPanel/Services/ThermaltakePanelTask.cs
+++ b/InfoPanel/Services/ThermaltakePanelTask.cs
@@ -1,0 +1,123 @@
+using InfoPanel.Models;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class ThermaltakePanelTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<ThermaltakePanelTask>();
+        private static readonly Lazy<ThermaltakePanelTask> _instance = new(() => new ThermaltakePanelTask());
+
+        private readonly ConcurrentDictionary<string, ThermaltakePanelDeviceTask> _deviceTasks = new();
+
+        public static ThermaltakePanelTask Instance => _instance.Value;
+
+        private ThermaltakePanelTask() { }
+
+        public override async Task StopAsync(bool shutdown = false)
+        {
+            await base.StopAsync(shutdown);
+            await StopAllDevices();
+        }
+
+        public async Task StartDevice(ThermaltakePanelDevice device)
+        {
+            if (_deviceTasks.TryGetValue(device.Id, out var task))
+            {
+                await task.StopAsync();
+                _deviceTasks.TryRemove(device.Id, out _);
+            }
+
+            var deviceTask = new ThermaltakePanelDeviceTask(device);
+            if (_deviceTasks.TryAdd(device.Id, deviceTask))
+            {
+                await deviceTask.StartAsync(CancellationToken);
+                Logger.Information("Started Thermaltake panel device {Device}", device);
+            }
+        }
+
+        public async Task StopDevice(string deviceId)
+        {
+            if (_deviceTasks.TryRemove(deviceId, out var deviceTask))
+            {
+                await deviceTask.StopAsync();
+                Logger.Information("Stopped Thermaltake panel device {DeviceId}", deviceId);
+            }
+        }
+
+        public async Task StopAllDevices()
+        {
+            var tasks = new List<Task>();
+            foreach (var kvp in _deviceTasks.ToList())
+            {
+                if (_deviceTasks.TryRemove(kvp.Key, out var deviceTask))
+                    tasks.Add(Task.Run(async () => await deviceTask.StopAsync()));
+            }
+            await Task.WhenAll(tasks);
+            Logger.Information("Stopped all Thermaltake panel devices");
+        }
+
+        public bool IsDeviceRunning(string deviceId)
+        {
+            return _deviceTasks.TryGetValue(deviceId, out var task) && task.IsRunning;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            await Task.Delay(300, token);
+
+            try
+            {
+                var settings = ConfigModel.Instance.Settings;
+                if (settings.ThermaltakePanelMultiDeviceMode)
+                    await RunMultiDeviceMode(token);
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception e)
+            {
+                Logger.Error(e, "ThermaltakePanel: Error in DoWorkAsync");
+            }
+        }
+
+        private async Task RunMultiDeviceMode(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var settings = ConfigModel.Instance.Settings;
+                    if (!settings.ThermaltakePanelMultiDeviceMode) break;
+
+                    var enabledConfigs = settings.ThermaltakePanelDevices.Where(d => d.Enabled).ToList();
+
+                    foreach (var config in enabledConfigs)
+                    {
+                        if (!IsDeviceRunning(config.Id))
+                            await StartDevice(config);
+                    }
+
+                    var runningDeviceIds = _deviceTasks.Keys.ToList();
+                    foreach (var deviceId in runningDeviceIds)
+                    {
+                        if (!enabledConfigs.Any(c => c.Id == deviceId))
+                            await StopDevice(deviceId);
+                    }
+
+                    await Task.Delay(1000, token);
+                }
+                catch (TaskCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "ThermaltakePanel: Error in RunMultiDeviceMode");
+                    await Task.Delay(1000, token);
+                }
+            }
+        }
+    }
+}

--- a/InfoPanel/ThermaltakePanel/ThermaltakeHidDevice.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakeHidDevice.cs
@@ -1,0 +1,243 @@
+using HidSharp;
+using Serilog;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace InfoPanel.ThermaltakePanel
+{
+    /// <summary>
+    /// HID communication for Thermaltake LCD panels (VID 264A).
+    /// Protocol: text-based HTTP-like POST commands over 1024-byte HID reports.
+    /// The HID descriptor declares NO report IDs, so byte[0] must be 0x00 (null report ID).
+    /// </summary>
+    public class ThermaltakeHidDevice : IDisposable
+    {
+        private static readonly ILogger Logger = Log.ForContext<ThermaltakeHidDevice>();
+
+        private const int WIRE_PACKET_SIZE = 1024;
+        private const int REPORT_SIZE = WIRE_PACKET_SIZE + 1; // +1 for null report ID
+        private const int IMAGE_HEADER_SIZE = 24;
+        private const int IMAGE_PAYLOAD_PER_CHUNK = WIRE_PACKET_SIZE - IMAGE_HEADER_SIZE; // 1000
+
+        // Exact handshake packets captured from TT RGB Plus
+        private static readonly byte[] CONN_PACKET = HexToBytes(
+            "5a0048504f535420636f6e6e20310d0a5365714e756d6265723d3131320d0a" +
+            "436f6e74656e74547970653d6a736f6e0d0a436f6e74656e744c656e677468" +
+            "3d3234300d0a0d0a075a00");
+
+        private static readonly byte[] REALTIME_ENABLE_PACKET = HexToBytes(
+            "5a0061504f5354207265616c74696d65446973706c617920310d0a5365714e" +
+            "756d6265723d3131320d0a436f6e74656e74547970653d6a736f6e0d0a436f" +
+            "6e74656e744c656e6774683d31350d0a0d0a7b22656e61626c65223a747275" +
+            "657d085a00");
+
+        private static readonly byte[] REALTIME_DISABLE_PACKET = HexToBytes(
+            "5a0062504f5354207265616c74696d65446973706c617920310d0a5365714e" +
+            "756d6265723d3131320d0a436f6e74656e74547970653d6a736f6e0d0a436f" +
+            "6e74656e744c656e6774683d31360d0a0d0a7b22656e61626c65223a66616c" +
+            "73657d035a00");
+
+        private HidStream? _stream;
+        private bool _disposed;
+
+        public bool IsOpen => _stream != null;
+
+        /// <summary>
+        /// Opens a Thermaltake LCD HID device by VID/PID.
+        /// </summary>
+        public static ThermaltakeHidDevice? Open(int vendorId, int productId)
+        {
+            Logger.Information("ThermaltakeHidDevice: Scanning for VID={Vid:X4} PID={Pid:X4}", vendorId, productId);
+
+            var deviceList = DeviceList.Local;
+            var hidDevices = deviceList.GetHidDevices(vendorId, productId).ToList();
+
+            if (hidDevices.Count == 0)
+            {
+                Logger.Warning("ThermaltakeHidDevice: No HID device found");
+                return null;
+            }
+
+            foreach (var device in hidDevices)
+            {
+                try
+                {
+                    if (device.GetMaxOutputReportLength() < REPORT_SIZE)
+                    {
+                        Logger.Debug("ThermaltakeHidDevice: Skipping {Path}, MaxOut={MaxOut} < {Required}",
+                            device.DevicePath, device.GetMaxOutputReportLength(), REPORT_SIZE);
+                        continue;
+                    }
+
+                    var stream = device.Open();
+                    stream.WriteTimeout = 5000;
+                    stream.ReadTimeout = 2000;
+
+                    Logger.Information("ThermaltakeHidDevice: Opened {Path}", device.DevicePath);
+                    return new ThermaltakeHidDevice { _stream = stream };
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "ThermaltakeHidDevice: Failed to open {Path}", device.DevicePath);
+                }
+            }
+
+            Logger.Error("ThermaltakeHidDevice: Could not open any device");
+            return null;
+        }
+
+        /// <summary>
+        /// Performs the full handshake: conn, realtimeDisplay enable.
+        /// Returns true if all commands received 200 OK responses.
+        /// </summary>
+        public bool Handshake()
+        {
+            Logger.Information("ThermaltakeHidDevice: Starting handshake");
+
+            // POST conn
+            if (!SendPacketAndCheckResponse(CONN_PACKET, "conn"))
+                return false;
+
+            // POST realtimeDisplay enable
+            if (!SendPacketAndCheckResponse(REALTIME_ENABLE_PACKET, "realtimeDisplay"))
+                return false;
+
+            Logger.Information("ThermaltakeHidDevice: Handshake complete");
+            return true;
+        }
+
+        /// <summary>
+        /// Sends a JPEG image frame as chunked image data.
+        /// </summary>
+        public void SendJpegFrame(byte[] jpegData)
+        {
+            if (_stream == null) throw new InvalidOperationException("Device not open");
+
+            int totalChunks = (jpegData.Length + IMAGE_PAYLOAD_PER_CHUNK - 1) / IMAGE_PAYLOAD_PER_CHUNK;
+
+            for (int chunk = 0; chunk < totalChunks; chunk++)
+            {
+                int offset = chunk * IMAGE_PAYLOAD_PER_CHUNK;
+                int payloadSize = Math.Min(IMAGE_PAYLOAD_PER_CHUNK, jpegData.Length - offset);
+
+                var wireData = new byte[WIRE_PACKET_SIZE];
+                wireData[0] = 0x5C;  // Image magic
+                wireData[1] = 0x03;
+                wireData[2] = 0xFD;  // CMD: image data
+                wireData[3] = 0x00;  // area index
+                wireData[4] = (byte)((totalChunks >> 8) & 0xFF); // total chunks BE16
+                wireData[5] = (byte)(totalChunks & 0xFF);
+                wireData[6] = (byte)((chunk >> 8) & 0xFF);       // chunk index BE16
+                wireData[7] = (byte)(chunk & 0xFF);
+                wireData[8] = 0x01;  // flag
+                // bytes 9-23: zeros (already)
+                Array.Copy(jpegData, offset, wireData, IMAGE_HEADER_SIZE, payloadSize);
+
+                WritePacket(wireData);
+            }
+        }
+
+        /// <summary>
+        /// Disables realtime display mode (returns LCD to standby).
+        /// </summary>
+        public void DisableRealtimeDisplay()
+        {
+            try
+            {
+                SendPacketAndCheckResponse(REALTIME_DISABLE_PACKET, "realtimeDisplay disable");
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "ThermaltakeHidDevice: Failed to disable realtime display (device may be disconnected)");
+            }
+        }
+
+        /// <summary>
+        /// Reads a response from the device. Returns the ASCII text portion, or null on timeout.
+        /// </summary>
+        public string? ReadResponse()
+        {
+            if (_stream == null) return null;
+
+            try
+            {
+                var buffer = new byte[REPORT_SIZE];
+                int bytesRead = _stream.Read(buffer, 0, buffer.Length);
+
+                if (bytesRead > 4)
+                {
+                    // Response format: [00 report_id] [5A] [flags] [len] [text...]
+                    // Extract all printable ASCII from the entire buffer
+                    var sb = new StringBuilder();
+                    for (int i = 1; i < bytesRead; i++)
+                    {
+                        byte b = buffer[i];
+                        if (b >= 32 && b <= 126)
+                            sb.Append((char)b);
+                        else if (b == 13 || b == 10)
+                            sb.Append((char)b);
+                        // Don't break on nulls - response has nulls mixed with text (5A 00 len format)
+                    }
+                    return sb.Length > 0 ? sb.ToString() : null;
+                }
+            }
+            catch (TimeoutException) { }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "ThermaltakeHidDevice: Read error");
+            }
+
+            return null;
+        }
+
+        private bool SendPacketAndCheckResponse(byte[] wireData, string commandName)
+        {
+            WritePacket(wireData);
+
+            System.Threading.Thread.Sleep(50);
+
+            var response = ReadResponse();
+            if (response != null && response.Contains("200"))
+            {
+                Logger.Information("ThermaltakeHidDevice: {Command} OK", commandName);
+                return true;
+            }
+
+            Logger.Warning("ThermaltakeHidDevice: {Command} failed, response: {Response}", commandName, response ?? "(none)");
+            return false;
+        }
+
+        /// <summary>
+        /// Writes a 1024-byte packet to the HID device, prepending the 0x00 null report ID.
+        /// </summary>
+        private void WritePacket(byte[] wireData)
+        {
+            if (_stream == null) throw new InvalidOperationException("Device not open");
+
+            var report = new byte[REPORT_SIZE];
+            report[0] = 0x00; // Null report ID (device has no report IDs in descriptor)
+            Array.Copy(wireData, 0, report, 1, Math.Min(wireData.Length, WIRE_PACKET_SIZE));
+
+            _stream.Write(report, 0, report.Length);
+        }
+
+        private static byte[] HexToBytes(string hex)
+        {
+            return Enumerable.Range(0, hex.Length / 2)
+                .Select(i => Convert.ToByte(hex.Substring(i * 2, 2), 16))
+                .ToArray();
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                try { DisableRealtimeDisplay(); } catch { }
+                _stream?.Dispose();
+                _stream = null;
+            }
+        }
+    }
+}

--- a/InfoPanel/ThermaltakePanel/ThermaltakePanelHelper.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakePanelHelper.cs
@@ -1,0 +1,109 @@
+using HidSharp;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InfoPanel.ThermaltakePanel
+{
+    public class ThermaltakePanelDiscoveryInfo
+    {
+        public string DeviceId { get; set; } = "";
+        public string DeviceLocation { get; set; } = "";
+        public string DevicePath { get; set; } = "";
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
+        public ThermaltakePanelModel Model { get; set; }
+        public ThermaltakePanelModelInfo? ModelInfo { get; set; }
+    }
+
+    public static class ThermaltakePanelHelper
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(ThermaltakePanelHelper));
+
+        private const int MIN_OUTPUT_REPORT_LENGTH = 1025; // 1024 data + 1 null report ID
+
+        /// <summary>
+        /// Scans for connected Thermaltake LCD panels via HidSharp.
+        /// </summary>
+        public static List<ThermaltakePanelDiscoveryInfo> ScanDevices()
+        {
+            var devices = new List<ThermaltakePanelDiscoveryInfo>();
+
+            foreach (var (vendorId, productId) in ThermaltakePanelModelDatabase.SupportedDevices)
+            {
+                Logger.Information("ThermaltakePanelHelper: Scanning VID={Vid:X4} PID={Pid:X4}", vendorId, productId);
+
+                var deviceList = DeviceList.Local;
+                var hidDevices = deviceList.GetHidDevices(vendorId, productId).ToList();
+
+                foreach (var hidDevice in hidDevices)
+                {
+                    try
+                    {
+                        if (hidDevice.GetMaxOutputReportLength() < MIN_OUTPUT_REPORT_LENGTH)
+                        {
+                            Logger.Debug("ThermaltakePanelHelper: Skipping {Path}, MaxOut={MaxOut}",
+                                hidDevice.DevicePath, hidDevice.GetMaxOutputReportLength());
+                            continue;
+                        }
+
+                        var modelInfo = ThermaltakePanelModelDatabase.GetModelByVidPid(vendorId, productId);
+                        if (modelInfo == null) continue;
+
+                        // Extract DeviceId from path (e.g., VID_264A&PID_2347\SERIAL)
+                        string deviceId = ExtractDeviceId(hidDevice.DevicePath);
+                        string deviceLocation = ExtractDeviceLocation(hidDevice.DevicePath);
+
+                        Logger.Information("ThermaltakePanelHelper: Found {Model} at {Path}",
+                            modelInfo.Name, hidDevice.DevicePath);
+
+                        devices.Add(new ThermaltakePanelDiscoveryInfo
+                        {
+                            DeviceId = deviceId,
+                            DeviceLocation = deviceLocation,
+                            DevicePath = hidDevice.DevicePath,
+                            VendorId = vendorId,
+                            ProductId = productId,
+                            Model = modelInfo.Model,
+                            ModelInfo = modelInfo,
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warning(ex, "ThermaltakePanelHelper: Error scanning {Path}", hidDevice.DevicePath);
+                    }
+                }
+            }
+
+            Logger.Information("ThermaltakePanelHelper: Found {Count} device(s)", devices.Count);
+            return devices;
+        }
+
+        private static string ExtractDeviceId(string devicePath)
+        {
+            // HID path: \\?\hid#vid_264a&pid_2347#serial#{guid}
+            try
+            {
+                var parts = devicePath.Split('#');
+                if (parts.Length >= 3)
+                    return $"{parts[1]}\\{parts[2]}";
+            }
+            catch { }
+            return devicePath;
+        }
+
+        private static string ExtractDeviceLocation(string devicePath)
+        {
+            // Extract hub/port info from path
+            try
+            {
+                var parts = devicePath.Split('#');
+                if (parts.Length >= 3)
+                    return parts[2];
+            }
+            catch { }
+            return "";
+        }
+    }
+}

--- a/InfoPanel/ThermaltakePanel/ThermaltakePanelModel.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakePanelModel.cs
@@ -1,0 +1,8 @@
+namespace InfoPanel.ThermaltakePanel
+{
+    public enum ThermaltakePanelModel
+    {
+        Unknown,
+        ToughLiquid6Inch,       // PID 0x2347, 1480x720
+    }
+}

--- a/InfoPanel/ThermaltakePanel/ThermaltakePanelModelDatabase.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakePanelModelDatabase.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InfoPanel.ThermaltakePanel
+{
+    public static class ThermaltakePanelModelDatabase
+    {
+        public const int THERMALTAKE_VENDOR_ID = 0x264A;
+        public const int THERMALTAKE_PRODUCT_ID_6INCH = 0x2347;
+
+        public static readonly (int Vid, int Pid)[] SupportedDevices =
+        [
+            (THERMALTAKE_VENDOR_ID, THERMALTAKE_PRODUCT_ID_6INCH),
+        ];
+
+        public static readonly Dictionary<ThermaltakePanelModel, ThermaltakePanelModelInfo> Models = new()
+        {
+            [ThermaltakePanelModel.ToughLiquid6Inch] = new ThermaltakePanelModelInfo
+            {
+                Model = ThermaltakePanelModel.ToughLiquid6Inch,
+                Name = "Thermaltake 6\" LCD",
+                Width = 1480,
+                Height = 720,
+                VendorId = THERMALTAKE_VENDOR_ID,
+                ProductId = THERMALTAKE_PRODUCT_ID_6INCH,
+            },
+        };
+
+        public static ThermaltakePanelModelInfo? GetModelByVidPid(int vid, int pid)
+        {
+            return Models.Values.FirstOrDefault(m => m.VendorId == vid && m.ProductId == pid);
+        }
+    }
+}

--- a/InfoPanel/ThermaltakePanel/ThermaltakePanelModelInfo.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakePanelModelInfo.cs
@@ -1,0 +1,12 @@
+namespace InfoPanel.ThermaltakePanel
+{
+    public class ThermaltakePanelModelInfo
+    {
+        public ThermaltakePanelModel Model { get; init; }
+        public string Name { get; init; } = "Unknown Model";
+        public int Width { get; init; }
+        public int Height { get; init; }
+        public int VendorId { get; init; }
+        public int ProductId { get; init; }
+    }
+}

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -908,6 +908,304 @@
         </ui:CardExpander>
         <!--  end ThermalrightPanel Multi-Device settings  -->
 
+        <!--  ThermaltakePanel Multi-Device settings  -->
+        <ui:CardExpander
+            Margin="0,10,0,0"
+            IsExpanded="True">
+            <ui:CardExpander.Icon>
+                <ui:SymbolIcon Symbol="Whiteboard24" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock
+                            FontSize="13"
+                            FontWeight="Medium"
+                            Text="Thermaltake Displays" />
+                        <TextBlock
+                            Margin="0,5,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                            Text="Configure and run Thermaltake USB LCD panels." />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,10,0" Orientation="Horizontal">
+                            <ui:ToggleSwitch
+                                Grid.Column="1"
+                                Margin="0,0,10,0"
+                                IsChecked="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.ThermaltakePanelMultiDeviceMode}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <ui:Button
+                        Grid.Column="1"
+                        Margin="0,0,0,0"
+                        HorizontalAlignment="Right"
+                        Appearance="Primary"
+                        Click="ButtonDiscoverThermaltakePanelDevices_Click"
+                        Content="Discover Devices"
+                        Icon="{ui:SymbolIcon Search20}"
+                        Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.ThermaltakePanelMultiDeviceMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+
+                <!--  ThermaltakePanel Device List  -->
+                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.ThermaltakePanelDevices}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ui:CardControl Margin="0,0,0,10">
+                                <ui:CardControl.Header>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock FontSize="13" FontWeight="Medium">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0}">
+                                                        <Binding Path="RuntimeProperties.Name" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                                TextWrapping="Wrap">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                                        <Binding Path="DeviceId" />
+                                                        <Binding Path="DeviceLocation" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}Dimensions: {0}x{1}">
+                                                        <Binding Path="DisplayWidth" />
+                                                        <Binding Path="DisplayHeight" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <!--  Panel status when enabled  -->
+                                            <StackPanel Visibility="{Binding Enabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <!--  Show when running  -->
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Orientation="Horizontal"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="Panel is running:" />
+                                                    <TextBlock
+                                                        Margin="10,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="{Binding RuntimeProperties.FrameRate, StringFormat='{}{0} FPS'}" />
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="{Binding RuntimeProperties.FrameTime, StringFormat=' @ {0}ms'}" />
+                                                </StackPanel>
+
+                                                <!--  Show when not running  -->
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="Orange"
+                                                        Text="Display is not running. Check your USB connection and try again." />
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="Orange"
+                                                        Text="{Binding RuntimeProperties.ErrorMessage}"
+                                                        Visibility="{Binding RuntimeProperties.ErrorMessage, Converter={StaticResource StringToVisibilityConverter}}" />
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                </ui:CardControl.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <!--  Advanced settings popup  -->
+                                    <StackPanel Margin="10,0,0,0" VerticalAlignment="Top">
+                                        <ui:Button
+                                            Width="160"
+                                            Appearance="Secondary"
+                                            Content="Advanced"
+                                            Icon="{ui:SymbolIcon Settings20}"
+                                            Click="ButtonAdvancedPopup_Click" />
+                                        <Popup
+                                            AllowsTransparency="True"
+                                            Placement="Bottom"
+                                            StaysOpen="False">
+                                            <Border
+                                                Padding="15"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8">
+                                                <StackPanel Width="250">
+                                                    <!--  Brightness (hardware)  -->
+                                                    <StackPanel>
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="0"
+                                                            TickFrequency="1"
+                                                            Value="{Binding Brightness}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Brightness" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding Brightness}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  Target FPS  -->
+                                                    <StackPanel Margin="0,10,0,0">
+                                                            <Slider
+                                                                IsSnapToTickEnabled="True"
+                                                                Maximum="30"
+                                                                Minimum="1"
+                                                                TickFrequency="1"
+                                                                Value="{Binding TargetFrameRate}" />
+                                                            <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="Auto" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock
+                                                                    Margin="5,0,0,0"
+                                                                    FontSize="12"
+                                                                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                    Text="Target FPS" />
+                                                                <TextBlock
+                                                                    Grid.Column="1"
+                                                                    Margin="5,0,0,0"
+                                                                    FontSize="12"
+                                                                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                    Text="{Binding TargetFrameRate}" />
+                                                            </Grid>
+                                                        </StackPanel>
+                                                        <!--  JPEG Quality  -->
+                                                        <StackPanel Margin="0,10,0,0">
+                                                            <Slider
+                                                                IsSnapToTickEnabled="True"
+                                                                Maximum="100"
+                                                                Minimum="50"
+                                                                TickFrequency="5"
+                                                                Value="{Binding JpegQuality}" />
+                                                            <Grid>
+                                                                <Grid.ColumnDefinitions>
+                                                                    <ColumnDefinition Width="*" />
+                                                                    <ColumnDefinition Width="Auto" />
+                                                                </Grid.ColumnDefinitions>
+                                                                <TextBlock
+                                                                    Margin="5,0,0,0"
+                                                                    FontSize="12"
+                                                                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                    Text="JPEG Quality" />
+                                                                <TextBlock
+                                                                    Grid.Column="1"
+                                                                    Margin="5,0,0,0"
+                                                                    FontSize="12"
+                                                                    Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                    Text="{Binding JpegQuality}" />
+                                                            </Grid>
+                                                        </StackPanel>
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </StackPanel>
+                                    <StackPanel Margin="10,0,0,0">
+                                        <!--  Profile selection  -->
+                                        <ComboBox
+                                            Width="250"
+                                            Margin="0,0,0,0"
+                                            DisplayMemberPath="Name"
+                                            ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Profiles}"
+                                            SelectedValue="{Binding ProfileGuid}"
+                                            SelectedValuePath="Guid" />
+                                        <!--  Rotation  -->
+                                        <ComboBox
+                                            Margin="0,10,0,0"
+                                            ItemsSource="{Binding Path=ViewModel.RotationValues, RelativeSource={RelativeSource AncestorType=pages:UsbPanelsPage}}"
+                                            SelectedItem="{Binding Rotation}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Converter={StaticResource EnumToDescriptionConverter}}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <Grid Margin="20,0,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <!--  Enable toggle  -->
+                                        <ui:ToggleSwitch
+                                            Margin="0,0,0,0"
+                                            VerticalAlignment="Center"
+                                            IsChecked="{Binding Enabled}" />
+                                        <!--  Remove button  -->
+                                        <ui:Button
+                                            Grid.Row="1"
+                                            Width="32"
+                                            Height="32"
+                                            Margin="0,10,0,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Bottom"
+                                            Appearance="Danger"
+                                            BorderThickness="0"
+                                            Click="ButtonRemoveThermaltakePanelDevice_Click"
+                                            Icon="{ui:SymbolIcon Delete20}"
+                                            Tag="{Binding}"
+                                            ToolTip="Remove Device" />
+                                    </Grid>
+                                </StackPanel>
+                            </ui:CardControl>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ui:CardExpander>
+        <!--  end ThermaltakePanel Multi-Device settings  -->
+
         <!--  Global Hotkeys  -->
         <ui:CardExpander Margin="0,20,0,0" IsExpanded="False">
             <ui:CardExpander.Icon>

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -3,6 +3,7 @@ using InfoPanel.Models;
 using InfoPanel.Services;
 using InfoPanel.TuringPanel;
 using InfoPanel.ThermalrightPanel;
+using InfoPanel.ThermaltakePanel;
 using InfoPanel.ViewModels;
 using InfoPanel.Views.Windows;
 using LibUsbDotNet;
@@ -553,6 +554,87 @@ public partial class UsbPanelsPage : Page
                     }
 
                     settings.ThermalrightPanelDevices.Remove(deviceConfig);
+                }
+            });
+        }
+    }
+
+    // === Thermaltake Panel ===
+
+    private async void ButtonDiscoverThermaltakePanelDevices_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button)
+        {
+            button.IsEnabled = false;
+            await UpdateThermaltakePanelDeviceList();
+            button.IsEnabled = true;
+        }
+    }
+
+    private Task UpdateThermaltakePanelDeviceList()
+    {
+        var discoveredDevices = ThermaltakePanelHelper.ScanDevices();
+
+        Logger.Information("ThermaltakePanel Discovery: Found {Count} devices", discoveredDevices.Count);
+
+        foreach (var discoveredDevice in discoveredDevices)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var device = settings.ThermaltakePanelDevices.FirstOrDefault(d =>
+                    d.IsMatching(discoveredDevice.DeviceId, discoveredDevice.DeviceLocation, discoveredDevice.Model));
+
+                if (device == null)
+                {
+                    var newDevice = new ThermaltakePanelDevice()
+                    {
+                        DeviceId = discoveredDevice.DeviceId,
+                        DeviceLocation = discoveredDevice.DeviceLocation,
+                        Model = discoveredDevice.Model,
+                        ProfileGuid = ConfigModel.Instance.Profiles.FirstOrDefault()?.Guid ?? Guid.Empty
+                    };
+
+                    if (discoveredDevice.ModelInfo != null)
+                    {
+                        newDevice.RuntimeProperties.Name = $"Thermaltake {discoveredDevice.ModelInfo.Name}";
+                    }
+
+                    settings.ThermaltakePanelDevices.Add(newDevice);
+                    Logger.Information("ThermaltakePanel Discovery: Added new device '{DeviceId}'", discoveredDevice.DeviceId);
+                }
+                else
+                {
+                    device.DeviceLocation = discoveredDevice.DeviceLocation;
+
+                    if (device.ModelInfo != null)
+                    {
+                        device.RuntimeProperties.Name = $"Thermaltake {device.ModelInfo.Name}";
+                    }
+
+                    Logger.Information("ThermaltakePanel Discovery: Device '{DeviceId}' already exists", discoveredDevice.DeviceId);
+                }
+            });
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ButtonRemoveThermaltakePanelDevice_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is ThermaltakePanelDevice runtimeDevice)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var deviceConfig = settings.ThermaltakePanelDevices.FirstOrDefault(c => c.Id == runtimeDevice.Id);
+
+                if (deviceConfig != null)
+                {
+                    if (ThermaltakePanelTask.Instance.IsDeviceRunning(deviceConfig.Id))
+                    {
+                        _ = ThermaltakePanelTask.Instance.StopDevice(deviceConfig.Id);
+                    }
+
+                    settings.ThermaltakePanelDevices.Remove(deviceConfig);
                 }
             });
         }


### PR DESCRIPTION
## Summary
- Add support for Thermaltake TOUGHLIQUID ULTRA 6" LCD panels (VID 0x264A, PID 0x2347)
- Protocol reverse-engineered from USB captures of TT RGB Plus software
- Achieves ~23fps at 1480x720, JPEG quality 85

## Device details
- HID device manufactured by "BY" OEM, branded as Thermaltake
- HID descriptor declares NO report IDs (requires null report ID byte 0x00)
- Text-based HTTP-like POST protocol for handshake (conn, realtimeDisplay)
- JPEG image streaming via chunked 1024-byte HID reports with 24-byte header
- Software brightness via color matrix (same approach as Thermalright panels)

## Changes
**New files (8):**
- `InfoPanel/ThermaltakePanel/` - HID device communication, model database, device discovery
- `InfoPanel/Models/ThermaltakePanelDevice.cs` - device configuration model (MVVM)
- `InfoPanel/Services/ThermaltakePanelTask.cs` - singleton multi-device task manager
- `InfoPanel/Services/ThermaltakePanelDeviceTask.cs` - per-device render/send loop

**Modified (5):**
- `Settings.cs`, `ConfigModel.cs` - persistence for Thermaltake device configs
- `App.xaml.cs` - lifecycle integration (start/stop/suspend)
- `UsbPanelsPage.xaml/.cs` - UI section for discover, configure, and enable

🤖 Generated with [Claude Code](https://claude.com/claude-code)