### PR TITLE
Add ASRock Phantom Gaming 360 LCD support

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -424,6 +424,7 @@ namespace InfoPanel
                         await BeadaPanelTask.Instance.StopAsync(true);
                         await TuringPanelTask.Instance.StopAsync(true);
                         await ThermalrightPanelTask.Instance.StopAsync(true);
+                        await ThermaltakePanelTask.Instance.StopAsync(true);
                     });
                     break;
             }

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -227,5 +227,6 @@ namespace InfoPanel.Models
             if (e.PropertyName != nameof(ThermaltakePanelDevice.RuntimeProperties))
                 OnPropertyChanged(nameof(ThermaltakePanelDevices));
         }
+
     }
 }

--- a/InfoPanel/ThermaltakePanel/ThermaltakeHidDevice.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakeHidDevice.cs
@@ -8,7 +8,8 @@ namespace InfoPanel.ThermaltakePanel
 {
     /// <summary>
     /// HID communication for Thermaltake LCD panels (VID 264A).
-    /// Protocol: text-based HTTP-like POST commands over 1024-byte HID reports.
+    /// Protocol: text-based HTTP-like POST commands over 1024-byte HID reports with checksum.
+    /// Same BY OEM protocol as ASRock panels (VID 26CE).
     /// The HID descriptor declares NO report IDs, so byte[0] must be 0x00 (null report ID).
     /// </summary>
     public class ThermaltakeHidDevice : IDisposable
@@ -20,26 +21,14 @@ namespace InfoPanel.ThermaltakePanel
         private const int IMAGE_HEADER_SIZE = 24;
         private const int IMAGE_PAYLOAD_PER_CHUNK = WIRE_PACKET_SIZE - IMAGE_HEADER_SIZE; // 1000
 
-        // Exact handshake packets captured from TT RGB Plus
-        private static readonly byte[] CONN_PACKET = HexToBytes(
-            "5a0048504f535420636f6e6e20310d0a5365714e756d6265723d3131320d0a" +
-            "436f6e74656e74547970653d6a736f6e0d0a436f6e74656e744c656e677468" +
-            "3d3234300d0a0d0a075a00");
-
-        private static readonly byte[] REALTIME_ENABLE_PACKET = HexToBytes(
-            "5a0061504f5354207265616c74696d65446973706c617920310d0a5365714e" +
-            "756d6265723d3131320d0a436f6e74656e74547970653d6a736f6e0d0a436f" +
-            "6e74656e744c656e6774683d31350d0a0d0a7b22656e61626c65223a747275" +
-            "657d085a00");
-
-        private static readonly byte[] REALTIME_DISABLE_PACKET = HexToBytes(
-            "5a0062504f5354207265616c74696d65446973706c617920310d0a5365714e" +
-            "756d6265723d3131320d0a436f6e74656e74547970653d6a736f6e0d0a436f" +
-            "6e74656e744c656e6774683d31360d0a0d0a7b22656e61626c65223a66616c" +
-            "73657d035a00");
+        // Framing: 5A 00 [len] [content] [checksum] 5A 00
+        private const byte FRAME_MARKER = 0x5A;
+        private const byte FRAME_ZERO = 0x00;
+        private const int FRAME_OVERHEAD = 5; // 5A 00 [len] ... [checksum] 5A 00
 
         private HidStream? _stream;
         private bool _disposed;
+        private int _seqNumber = 100;
 
         public bool IsOpen => _stream != null;
 
@@ -96,15 +85,28 @@ namespace InfoPanel.ThermaltakePanel
             Logger.Information("ThermaltakeHidDevice: Starting handshake");
 
             // POST conn
-            if (!SendPacketAndCheckResponse(CONN_PACKET, "conn"))
+            var connPacket = BuildCommandPacket("POST conn 1", hasBody: false);
+            if (!SendPacketAndCheckResponse(connPacket, "conn"))
                 return false;
 
             // POST realtimeDisplay enable
-            if (!SendPacketAndCheckResponse(REALTIME_ENABLE_PACKET, "realtimeDisplay"))
+            var enablePacket = BuildCommandPacket("POST realtimeDisplay 1",
+                body: "{\"enable\":true}", contentType: "json");
+            if (!SendPacketAndCheckResponse(enablePacket, "realtimeDisplay"))
                 return false;
 
             Logger.Information("ThermaltakeHidDevice: Handshake complete");
             return true;
+        }
+
+        /// <summary>
+        /// Sets the hardware brightness (0-100).
+        /// </summary>
+        public bool SetBrightness(int value)
+        {
+            var packet = BuildCommandPacket("POST brightness 1",
+                body: $"{{\"value\":{value}}}", contentType: "json");
+            return SendPacketAndCheckResponse(packet, "brightness");
         }
 
         /// <summary>
@@ -145,7 +147,9 @@ namespace InfoPanel.ThermaltakePanel
         {
             try
             {
-                SendPacketAndCheckResponse(REALTIME_DISABLE_PACKET, "realtimeDisplay disable");
+                var disablePacket = BuildCommandPacket("POST realtimeDisplay 1",
+                    body: "{\"enable\":false}", contentType: "json");
+                SendPacketAndCheckResponse(disablePacket, "realtimeDisplay disable");
             }
             catch (Exception ex)
             {
@@ -167,8 +171,6 @@ namespace InfoPanel.ThermaltakePanel
 
                 if (bytesRead > 4)
                 {
-                    // Response format: [00 report_id] [5A] [flags] [len] [text...]
-                    // Extract all printable ASCII from the entire buffer
                     var sb = new StringBuilder();
                     for (int i = 1; i < bytesRead; i++)
                     {
@@ -177,7 +179,6 @@ namespace InfoPanel.ThermaltakePanel
                             sb.Append((char)b);
                         else if (b == 13 || b == 10)
                             sb.Append((char)b);
-                        // Don't break on nulls - response has nulls mixed with text (5A 00 len format)
                     }
                     return sb.Length > 0 ? sb.ToString() : null;
                 }
@@ -189,6 +190,53 @@ namespace InfoPanel.ThermaltakePanel
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Builds a framed command packet with SeqNumber, Date, and checksum.
+        /// Frame: 5A 00 [len] [content] [checksum] 5A 00
+        /// len = content_length + 5
+        /// checksum = (len + SUM(content)) mod 256
+        /// </summary>
+        private byte[] BuildCommandPacket(string command, string? body = null, string? contentType = null, bool hasBody = true)
+        {
+            var sb = new StringBuilder();
+            sb.Append(command);
+            sb.Append("\r\n");
+            sb.AppendFormat("SeqNumber={0}\r\n", _seqNumber++);
+            sb.AppendFormat("Date={0}\r\n", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
+            if (hasBody && contentType != null)
+            {
+                sb.AppendFormat("ContentType={0}\r\n", contentType);
+                sb.AppendFormat("ContentLength={0}\r\n", body?.Length ?? 0);
+            }
+
+            sb.Append("\r\n");
+
+            if (hasBody && body != null)
+                sb.Append(body);
+
+            byte[] content = Encoding.ASCII.GetBytes(sb.ToString());
+            byte lenByte = (byte)(content.Length + FRAME_OVERHEAD);
+
+            // Compute checksum: (lenByte + SUM(content)) mod 256
+            int sum = lenByte;
+            for (int i = 0; i < content.Length; i++)
+                sum += content[i];
+            byte checksum = (byte)(sum & 0xFF);
+
+            // Build wire data: 5A 00 [len] [content] [checksum] 5A 00
+            var wireData = new byte[WIRE_PACKET_SIZE];
+            wireData[0] = FRAME_MARKER;
+            wireData[1] = FRAME_ZERO;
+            wireData[2] = lenByte;
+            Array.Copy(content, 0, wireData, 3, content.Length);
+            wireData[3 + content.Length] = checksum;
+            wireData[3 + content.Length + 1] = FRAME_MARKER;
+            wireData[3 + content.Length + 2] = FRAME_ZERO;
+
+            return wireData;
         }
 
         private bool SendPacketAndCheckResponse(byte[] wireData, string commandName)
@@ -220,13 +268,6 @@ namespace InfoPanel.ThermaltakePanel
             Array.Copy(wireData, 0, report, 1, Math.Min(wireData.Length, WIRE_PACKET_SIZE));
 
             _stream.Write(report, 0, report.Length);
-        }
-
-        private static byte[] HexToBytes(string hex)
-        {
-            return Enumerable.Range(0, hex.Length / 2)
-                .Select(i => Convert.ToByte(hex.Substring(i * 2, 2), 16))
-                .ToArray();
         }
 
         public void Dispose()

--- a/InfoPanel/ThermaltakePanel/ThermaltakePanelModel.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakePanelModel.cs
@@ -3,6 +3,7 @@ namespace InfoPanel.ThermaltakePanel
     public enum ThermaltakePanelModel
     {
         Unknown,
-        ToughLiquid6Inch,       // PID 0x2347, 1480x720
+        ToughLiquid6Inch,           // PID 0x2347, 1480x720
+        AsrockPhantomGaming360LCD,  // VID 0x26CE, PID 0x0A10, 480x480
     }
 }

--- a/InfoPanel/ThermaltakePanel/ThermaltakePanelModelDatabase.cs
+++ b/InfoPanel/ThermaltakePanel/ThermaltakePanelModelDatabase.cs
@@ -8,9 +8,13 @@ namespace InfoPanel.ThermaltakePanel
         public const int THERMALTAKE_VENDOR_ID = 0x264A;
         public const int THERMALTAKE_PRODUCT_ID_6INCH = 0x2347;
 
+        public const int ASROCK_VENDOR_ID = 0x26CE;
+        public const int ASROCK_PRODUCT_ID_PG360 = 0x0A10;
+
         public static readonly (int Vid, int Pid)[] SupportedDevices =
         [
             (THERMALTAKE_VENDOR_ID, THERMALTAKE_PRODUCT_ID_6INCH),
+            (ASROCK_VENDOR_ID, ASROCK_PRODUCT_ID_PG360),
         ];
 
         public static readonly Dictionary<ThermaltakePanelModel, ThermaltakePanelModelInfo> Models = new()
@@ -23,6 +27,15 @@ namespace InfoPanel.ThermaltakePanel
                 Height = 720,
                 VendorId = THERMALTAKE_VENDOR_ID,
                 ProductId = THERMALTAKE_PRODUCT_ID_6INCH,
+            },
+            [ThermaltakePanelModel.AsrockPhantomGaming360LCD] = new ThermaltakePanelModelInfo
+            {
+                Model = ThermaltakePanelModel.AsrockPhantomGaming360LCD,
+                Name = "ASRock Phantom Gaming 360 LCD",
+                Width = 480,
+                Height = 480,
+                VendorId = ASROCK_VENDOR_ID,
+                ProductId = ASROCK_PRODUCT_ID_PG360,
             },
         };
 

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -925,12 +925,12 @@
                         <TextBlock
                             FontSize="13"
                             FontWeight="Medium"
-                            Text="Thermaltake Displays" />
+                            Text="Thermaltake / ASRock LCD" />
                         <TextBlock
                             Margin="0,5,0,0"
                             FontSize="12"
                             Foreground="{DynamicResource TextFillColorTertiaryBrush}"
-                            Text="Configure and run Thermaltake USB LCD panels." />
+                            Text="Configure and run Thermaltake, ASRock, and compatible USB LCD panels." />
                     </StackPanel>
 
                     <StackPanel Grid.Column="1" VerticalAlignment="Center">

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -596,7 +596,7 @@ public partial class UsbPanelsPage : Page
 
                     if (discoveredDevice.ModelInfo != null)
                     {
-                        newDevice.RuntimeProperties.Name = $"Thermaltake {discoveredDevice.ModelInfo.Name}";
+                        newDevice.RuntimeProperties.Name = discoveredDevice.ModelInfo.Name;
                     }
 
                     settings.ThermaltakePanelDevices.Add(newDevice);
@@ -608,7 +608,7 @@ public partial class UsbPanelsPage : Page
 
                     if (device.ModelInfo != null)
                     {
-                        device.RuntimeProperties.Name = $"Thermaltake {device.ModelInfo.Name}";
+                        device.RuntimeProperties.Name = device.ModelInfo.Name;
                     }
 
                     Logger.Information("ThermaltakePanel Discovery: Device '{DeviceId}' already exists", discoveredDevice.DeviceId);
@@ -639,4 +639,5 @@ public partial class UsbPanelsPage : Page
             });
         }
     }
+
 }


### PR DESCRIPTION
## Summary
- Add ASRock Phantom Gaming 360 LCD panel (VID 0x26CE, PID 0x0A10, 480x480) to the existing Thermaltake panel driver
- Both ASRock and Thermaltake LCD panels use the same BY OEM protocol (text-based HTTP POST over HID with null report ID), so they share a single driver implementation
- Refactored ThermaltakeHidDevice from hardcoded hex packets to dynamic packet building with proper checksum, incrementing SeqNumber, and Date header
- Added SetBrightness() method for hardware brightness control
- UI section renamed to "Thermaltake / ASRock LCD" to cover both brands under one panel type with shared discovery

Based on work by @synqark (https://github.com/synqark/infopanel/tree/asrock-lcd) who reverse-engineered the ASRock panel and identified it uses the same BY OEM protocol as Thermaltake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)