### PR TITLE
Add rotation support for text, bar, graph, and gauge items

### DIFF
--- a/InfoPanel/Drawing/GraphDraw.cs
+++ b/InfoPanel/Drawing/GraphDraw.cs
@@ -443,7 +443,7 @@ namespace InfoPanel.Drawing
 
                             var offset = 1;
                             g.FillDonut((int)frameRect.Left + offset, (int)frameRect.Top + offset, ((int)frameRect.Width / 2) - offset, donutDisplayItem.Thickness,
-                                 donutDisplayItem.Rotation, (int)value, donutDisplayItem.Span, donutDisplayItem.Color,
+                                 0, (int)value, donutDisplayItem.Span, donutDisplayItem.Color,
                                 donutDisplayItem.Background ? donutDisplayItem.BackgroundColor : "#00000000",
                                 donutDisplayItem.Frame ? 1 : 0, donutDisplayItem.FrameColor);
 

--- a/InfoPanel/Drawing/PanelDraw.cs
+++ b/InfoPanel/Drawing/PanelDraw.cs
@@ -382,11 +382,11 @@ namespace InfoPanel.Drawing
 
                         if (chartDisplayItem.FlipX)
                         {
-                            g.DrawBitmap(graphBitmap, x, y, width, height, flipX: true);
+                            g.DrawBitmap(graphBitmap, x, y, width, height, rotation: chartDisplayItem.Rotation, flipX: true);
                         }
                         else
                         {
-                            g.DrawBitmap(graphBitmap, x, y, width, height);
+                            g.DrawBitmap(graphBitmap, x, y, width, height, rotation: chartDisplayItem.Rotation);
                         }
 
                         break;
@@ -921,10 +921,12 @@ namespace InfoPanel.Drawing
             var glowColor = textDisplayItem.GlowEnabled && !string.IsNullOrEmpty(textDisplayItem.GlowColor) ? textDisplayItem.GlowColor : null;
             var glowBlendMode = textDisplayItem.GlowEnabled ? textDisplayItem.GlowBlendMode : null;
 
-            g.DrawString(text, textDisplayItem.Font, textDisplayItem.FontStyle, fontSize, color, 
+            var drawHeight = (int)(textDisplayItem.Height * scale);
+
+            g.DrawString(text, textDisplayItem.Font, textDisplayItem.FontStyle, fontSize, color,
                 x, y, textDisplayItem.RightAlign, textDisplayItem.CenterAlign,
-                textDisplayItem.Bold, textDisplayItem.Italic, textDisplayItem.Underline, 
-                textDisplayItem.Strikeout, textDisplayItem.Wrap, textDisplayItem.Ellipsis, drawWidth, 0, glowRadius, glowColor, glowBlendMode);
+                textDisplayItem.Bold, textDisplayItem.Italic, textDisplayItem.Underline,
+                textDisplayItem.Strikeout, textDisplayItem.Wrap, textDisplayItem.Ellipsis, drawWidth, drawHeight, glowRadius, glowColor, glowBlendMode, textDisplayItem.Rotation);
         }
 
     }

--- a/InfoPanel/Drawing/PanelDraw.cs
+++ b/InfoPanel/Drawing/PanelDraw.cs
@@ -355,14 +355,14 @@ namespace InfoPanel.Drawing
                                 scaledWidth = (int)Math.Floor(scaledWidth * gaugeDisplayItem.Scale / 100.0f * scale);
                                 scaledHeight = (int)Math.Floor(scaledHeight * gaugeDisplayItem.Scale / 100.0f * scale);
 
-                                g.DrawImage(cachedA, x, y, scaledWidth, scaledHeight, 0, 0, 0, cache, cacheHint);
+                                g.DrawImage(cachedA, x, y, scaledWidth, scaledHeight, gaugeDisplayItem.Rotation, 0, 0, cache, cacheHint);
 
                                 if (imageB != null && imageB != imageA && blend > 0f)
                                 {
                                     var cachedB = Cache.GetLocalImage(imageB);
                                     if (cachedB != null)
                                     {
-                                        g.DrawImage(cachedB, x, y, scaledWidth, scaledHeight, 0, 0, 0, cache, cacheHint, opacity: blend);
+                                        g.DrawImage(cachedB, x, y, scaledWidth, scaledHeight, gaugeDisplayItem.Rotation, 0, 0, cache, cacheHint, opacity: blend);
                                     }
                                 }
                             }

--- a/InfoPanel/Drawing/SkiaGraphics.cs
+++ b/InfoPanel/Drawing/SkiaGraphics.cs
@@ -177,8 +177,19 @@ namespace InfoPanel.Drawing
 
             if (rotation != 0)
             {
-                int centerX = x + width / 2;
-                int centerY = y + height / 2;
+                int centerX;
+                int centerY;
+                if (width > 0 && height > 0)
+                {
+                    centerX = x + width / 2;
+                    centerY = y + height / 2;
+                }
+                else
+                {
+                    var (measuredWidth, measuredHeight) = MeasureString(text, fontName, fontStyle, fontSize, bold, italic, underline, strikeout, wrap, ellipsis, width, height);
+                    centerX = x + (width > 0 ? width / 2 : (int)(measuredWidth / 2));
+                    centerY = y + (height > 0 ? height / 2 : (int)(measuredHeight / 2));
+                }
                 Canvas.RotateDegrees(rotation, centerX, centerY);
             }
 

--- a/InfoPanel/Drawing/SkiaGraphics.cs
+++ b/InfoPanel/Drawing/SkiaGraphics.cs
@@ -168,10 +168,19 @@ namespace InfoPanel.Drawing
             Canvas.Restore();
         }
 
-        public void DrawString(string text, string fontName, string fontStyle, int fontSize, string color, int x, int y, bool rightAlign = false, bool centerAlign = false, bool bold = false, bool italic = false, bool underline = false, bool strikeout = false, bool wrap = false, bool ellipsis = true, int width = 0, int height = 0, int glowRadius = 0, string? glowColor = null, string? glowBlendMode = null)
+        public void DrawString(string text, string fontName, string fontStyle, int fontSize, string color, int x, int y, bool rightAlign = false, bool centerAlign = false, bool bold = false, bool italic = false, bool underline = false, bool strikeout = false, bool wrap = false, bool ellipsis = true, int width = 0, int height = 0, int glowRadius = 0, string? glowColor = null, string? glowBlendMode = null, int rotation = 0)
         {
             if (string.IsNullOrEmpty(text))
                 return;
+
+            Canvas.Save();
+
+            if (rotation != 0)
+            {
+                int centerX = x + width / 2;
+                int centerY = y + height / 2;
+                Canvas.RotateDegrees(rotation, centerX, centerY);
+            }
 
             if (glowRadius > 0)
             {
@@ -193,10 +202,13 @@ namespace InfoPanel.Drawing
                 DrawStringCore(text, fontName, fontStyle, fontSize, color, x, y, rightAlign, centerAlign, bold, italic, underline, strikeout, wrap, ellipsis, width);
 
                 Canvas.Restore();
+                Canvas.Restore();
                 return;
             }
 
             DrawStringCore(text, fontName, fontStyle, fontSize, color, x, y, rightAlign, centerAlign, bold, italic, underline, strikeout, wrap, ellipsis, width);
+
+            Canvas.Restore();
         }
 
         private static bool TryParseBlendMode(string? value, out SKBlendMode mode)

--- a/InfoPanel/Models/ChartDisplayItem.cs
+++ b/InfoPanel/Models/ChartDisplayItem.cs
@@ -542,23 +542,10 @@ namespace InfoPanel.Models
             }
         }
 
-        private int _rotation = 90;
-        public int Rotation
-        {
-            get { return _rotation; }
-            set
-            {
-                if (value < 0 || value > 360)
-                {
-                    return;
-                }
-                SetProperty(ref _rotation, value);
-            }
-        }
-
         public DonutDisplayItem()
         {
             Name = "Donut";
+            Rotation = 90;
         }
 
         public DonutDisplayItem(string name, Profile profile) : base(name, profile)
@@ -566,6 +553,7 @@ namespace InfoPanel.Models
             Frame = false;
             BackgroundColor = "#FFDCDCDC";
             Width = 100; Height = 100;
+            Rotation = 90;
         }
 
         public DonutDisplayItem(string name, Profile profile, string libreSensorId) : base(name, profile, libreSensorId)
@@ -573,13 +561,15 @@ namespace InfoPanel.Models
             Frame = false;
             BackgroundColor = "#FFDCDCDC";
             Width = 100; Height = 100;
+            Rotation = 90;
         }
 
         public DonutDisplayItem(string name, Profile profile, UInt32 id, UInt32 instance, UInt32 entryId) : base(name, profile, id, instance, entryId)
         {
             Frame = false;
             BackgroundColor = "#FFDCDCDC";
-            Width = 100; Height = 100; 
+            Width = 100; Height = 100;
+            Rotation = 90;
         }
 
         public override object Clone()

--- a/InfoPanel/Views/Components/Chart/BarProperties.xaml
+++ b/InfoPanel/Views/Components/Chart/BarProperties.xaml
@@ -31,6 +31,7 @@
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
@@ -171,7 +172,10 @@
         </Grid>
 
 
-        <Grid Grid.Row="0" Grid.Column="1" Margin="20,0,0,0">
+        <Grid
+            Grid.Row="0"
+            Grid.Column="1"
+            Margin="20,0,0,0">
 
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
@@ -207,7 +211,7 @@
                         <TextBlock.Text>
                             <MultiBinding Converter="{StaticResource SensorSourceConverter}">
                                 <Binding Path="SensorType" />
-                                <Binding Path="HwInfoRemoteIndex" FallbackValue="-1" />
+                                <Binding FallbackValue="-1" Path="HwInfoRemoteIndex" />
                             </MultiBinding>
                         </TextBlock.Text>
                     </TextBlock>
@@ -263,31 +267,39 @@
                 </StackPanel>
             </Grid>
 
-
         </Grid>
 
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,10,0,0">
-            <Slider
-                Maximum="180"
-                Minimum="-180"
-                Value="{Binding Rotation}" />
-            <Grid Margin="5,0,5,0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock
-                    Grid.Column="0"
-                    FontSize="12"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Text="Rotation" />
-                <TextBlock
-                    Grid.Column="1"
-                    FontSize="12"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Text="{Binding Rotation, Mode=OneWay}" />
-            </Grid>
-        </StackPanel>
+        <Grid Grid.Row="1" Margin="0,10,0,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <StackPanel Grid.Column="1">
+                <Slider
+                    Margin="0,0,0,0"
+                    Maximum="180"
+                    Minimum="-180"
+                    Value="{Binding Rotation}" />
+                <Grid Margin="5,0,5,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,0,0"
+                        FontSize="12"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="Rotation °" />
+                    <TextBlock
+                        Grid.Column="1"
+                        Margin="0,0,0,0"
+                        FontSize="12"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="{Binding Rotation, Mode=OneWay}" />
+                </Grid>
+            </StackPanel>
+        </Grid>
 
     </Grid>
 

--- a/InfoPanel/Views/Components/Chart/BarProperties.xaml
+++ b/InfoPanel/Views/Components/Chart/BarProperties.xaml
@@ -18,8 +18,12 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
-        <Grid Margin="0,0,0,0">
+        <Grid Grid.Row="0" Margin="0,0,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -167,7 +171,7 @@
         </Grid>
 
 
-        <Grid Grid.Column="1" Margin="20,0,0,0">
+        <Grid Grid.Row="0" Grid.Column="1" Margin="20,0,0,0">
 
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
@@ -261,6 +265,29 @@
 
 
         </Grid>
+
+        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,10,0,0">
+            <Slider
+                Maximum="180"
+                Minimum="-180"
+                Value="{Binding Rotation}" />
+            <Grid Margin="5,0,5,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock
+                    Grid.Column="0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="Rotation" />
+                <TextBlock
+                    Grid.Column="1"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="{Binding Rotation, Mode=OneWay}" />
+            </Grid>
+        </StackPanel>
 
     </Grid>
 

--- a/InfoPanel/Views/Components/Chart/DonutProperties.xaml
+++ b/InfoPanel/Views/Components/Chart/DonutProperties.xaml
@@ -161,8 +161,8 @@
                     <Slider
                         Grid.Column="1"
                         Margin="0,0,0,0"
-                        Maximum="360"
-                        Minimum="0"
+                        Maximum="180"
+                        Minimum="-180"
                         Value="{Binding Rotation}" />
 
                     <Grid Margin="5,0,5,0">

--- a/InfoPanel/Views/Components/Chart/GraphProperties.xaml
+++ b/InfoPanel/Views/Components/Chart/GraphProperties.xaml
@@ -152,6 +152,7 @@
                     SelectedColor="{Binding BackgroundColor, Mode=TwoWay}" />
             </Grid>
 
+
         </Grid>
 
         <Grid Grid.Row="0" Grid.Column="1" Margin="20,0,0,0">
@@ -282,30 +283,38 @@
             </Grid>
         </Grid>
 
-        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,10,0,0">
-            <Slider
-                Maximum="180"
-                Minimum="-180"
-                Value="{Binding Rotation}" />
-            <Grid Margin="5,0,5,0">
+        <Grid Grid.Row="1" Margin="0,10,0,0">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="auto" />
+                <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <TextBlock
-                Grid.Column="0"
-                FontSize="12"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Text="Rotation" />
-            <TextBlock
-                Grid.Column="1"
-                FontSize="12"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Text="{Binding Rotation, Mode=OneWay}" />
-            </Grid>
-        </StackPanel>
+            <StackPanel Grid.Column="1">
+                <Slider
+                    Margin="0,0,0,0"
+                    Maximum="180"
+                    Minimum="-180"
+                    Value="{Binding Rotation}" />
+                <Grid Margin="5,0,5,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        Margin="0,0,0,0"
+                        FontSize="12"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="Rotation °" />
+                    <TextBlock
+                        Grid.Column="1"
+                        Margin="0,0,0,0"
+                        FontSize="12"
+                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                        Text="{Binding Rotation, Mode=OneWay}" />
+                </Grid>
+            </StackPanel>
+        </Grid>
 
     </Grid>
-
 
 </UserControl>

--- a/InfoPanel/Views/Components/Chart/GraphProperties.xaml
+++ b/InfoPanel/Views/Components/Chart/GraphProperties.xaml
@@ -16,8 +16,12 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
-        <Grid Margin="0,0,0,0">
+        <Grid Grid.Row="0" Margin="0,0,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -150,7 +154,7 @@
 
         </Grid>
 
-        <Grid Grid.Column="1" Margin="20,0,0,0">
+        <Grid Grid.Row="0" Grid.Column="1" Margin="20,0,0,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="auto" />
@@ -277,6 +281,30 @@
                 </StackPanel>
             </Grid>
         </Grid>
+
+        <StackPanel Grid.Row="1" Grid.Column="0" Margin="0,10,0,0">
+            <Slider
+                Maximum="180"
+                Minimum="-180"
+                Value="{Binding Rotation}" />
+            <Grid Margin="5,0,5,0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="auto" />
+            </Grid.ColumnDefinitions>
+            <TextBlock
+                Grid.Column="0"
+                FontSize="12"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="Rotation" />
+            <TextBlock
+                Grid.Column="1"
+                FontSize="12"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="{Binding Rotation, Mode=OneWay}" />
+            </Grid>
+        </StackPanel>
+
     </Grid>
 
 

--- a/InfoPanel/Views/Components/Custom/CustomProperties.xaml
+++ b/InfoPanel/Views/Components/Custom/CustomProperties.xaml
@@ -80,6 +80,28 @@
                     Text="Height" />
             </StackPanel>
 
+            <Slider
+                Margin="0,10,0,0"
+                Maximum="180"
+                Minimum="-180"
+                Value="{Binding Rotation}" />
+            <Grid Margin="5,0,5,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock
+                    Grid.Column="0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="Rotation" />
+                <TextBlock
+                    Grid.Column="1"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="{Binding Rotation, Mode=OneWay}" />
+            </Grid>
+
         </StackPanel>
 
         <StackPanel Grid.Column="1" Margin="10,0,10,0">

--- a/InfoPanel/Views/Components/Custom/CustomProperties.xaml
+++ b/InfoPanel/Views/Components/Custom/CustomProperties.xaml
@@ -92,11 +92,13 @@
                 </Grid.ColumnDefinitions>
                 <TextBlock
                     Grid.Column="0"
+                    Margin="0,0,0,0"
                     FontSize="12"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Text="Rotation" />
+                    Text="Rotation °" />
                 <TextBlock
                     Grid.Column="1"
+                    Margin="0,0,0,0"
                     FontSize="12"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                     Text="{Binding Rotation, Mode=OneWay}" />

--- a/InfoPanel/Views/Components/Image/ImageProperties.xaml
+++ b/InfoPanel/Views/Components/Image/ImageProperties.xaml
@@ -224,7 +224,7 @@
                             Margin="0,0,0,0"
                             FontSize="12"
                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="Rotation" />
+                            Text="Rotation °" />
                         <TextBlock
                             Grid.Column="1"
                             Margin="0,0,0,0"

--- a/InfoPanel/Views/Components/Shape/ShapeProperties.xaml
+++ b/InfoPanel/Views/Components/Shape/ShapeProperties.xaml
@@ -196,7 +196,7 @@
                             Margin="0,0,0,0"
                             FontSize="12"
                             Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                            Text="Rotation" />
+                            Text="Rotation °" />
                         <TextBlock
                             Grid.Column="1"
                             Margin="0,0,0,0"

--- a/InfoPanel/Views/Components/Text/TextProperties.xaml
+++ b/InfoPanel/Views/Components/Text/TextProperties.xaml
@@ -279,26 +279,36 @@
                 </StackPanel>
             </Grid>
 
-            <Slider
-                Margin="0,10,0,0"
-                Maximum="180"
-                Minimum="-180"
-                Value="{Binding Rotation}" />
-            <Grid Margin="5,0,5,0">
+            <Grid Margin="0,10,0,0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="auto" />
+                    <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBlock
-                    Grid.Column="0"
-                    FontSize="12"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Text="Rotation" />
-                <TextBlock
-                    Grid.Column="1"
-                    FontSize="12"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Text="{Binding Rotation, Mode=OneWay}" />
+                <StackPanel Grid.Column="0">
+                    <Slider
+                        Margin="0,0,0,0"
+                        Maximum="180"
+                        Minimum="-180"
+                        Value="{Binding Rotation}" />
+                    <Grid Margin="5,0,5,0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Column="0"
+                            Margin="0,0,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Text="Rotation °" />
+                        <TextBlock
+                            Grid.Column="1"
+                            Margin="0,0,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Text="{Binding Rotation, Mode=OneWay}" />
+                    </Grid>
+                </StackPanel>
             </Grid>
 
         </StackPanel>

--- a/InfoPanel/Views/Components/Text/TextProperties.xaml
+++ b/InfoPanel/Views/Components/Text/TextProperties.xaml
@@ -279,6 +279,28 @@
                 </StackPanel>
             </Grid>
 
+            <Slider
+                Margin="0,10,0,0"
+                Maximum="180"
+                Minimum="-180"
+                Value="{Binding Rotation}" />
+            <Grid Margin="5,0,5,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock
+                    Grid.Column="0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="Rotation" />
+                <TextBlock
+                    Grid.Column="1"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="{Binding Rotation, Mode=OneWay}" />
+            </Grid>
+
         </StackPanel>
 
 


### PR DESCRIPTION
## Summary
- Wire up the existing `Rotation` property (from `DisplayItem` base class) for text, bar, graph, and gauge display items
- Text rendering (`SkiaGraphics.DrawString`) now applies canvas rotation before drawing, including glow effects
- Chart rendering (`PanelDraw` ChartDisplayItem case) passes rotation to `DrawBitmap`
- Gauge rendering passes rotation to both image layers (A and B blend rotate together)
- Add rotation slider (-180 to 180) to TextProperties, BarProperties, GraphProperties, and CustomProperties (gauge) UI panels
- All text-based items (text, sensor, clock, calendar) inherit the support automatically
- Selection bounds and hit-testing already handled rotation, so no changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)