### PR TITLE
Add Jungle Leopard / Hongtai cooler display support

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -405,6 +405,7 @@ namespace InfoPanel
                 await TuringPanelTask.Instance.StopAsync(true);
                 await ThermalrightPanelTask.Instance.StopAsync(true);
                 await ThermaltakePanelTask.Instance.StopAsync(true);
+                await JlPanelTask.Instance.StopAsync(true);
             });
         }
 
@@ -426,6 +427,7 @@ namespace InfoPanel
                         await TuringPanelTask.Instance.StopAsync(true);
                         await ThermalrightPanelTask.Instance.StopAsync(true);
                         await ThermaltakePanelTask.Instance.StopAsync(true);
+                        await JlPanelTask.Instance.StopAsync(true);
                     });
                     break;
             }
@@ -453,6 +455,11 @@ namespace InfoPanel
                 await ThermaltakePanelTask.Instance.StartAsync();
             }
 
+            if (ConfigModel.Instance.Settings.JlPanelMultiDeviceMode)
+            {
+                await JlPanelTask.Instance.StartAsync();
+            }
+
             if (ConfigModel.Instance.Settings.WebServer)
             {
                 await WebServerTask.Instance.StartAsync();
@@ -466,6 +473,7 @@ namespace InfoPanel
             await TuringPanelTask.Instance.StopAsync();
             await ThermalrightPanelTask.Instance.StopAsync();
             await ThermaltakePanelTask.Instance.StopAsync();
+            await JlPanelTask.Instance.StopAsync();
         }
 
         private void App_Exit(object sender, ExitEventArgs e)

--- a/InfoPanel/JlPanel/JlPanelHelper.cs
+++ b/InfoPanel/JlPanel/JlPanelHelper.cs
@@ -1,0 +1,81 @@
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+using System.Text.RegularExpressions;
+
+namespace InfoPanel.JlPanel
+{
+    public class JlPanelDiscoveryInfo
+    {
+        public string DeviceId { get; set; } = "";
+        public string DeviceLocation { get; set; } = ""; // COM port name (e.g. "COM5")
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
+        public JlPanelModel Model { get; set; }
+        public JlPanelModelInfo? ModelInfo { get; set; }
+    }
+
+    public static partial class JlPanelHelper
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(JlPanelHelper));
+
+        /// <summary>
+        /// Scans Win32_SerialPort for CDC-ACM devices matching JL VID/PID.
+        /// </summary>
+        public static List<JlPanelDiscoveryInfo> ScanDevices()
+        {
+            var devices = new List<JlPanelDiscoveryInfo>();
+
+            try
+            {
+                using var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_SerialPort");
+                foreach (ManagementObject obj in searcher.Get().Cast<ManagementObject>())
+                {
+                    string? comPort = obj["DeviceID"]?.ToString();
+                    string? pnpDeviceId = obj["PNPDeviceID"]?.ToString();
+
+                    if (comPort == null || pnpDeviceId == null) continue;
+                    if (!TryParseVidPid(pnpDeviceId, out var vid, out var pid)) continue;
+
+                    var modelInfo = JlPanelModelDatabase.GetModelByVidPid(vid, pid);
+                    if (modelInfo == null) continue;
+
+                    Logger.Information("JlPanelHelper: Found {Name} on {Port} (PNP={Pnp})",
+                        modelInfo.Name, comPort, pnpDeviceId);
+
+                    devices.Add(new JlPanelDiscoveryInfo
+                    {
+                        DeviceId = pnpDeviceId,
+                        DeviceLocation = comPort,
+                        VendorId = vid,
+                        ProductId = pid,
+                        Model = modelInfo.Model,
+                        ModelInfo = modelInfo,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "JlPanelHelper: Error scanning serial ports");
+            }
+
+            Logger.Information("JlPanelHelper: Found {Count} JL panel device(s)", devices.Count);
+            return devices;
+        }
+
+        private static bool TryParseVidPid(string pnpDeviceId, out int vid, out int pid)
+        {
+            vid = 0; pid = 0;
+            var match = VidPidRegex().Match(pnpDeviceId);
+            if (!match.Success) return false;
+            vid = Convert.ToInt32(match.Groups[1].Value, 16);
+            pid = Convert.ToInt32(match.Groups[2].Value, 16);
+            return true;
+        }
+
+        [GeneratedRegex(@"VID_([0-9A-Fa-f]{4})&PID_([0-9A-Fa-f]{4})")]
+        private static partial Regex VidPidRegex();
+    }
+}

--- a/InfoPanel/JlPanel/JlPanelModel.cs
+++ b/InfoPanel/JlPanel/JlPanelModel.cs
@@ -1,0 +1,9 @@
+namespace InfoPanel.JlPanel
+{
+    public enum JlPanelModel
+    {
+        Unknown,
+        ChillArc360,        // VID 0x33C3, PID 0x7788, 480x960 CDC JPEG
+        StripDisplay,       // VID 0x33C3, PID 0x7791..0x7810, 1920x462 CDC JPEG (high frame rate)
+    }
+}

--- a/InfoPanel/JlPanel/JlPanelModelDatabase.cs
+++ b/InfoPanel/JlPanel/JlPanelModelDatabase.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InfoPanel.JlPanel
+{
+    /// <summary>
+    /// Jungle Leopard / Hongtai-based cooler displays.
+    /// Reference platform: JL Chill Arc 360 (480x960). Same firmware/protocol is shared
+    /// across ~80 white-label SKUs (MSI EZ Display, Thermaltake LCD, ZOTAC, Jonsbo, ...).
+    /// Transport is USB CDC ACM (virtual COM port) at 2 Mbaud.
+    /// </summary>
+    public static class JlPanelModelDatabase
+    {
+        public const int JL_VENDOR_ID = 0x33C3;
+        public const int JL_PRODUCT_ID_CHILL_ARC_360 = 0x7788;
+
+        // OEM PIDs in the 0x7791..0x7810 range share the same protocol but vary in
+        // resolution. The reference firmware also has an SPI variant on 0x7793 that
+        // uses RGB565 over a CH340 USB-UART; that one is intentionally NOT supported
+        // here yet (different transport).
+        public static readonly (int Vid, int Pid)[] SupportedDevices =
+        [
+            (JL_VENDOR_ID, JL_PRODUCT_ID_CHILL_ARC_360),
+        ];
+
+        public static readonly Dictionary<JlPanelModel, JlPanelModelInfo> Models = new()
+        {
+            [JlPanelModel.ChillArc360] = new JlPanelModelInfo
+            {
+                Model = JlPanelModel.ChillArc360,
+                Name = "JL Chill Arc 360",
+                Width = 480,
+                Height = 960,
+                VendorId = JL_VENDOR_ID,
+                ProductId = JL_PRODUCT_ID_CHILL_ARC_360,
+                MaxJpegBytes = 80 * 1024,
+                DefaultFrameRate = 30,
+            },
+            [JlPanelModel.StripDisplay] = new JlPanelModelInfo
+            {
+                Model = JlPanelModel.StripDisplay,
+                Name = "JL Strip Display",
+                Width = 1920,
+                Height = 462,
+                VendorId = JL_VENDOR_ID,
+                ProductId = JL_PRODUCT_ID_CHILL_ARC_360, // OEM SKUs vary; matched by resolution
+                MaxJpegBytes = 80 * 1024,
+                DefaultFrameRate = 60,
+            },
+        };
+
+        public static JlPanelModelInfo? GetModelByVidPid(int vid, int pid)
+        {
+            return Models.Values.FirstOrDefault(m => m.VendorId == vid && m.ProductId == pid);
+        }
+    }
+}

--- a/InfoPanel/JlPanel/JlPanelModelInfo.cs
+++ b/InfoPanel/JlPanel/JlPanelModelInfo.cs
@@ -1,0 +1,18 @@
+namespace InfoPanel.JlPanel
+{
+    public class JlPanelModelInfo
+    {
+        public JlPanelModel Model { get; init; }
+        public string Name { get; init; } = "Unknown Model";
+        public int Width { get; init; }
+        public int Height { get; init; }
+        public int VendorId { get; init; }
+        public int ProductId { get; init; }
+
+        /// <summary>Soft cap on JPEG payload size in bytes (~80 KB for Chill Arc 360).</summary>
+        public int MaxJpegBytes { get; init; } = 80 * 1024;
+
+        /// <summary>Default frame rate for this panel (60 for strip, 30 otherwise per spec).</summary>
+        public int DefaultFrameRate { get; init; } = 30;
+    }
+}

--- a/InfoPanel/JlPanel/JlSerialDevice.cs
+++ b/InfoPanel/JlPanel/JlSerialDevice.cs
@@ -1,0 +1,275 @@
+using Serilog;
+using System;
+using System.IO;
+using System.IO.Ports;
+using System.Text;
+using System.Text.Json;
+
+namespace InfoPanel.JlPanel
+{
+    /// <summary>
+    /// Serial communication for Jungle Leopard / Hongtai cooler displays.
+    /// Protocol (reverse-engineered from `Jungle Leopard Display.exe`):
+    ///   * USB CDC ACM at 2 000 000 baud, no flow control.
+    ///   * Frame: 0x55 0xAA [len_LE16] [cmd] [payload] [chk_LE16]
+    ///     - len = total frame size (= payload length + 7)
+    ///     - chk = u16 sum of all preceding bytes (NOT a CRC), little-endian.
+    ///   * Live JPEG envelope (firmware >= 2.8):
+    ///     [size_LE32] [JPEG bytes] [sum_LE16]
+    ///     - sum = u16 sum of size_field + JPEG bytes.
+    ///   * Frame terminator: FF D9 FF D9 (two JPEG EOI markers back-to-back).
+    ///   * Pipeline reset: FF D9 FF D9 00 00 00 00.
+    ///   * Keep-alive: send cmd 0x11 (refresh) at least every 1500 ms.
+    /// </summary>
+    public sealed class JlSerialDevice : IDisposable
+    {
+        private static readonly ILogger Logger = Log.ForContext<JlSerialDevice>();
+
+        public const byte CMD_RESTART          = 0x01;
+        public const byte CMD_SET_LIGHT        = 0x03;
+        public const byte CMD_GET_DEVICE_INFO  = 0x06;
+        public const byte CMD_KEEP_ALIVE       = 0x11; // "live frame ack" / refresh
+        public const byte CMD_SET_REGION       = 0x20;
+        public const byte CMD_CLOSE            = 0x21;
+
+        private const int BaudRate = 2_000_000;
+        private const int ReadTimeoutMs = 2000;
+        private const int WriteTimeoutMs = 5000;
+
+        private static readonly byte[] PipelineReset =
+            [0xFF, 0xD9, 0xFF, 0xD9, 0x00, 0x00, 0x00, 0x00];
+
+        private static readonly byte[] FrameTerminator =
+            [0xFF, 0xD9, 0xFF, 0xD9];
+
+        private SerialPort? _port;
+        private bool _disposed;
+
+        public bool IsOpen => _port?.IsOpen == true;
+        public string PortName { get; private set; } = string.Empty;
+
+        public class DeviceInfo
+        {
+            public int Status { get; set; }
+            public string? Uid { get; set; }
+            public string? Model { get; set; }
+            public string? Version { get; set; }
+            public int Width { get; set; }
+            public int Height { get; set; }
+            public int Angle { get; set; }
+            public string? Region { get; set; }
+        }
+
+        /// <summary>
+        /// Opens the COM port at 2 Mbaud and performs the device-clear handshake.
+        /// </summary>
+        public static JlSerialDevice? Open(string comPort)
+        {
+            var dev = new JlSerialDevice();
+            try
+            {
+                dev._port = new SerialPort(comPort, BaudRate)
+                {
+                    ReadTimeout = ReadTimeoutMs,
+                    WriteTimeout = WriteTimeoutMs,
+                    DtrEnable = true,
+                    RtsEnable = true,
+                    Handshake = Handshake.None,
+                };
+                dev._port.Open();
+                dev.PortName = comPort;
+
+                // Pipeline reset: flush any pending frame state before we start talking.
+                System.Threading.Thread.Sleep(200);
+                dev._port.Write(PipelineReset, 0, PipelineReset.Length);
+                System.Threading.Thread.Sleep(200);
+                dev._port.DiscardInBuffer();
+
+                Logger.Information("JlSerialDevice: Opened {Port} @ {Baud}", comPort, BaudRate);
+                return dev;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "JlSerialDevice: Failed to open {Port}", comPort);
+                dev.Dispose();
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Builds a command frame: 0x55 0xAA [len_LE16] [cmd] [payload] [chk_LE16].
+        /// </summary>
+        public static byte[] BuildFrame(byte cmd, ReadOnlySpan<byte> payload)
+        {
+            int totalLen = 7 + payload.Length; // magic(2) + len(2) + cmd(1) + payload + chk(2)
+            var frame = new byte[totalLen];
+            frame[0] = 0x55;
+            frame[1] = 0xAA;
+            frame[2] = (byte)(totalLen & 0xFF);
+            frame[3] = (byte)((totalLen >> 8) & 0xFF);
+            frame[4] = cmd;
+            payload.CopyTo(frame.AsSpan(5));
+
+            ushort sum = 0;
+            for (int i = 0; i < totalLen - 2; i++) sum += frame[i];
+            frame[totalLen - 2] = (byte)(sum & 0xFF);
+            frame[totalLen - 1] = (byte)((sum >> 8) & 0xFF);
+            return frame;
+        }
+
+        /// <summary>Sends a framed command and discards any response.</summary>
+        public void SendCommand(byte cmd, ReadOnlySpan<byte> payload = default)
+        {
+            if (_port == null || !_port.IsOpen) throw new InvalidOperationException("Port not open");
+            var frame = BuildFrame(cmd, payload);
+            _port.Write(frame, 0, frame.Length);
+        }
+
+        /// <summary>
+        /// Sends a framed command and reads back one response frame.
+        /// Returns the unwrapped payload bytes (excluding magic, length, cmd, checksum), or null on timeout.
+        /// </summary>
+        public byte[]? SendCommandAndReadResponse(byte cmd, ReadOnlySpan<byte> payload = default)
+        {
+            if (_port == null || !_port.IsOpen) throw new InvalidOperationException("Port not open");
+            SendCommand(cmd, payload);
+            return ReadFrame();
+        }
+
+        /// <summary>Reads one response frame and returns the payload bytes (without magic/length/cmd/checksum).</summary>
+        public byte[]? ReadFrame()
+        {
+            if (_port == null || !_port.IsOpen) return null;
+            try
+            {
+                // Sync to magic 0x55 0xAA
+                int b1 = _port.ReadByte();
+                while (b1 != 0x55)
+                {
+                    if (b1 < 0) return null;
+                    b1 = _port.ReadByte();
+                }
+                int b2 = _port.ReadByte();
+                if (b2 != 0xAA) return null;
+
+                int lenLo = _port.ReadByte();
+                int lenHi = _port.ReadByte();
+                int totalLen = (lenHi << 8) | lenLo;
+                if (totalLen < 7 || totalLen > 64 * 1024) return null;
+
+                int payloadLen = totalLen - 7;
+                int cmd = _port.ReadByte();
+                _ = cmd; // not needed by callers
+
+                var payload = new byte[payloadLen];
+                int read = 0;
+                while (read < payloadLen)
+                {
+                    int n = _port.Read(payload, read, payloadLen - read);
+                    if (n <= 0) return null;
+                    read += n;
+                }
+
+                // Discard checksum bytes (we don't validate response checksums)
+                _ = _port.ReadByte();
+                _ = _port.ReadByte();
+
+                return payload;
+            }
+            catch (TimeoutException) { return null; }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "JlSerialDevice: ReadFrame error");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Calls cmd 0x06 (getDeviceInfo). The response payload is JSON.
+        /// </summary>
+        public DeviceInfo? GetDeviceInfo()
+        {
+            var payload = SendCommandAndReadResponse(CMD_GET_DEVICE_INFO);
+            if (payload == null || payload.Length < 5) return null;
+
+            try
+            {
+                string json = Encoding.UTF8.GetString(payload).Trim('\0');
+                var info = JsonSerializer.Deserialize<DeviceInfo>(json,
+                    new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                return info;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "JlSerialDevice: Failed to parse getDeviceInfo response");
+                return null;
+            }
+        }
+
+        /// <summary>Sends the 0x11 keep-alive (live frame ack).</summary>
+        public void SendKeepAlive() => SendCommand(CMD_KEEP_ALIVE);
+
+        /// <summary>Sets backlight brightness (0..100).</summary>
+        public void SetBrightness(int brightness)
+        {
+            byte clamped = (byte)Math.Clamp(brightness, 0, 100);
+            SendCommand(CMD_SET_LIGHT, [clamped]);
+        }
+
+        /// <summary>
+        /// Sends one live JPEG frame using the v2.8+ envelope:
+        ///   [size_LE32] [JPEG bytes] [sum_LE16]   followed by FF D9 FF D9 terminator.
+        /// </summary>
+        public void SendJpegFrame(byte[] jpeg)
+        {
+            if (_port == null || !_port.IsOpen) throw new InvalidOperationException("Port not open");
+
+            // Refresh the live pipeline before each frame.
+            SendKeepAlive();
+
+            int envelopeSize = 4 + jpeg.Length + 2;
+            var envelope = new byte[envelopeSize];
+
+            // Size field (LE32) covers JPEG bytes only.
+            envelope[0] = (byte)(jpeg.Length & 0xFF);
+            envelope[1] = (byte)((jpeg.Length >> 8) & 0xFF);
+            envelope[2] = (byte)((jpeg.Length >> 16) & 0xFF);
+            envelope[3] = (byte)((jpeg.Length >> 24) & 0xFF);
+
+            Buffer.BlockCopy(jpeg, 0, envelope, 4, jpeg.Length);
+
+            // Sum: size_field bytes + JPEG bytes.
+            ushort sum = 0;
+            for (int i = 0; i < 4 + jpeg.Length; i++) sum += envelope[i];
+            envelope[envelopeSize - 2] = (byte)(sum & 0xFF);
+            envelope[envelopeSize - 1] = (byte)((sum >> 8) & 0xFF);
+
+            _port.Write(envelope, 0, envelope.Length);
+            // Frame terminator (two JPEG EOI markers back-to-back).
+            _port.Write(FrameTerminator, 0, FrameTerminator.Length);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                if (_port != null)
+                {
+                    if (_port.IsOpen)
+                    {
+                        try { SendCommand(CMD_CLOSE); } catch { /* best effort */ }
+                        try { _port.Close(); } catch { }
+                    }
+                    _port.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "JlSerialDevice: Dispose error");
+            }
+            _port = null;
+        }
+    }
+}

--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -502,6 +502,17 @@ namespace InfoPanel
                     await ThermaltakePanelTask.Instance.StopAsync();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.JlPanelMultiDeviceMode))
+            {
+                if (Settings.JlPanelMultiDeviceMode)
+                {
+                    await JlPanelTask.Instance.StartAsync();
+                }
+                else
+                {
+                    await JlPanelTask.Instance.StopAsync();
+                }
+            }
 
             await SaveSettingsAsync();
         }
@@ -711,6 +722,15 @@ namespace InfoPanel
                             foreach (var device in settings.ThermaltakePanelDevices)
                             {
                                 Settings.ThermaltakePanelDevices.Add(device);
+                            }
+
+                            // Load JL panel settings
+                            Settings.JlPanelMultiDeviceMode = settings.JlPanelMultiDeviceMode;
+
+                            Settings.JlPanelDevices.Clear();
+                            foreach (var device in settings.JlPanelDevices)
+                            {
+                                Settings.JlPanelDevices.Add(device);
                             }
 
                             // Load hotkey bindings

--- a/InfoPanel/Models/JlPanelDevice.cs
+++ b/InfoPanel/Models/JlPanelDevice.cs
@@ -1,0 +1,132 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using InfoPanel.JlPanel;
+using InfoPanel.ViewModels;
+using Serilog;
+using System;
+using System.Linq;
+using System.Windows.Threading;
+
+namespace InfoPanel.Models
+{
+    public partial class JlPanelDevice : ObservableObject
+    {
+        private static readonly ILogger Logger = Log.ForContext<JlPanelDevice>();
+
+        [ObservableProperty]
+        private string _deviceId = string.Empty;
+
+        [ObservableProperty]
+        private string _deviceLocation = string.Empty; // COM port e.g. "COM5"
+
+        [ObservableProperty]
+        private JlPanelModel _model = JlPanelModel.ChillArc360;
+
+        partial void OnModelChanged(JlPanelModel value)
+        {
+            OnPropertyChanged(nameof(ModelInfo));
+            OnPropertyChanged(nameof(DisplayWidth));
+            OnPropertyChanged(nameof(DisplayHeight));
+        }
+
+        [ObservableProperty]
+        private bool _enabled = false;
+
+        [ObservableProperty]
+        private Guid _profileGuid = Guid.Empty;
+
+        [ObservableProperty]
+        private LCD_ROTATION _rotation = LCD_ROTATION.RotateNone;
+
+        [ObservableProperty]
+        private int _brightness = 100;
+
+        [ObservableProperty]
+        private int _targetFrameRate = 15;
+
+        [ObservableProperty]
+        private int _jpegQuality = 80;
+
+        // Runtime properties (not persisted)
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private string _id = Guid.NewGuid().ToString();
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private JlPanelDeviceRuntimeProperties _runtimeProperties;
+
+        public JlPanelDevice()
+        {
+            _runtimeProperties = new();
+        }
+
+        public JlPanelModelInfo? ModelInfo =>
+            JlPanelModelDatabase.Models.TryGetValue(Model, out var info) ? info : null;
+
+        public int DisplayWidth => ModelInfo?.Width ?? 0;
+        public int DisplayHeight => ModelInfo?.Height ?? 0;
+
+        public bool IsMatching(string deviceId, string deviceLocation, JlPanelModel model)
+        {
+            if (DeviceId.Equals(deviceId) && DeviceLocation.Equals(deviceLocation) && Model.Equals(model))
+                return true;
+            // Fallback: match by PNP device id alone (COM ports can change)
+            if (DeviceId.Equals(deviceId) && Model.Equals(model))
+                return true;
+            return false;
+        }
+
+        private DateTime _lastUpdate = DateTime.MinValue;
+        private readonly TimeSpan _throttleInterval = TimeSpan.FromSeconds(1);
+
+        public void UpdateRuntimeProperties(bool? isRunning = null, int? frameRate = null, long? frameTime = null, string? errorMessage = null)
+        {
+            var now = DateTime.UtcNow;
+
+            if (isRunning != null || errorMessage != null)
+            {
+                _lastUpdate = now;
+                DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+                return;
+            }
+
+            if (now - _lastUpdate < _throttleInterval) return;
+            _lastUpdate = now;
+            DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+        }
+
+        private void DispatchUpdate(bool? isRunning, int? frameRate, long? frameTime, string? errorMessage)
+        {
+            if (System.Windows.Application.Current?.Dispatcher is Dispatcher dispatcher)
+            {
+                dispatcher.BeginInvoke(() =>
+                {
+                    if (isRunning != null) RuntimeProperties.IsRunning = isRunning.Value;
+                    if (frameRate != null) RuntimeProperties.FrameRate = frameRate.Value;
+                    if (frameTime != null) RuntimeProperties.FrameTime = frameTime.Value;
+                    if (errorMessage != null) RuntimeProperties.ErrorMessage = errorMessage;
+                });
+            }
+        }
+
+        public override string ToString() => DeviceLocation;
+
+        public partial class JlPanelDeviceRuntimeProperties : ObservableObject
+        {
+            [ObservableProperty]
+            private bool _isRunning = false;
+
+            [ObservableProperty]
+            private string _name = "JL Panel";
+
+            [ObservableProperty]
+            private int _frameRate = 0;
+
+            [ObservableProperty]
+            private long _frameTime = 0;
+
+            [ObservableProperty]
+            private string _errorMessage = string.Empty;
+        }
+    }
+}

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -93,6 +93,16 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _thermaltakePanelMultiDeviceMode = false;
 
+        private readonly ObservableCollection<JlPanelDevice> _jlPanelDevices = [];
+
+        public ObservableCollection<JlPanelDevice> JlPanelDevices
+        {
+            get { return _jlPanelDevices; }
+        }
+
+        [ObservableProperty]
+        private bool _jlPanelMultiDeviceMode = false;
+
         private readonly ObservableCollection<HotkeyBinding> _hotkeyBindings = [];
 
         public ObservableCollection<HotkeyBinding> HotkeyBindings
@@ -140,6 +150,7 @@ namespace InfoPanel.Models
             TuringPanelDevices.CollectionChanged += TuringPanelDevices_CollectionChanged;
             ThermalrightPanelDevices.CollectionChanged += ThermalrightPanelDevices_CollectionChanged;
             ThermaltakePanelDevices.CollectionChanged += ThermaltakePanelDevices_CollectionChanged;
+            JlPanelDevices.CollectionChanged += JlPanelDevices_CollectionChanged;
         }
 
         private void BeadaPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -232,6 +243,27 @@ namespace InfoPanel.Models
         {
             if (e.PropertyName != nameof(ThermaltakePanelDevice.RuntimeProperties))
                 OnPropertyChanged(nameof(ThermaltakePanelDevices));
+        }
+
+        private void JlPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (JlPanelDevice device in e.OldItems)
+                    device.PropertyChanged -= JlDevice_PropertyChanged;
+            }
+            if (e.NewItems != null)
+            {
+                foreach (JlPanelDevice device in e.NewItems)
+                    device.PropertyChanged += JlDevice_PropertyChanged;
+            }
+            OnPropertyChanged(nameof(JlPanelDevices));
+        }
+
+        private void JlDevice_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(JlPanelDevice.RuntimeProperties))
+                OnPropertyChanged(nameof(JlPanelDevices));
         }
 
     }

--- a/InfoPanel/Services/JlPanelDeviceTask.cs
+++ b/InfoPanel/Services/JlPanelDeviceTask.cs
@@ -1,0 +1,294 @@
+using InfoPanel.Drawing;
+using InfoPanel.Extensions;
+using InfoPanel.JlPanel;
+using InfoPanel.Models;
+using InfoPanel.Utils;
+using Serilog;
+using SkiaSharp;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class JlPanelDeviceTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<JlPanelDeviceTask>();
+
+        private readonly JlPanelDevice _device;
+        private int _panelWidth;
+        private int _panelHeight;
+        private int _lastBrightness;
+
+        public JlPanelDeviceTask(JlPanelDevice device)
+        {
+            _device = device;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            var modelInfo = _device.ModelInfo;
+            if (modelInfo == null)
+            {
+                _device.UpdateRuntimeProperties(errorMessage: "Unknown model");
+                return;
+            }
+
+            _panelWidth = modelInfo.Width;
+            _panelHeight = modelInfo.Height;
+            _lastBrightness = _device.Brightness;
+
+            _device.UpdateRuntimeProperties(isRunning: false, errorMessage: string.Empty);
+            _device.RuntimeProperties.Name = $"{modelInfo.Name} ({_panelWidth}x{_panelHeight})";
+
+            int retryCount = 0;
+            while (!token.IsCancellationRequested)
+            {
+                JlSerialDevice? serial = null;
+                try
+                {
+                    Logger.Information("JlDevice {Device}: Opening (attempt {Retry})", _device, retryCount + 1);
+                    serial = JlSerialDevice.Open(_device.DeviceLocation);
+
+                    if (serial == null)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: $"Cannot open {_device.DeviceLocation}");
+                        await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    // Handshake: getDeviceInfo. The reply confirms the panel is responsive
+                    // and tells us its actual width/height (in case the model database is wrong).
+                    var info = serial.GetDeviceInfo();
+                    if (info == null || info.Status != 200)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: "getDeviceInfo failed");
+                        serial.Dispose();
+                        await Task.Delay(2000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    Logger.Information("JlDevice {Device}: model={Model} ver={Ver} {W}x{H} angle={Angle}",
+                        _device, info.Model, info.Version, info.Width, info.Height, info.Angle);
+
+                    // Trust the device-reported resolution if it differs from our database.
+                    if (info.Width > 0 && info.Height > 0)
+                    {
+                        _panelWidth = info.Width;
+                        _panelHeight = info.Height;
+                    }
+
+                    // Push initial brightness.
+                    try { serial.SetBrightness(_device.Brightness); }
+                    catch (Exception ex) { Logger.Warning(ex, "JlDevice {Device}: SetBrightness failed", _device); }
+
+                    retryCount = 0;
+                    await RunRenderSendLoop(serial, token);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "JlDevice {Device}: Error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+                    retryCount++;
+                }
+                finally
+                {
+                    serial?.Dispose();
+                    _device.UpdateRuntimeProperties(isRunning: false);
+                }
+
+                if (!token.IsCancellationRequested)
+                    await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+            }
+        }
+
+        private async Task RunRenderSendLoop(JlSerialDevice serial, CancellationToken token)
+        {
+            FpsCounter fpsCounter = new(60);
+            byte[]? latestFrame = null;
+            AutoResetEvent frameAvailable = new(false);
+
+            var renderCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var renderToken = renderCts.Token;
+
+            _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
+
+            // Render thread: produce JPEG frames at the target frame rate.
+            var renderTask = Task.Run(async () =>
+            {
+                Thread.CurrentThread.Name ??= $"Jl-Render-{_device.DeviceLocation}";
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    while (!renderToken.IsCancellationRequested)
+                    {
+                        stopwatch.Restart();
+
+                        var frame = GenerateJpegBuffer();
+                        Interlocked.Exchange(ref latestFrame, frame);
+                        frameAvailable.Set();
+
+                        var targetFrameTime = 1000 / Math.Max(1, _device.TargetFrameRate);
+                        var elapsedMs = (int)stopwatch.ElapsedMilliseconds;
+                        var remaining = targetFrameTime - elapsedMs;
+                        if (remaining > 0) await Task.Delay(remaining, renderToken);
+                    }
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "JlDevice {Device}: Render error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: e.Message);
+                    renderCts.Cancel();
+                }
+            }, renderToken);
+
+            // Send thread: drain frames to the serial port.
+            // Also drives the keep-alive: the firmware needs cmd 0x11 at least every 1500 ms,
+            // and SendJpegFrame already prepends one keep-alive per frame, so any framerate
+            // >= ~1 fps is safe. We add a fallback ping if frames stop being produced.
+            var sendTask = Task.Run(() =>
+            {
+                Thread.CurrentThread.Name ??= $"Jl-Send-{_device.DeviceLocation}";
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    while (!token.IsCancellationRequested)
+                    {
+                        if (frameAvailable.WaitOne(1000))
+                        {
+                            var jpegData = Interlocked.Exchange(ref latestFrame, null);
+                            if (jpegData != null)
+                            {
+                                stopwatch.Restart();
+
+                                // Push brightness if it changed.
+                                if (_lastBrightness != _device.Brightness)
+                                {
+                                    _lastBrightness = _device.Brightness;
+                                    try { serial.SetBrightness(_lastBrightness); }
+                                    catch (Exception ex) { Logger.Warning(ex, "JlDevice {Device}: SetBrightness failed", _device); }
+                                }
+
+                                serial.SendJpegFrame(jpegData);
+
+                                fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                                _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+                            }
+                        }
+                        else
+                        {
+                            // No frame in 1s — send a keep-alive so the live pipeline doesn't time out.
+                            try { serial.SendKeepAlive(); }
+                            catch (Exception ex)
+                            {
+                                Logger.Warning(ex, "JlDevice {Device}: keep-alive failed", _device);
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "JlDevice {Device}: Send error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: e.Message);
+                }
+                finally
+                {
+                    renderCts.Cancel();
+                }
+            }, token);
+
+            await Task.WhenAll(renderTask, sendTask);
+
+            frameAvailable.Dispose();
+            renderCts.Dispose();
+        }
+
+        private byte[] GenerateJpegBuffer()
+        {
+            var modelInfo = _device.ModelInfo;
+            int maxBytes = modelInfo?.MaxJpegBytes ?? 80 * 1024;
+
+            if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
+            {
+                var rotation = _device.Rotation;
+
+                using var bitmap = PanelDrawTask.RenderSK(profile, false,
+                    colorType: SKColorType.Rgba8888,
+                    alphaType: SKAlphaType.Opaque);
+
+                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
+
+                SKBitmap encodeBitmap = resizedBitmap;
+                SKBitmap? dimmed = null;
+                try
+                {
+                    if (_device.Brightness < 100)
+                    {
+                        // The firmware also has a hardware backlight (cmd 0x03), but applying
+                        // brightness in-pixel preserves the look of dim profiles below the
+                        // backlight floor.
+                        dimmed = ApplyBrightness(resizedBitmap);
+                        encodeBitmap = dimmed;
+                    }
+
+                    int quality = _device.JpegQuality;
+                    using var image = SKImage.FromBitmap(encodeBitmap);
+
+                    // Drop quality until the JPEG fits in the firmware's max payload.
+                    for (int attempt = 0; attempt < 5; attempt++)
+                    {
+                        using var data = image.Encode(SKEncodedImageFormat.Jpeg, quality);
+                        if (data.Size <= maxBytes || quality <= 30)
+                            return data.ToArray();
+                        quality = Math.Max(30, quality - 15);
+                    }
+                    using var fallback = image.Encode(SKEncodedImageFormat.Jpeg, 30);
+                    return fallback.ToArray();
+                }
+                finally
+                {
+                    dimmed?.Dispose();
+                }
+            }
+
+            return GenerateBlackJpeg();
+        }
+
+        private SKBitmap ApplyBrightness(SKBitmap source)
+        {
+            float scale = Math.Clamp(_device.Brightness, 0, 100) / 100f;
+            var result = new SKBitmap(source.Width, source.Height, source.ColorType, source.AlphaType);
+            using var canvas = new SKCanvas(result);
+            using var paint = new SKPaint();
+            paint.ColorFilter = SKColorFilter.CreateColorMatrix(
+            [
+                scale, 0,     0,     0, 0,
+                0,     scale, 0,     0, 0,
+                0,     0,     scale, 0, 0,
+                0,     0,     0,     1, 0
+            ]);
+            canvas.DrawBitmap(source, 0, 0, paint);
+            return result;
+        }
+
+        private byte[]? _cachedBlackJpeg;
+
+        private byte[] GenerateBlackJpeg()
+        {
+            if (_cachedBlackJpeg != null) return _cachedBlackJpeg;
+            using var bitmap = new SKBitmap(_panelWidth, _panelHeight, SKColorType.Rgba8888, SKAlphaType.Opaque);
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(SKColors.Black);
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Jpeg, 50);
+            _cachedBlackJpeg = data.ToArray();
+            return _cachedBlackJpeg;
+        }
+    }
+}

--- a/InfoPanel/Services/JlPanelTask.cs
+++ b/InfoPanel/Services/JlPanelTask.cs
@@ -1,0 +1,123 @@
+using InfoPanel.Models;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class JlPanelTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<JlPanelTask>();
+        private static readonly Lazy<JlPanelTask> _instance = new(() => new JlPanelTask());
+
+        private readonly ConcurrentDictionary<string, JlPanelDeviceTask> _deviceTasks = new();
+
+        public static JlPanelTask Instance => _instance.Value;
+
+        private JlPanelTask() { }
+
+        public override async Task StopAsync(bool shutdown = false)
+        {
+            await base.StopAsync(shutdown);
+            await StopAllDevices();
+        }
+
+        public async Task StartDevice(JlPanelDevice device)
+        {
+            if (_deviceTasks.TryGetValue(device.Id, out var task))
+            {
+                await task.StopAsync();
+                _deviceTasks.TryRemove(device.Id, out _);
+            }
+
+            var deviceTask = new JlPanelDeviceTask(device);
+            if (_deviceTasks.TryAdd(device.Id, deviceTask))
+            {
+                await deviceTask.StartAsync(CancellationToken);
+                Logger.Information("Started JL panel device {Device}", device);
+            }
+        }
+
+        public async Task StopDevice(string deviceId)
+        {
+            if (_deviceTasks.TryRemove(deviceId, out var deviceTask))
+            {
+                await deviceTask.StopAsync();
+                Logger.Information("Stopped JL panel device {DeviceId}", deviceId);
+            }
+        }
+
+        public async Task StopAllDevices()
+        {
+            var tasks = new List<Task>();
+            foreach (var kvp in _deviceTasks.ToList())
+            {
+                if (_deviceTasks.TryRemove(kvp.Key, out var deviceTask))
+                    tasks.Add(Task.Run(async () => await deviceTask.StopAsync()));
+            }
+            await Task.WhenAll(tasks);
+            Logger.Information("Stopped all JL panel devices");
+        }
+
+        public bool IsDeviceRunning(string deviceId)
+        {
+            return _deviceTasks.TryGetValue(deviceId, out var task) && task.IsRunning;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            await Task.Delay(300, token);
+
+            try
+            {
+                var settings = ConfigModel.Instance.Settings;
+                if (settings.JlPanelMultiDeviceMode)
+                    await RunMultiDeviceMode(token);
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception e)
+            {
+                Logger.Error(e, "JlPanel: Error in DoWorkAsync");
+            }
+        }
+
+        private async Task RunMultiDeviceMode(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var settings = ConfigModel.Instance.Settings;
+                    if (!settings.JlPanelMultiDeviceMode) break;
+
+                    var enabledConfigs = settings.JlPanelDevices.Where(d => d.Enabled).ToList();
+
+                    foreach (var config in enabledConfigs)
+                    {
+                        if (!IsDeviceRunning(config.Id))
+                            await StartDevice(config);
+                    }
+
+                    var runningDeviceIds = _deviceTasks.Keys.ToList();
+                    foreach (var deviceId in runningDeviceIds)
+                    {
+                        if (!enabledConfigs.Any(c => c.Id == deviceId))
+                            await StopDevice(deviceId);
+                    }
+
+                    await Task.Delay(1000, token);
+                }
+                catch (TaskCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "JlPanel: Error in RunMultiDeviceMode");
+                    await Task.Delay(1000, token);
+                }
+            }
+        }
+    }
+}

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -1206,6 +1206,299 @@
         </ui:CardExpander>
         <!--  end ThermaltakePanel Multi-Device settings  -->
 
+        <!--  JlPanel Multi-Device settings (Jungle Leopard / Hongtai-based cooler displays)  -->
+        <ui:CardExpander
+            Margin="0,10,0,0"
+            IsExpanded="True">
+            <ui:CardExpander.Icon>
+                <ui:SymbolIcon Symbol="Whiteboard24" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock
+                            FontSize="13"
+                            FontWeight="Medium"
+                            Text="Jungle Leopard / Hongtai" />
+                        <TextBlock
+                            Margin="0,5,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                            Text="JL Chill Arc 360, MSI EZ Display, and other Hongtai-based cooler displays. CDC serial @ 2 Mbaud." />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,10,0" Orientation="Horizontal">
+                            <ui:ToggleSwitch
+                                Grid.Column="1"
+                                Margin="0,0,10,0"
+                                IsChecked="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.JlPanelMultiDeviceMode}" />
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <ui:Button
+                        Grid.Column="1"
+                        Margin="0,0,0,0"
+                        HorizontalAlignment="Right"
+                        Appearance="Primary"
+                        Click="ButtonDiscoverJlPanelDevices_Click"
+                        Content="Discover Devices"
+                        Icon="{ui:SymbolIcon Search20}"
+                        Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.JlPanelMultiDeviceMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+
+                <!--  JlPanel Device List  -->
+                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.JlPanelDevices}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ui:CardControl Margin="0,0,0,10">
+                                <ui:CardControl.Header>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock FontSize="13" FontWeight="Medium">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0}">
+                                                        <Binding Path="RuntimeProperties.Name" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                                TextWrapping="Wrap">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                                        <Binding Path="DeviceId" />
+                                                        <Binding Path="DeviceLocation" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}Dimensions: {0}x{1}">
+                                                        <Binding Path="DisplayWidth" />
+                                                        <Binding Path="DisplayHeight" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <!--  Panel status when enabled  -->
+                                            <StackPanel Visibility="{Binding Enabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Orientation="Horizontal"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="Panel is running:" />
+                                                    <TextBlock
+                                                        Margin="10,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="{Binding RuntimeProperties.FrameRate, StringFormat='{}{0} FPS'}" />
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="{Binding RuntimeProperties.FrameTime, StringFormat=' @ {0}ms'}" />
+                                                </StackPanel>
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="Orange"
+                                                        Text="Display is not running. Check the COM port and connection." />
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="Orange"
+                                                        Text="{Binding RuntimeProperties.ErrorMessage}"
+                                                        Visibility="{Binding RuntimeProperties.ErrorMessage, Converter={StaticResource StringToVisibilityConverter}}" />
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                </ui:CardControl.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Margin="10,0,0,0" VerticalAlignment="Top">
+                                        <ui:Button
+                                            Width="160"
+                                            Appearance="Secondary"
+                                            Click="ButtonAdvancedPopup_Click"
+                                            Content="Advanced"
+                                            Icon="{ui:SymbolIcon Settings20}" />
+                                        <Popup
+                                            AllowsTransparency="True"
+                                            Placement="Bottom"
+                                            StaysOpen="False">
+                                            <Border
+                                                Padding="15"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8">
+                                                <StackPanel Width="250">
+                                                    <!--  Brightness  -->
+                                                    <StackPanel>
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="0"
+                                                            TickFrequency="1"
+                                                            Value="{Binding Brightness}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Brightness" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding Brightness}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  Target FPS  -->
+                                                    <StackPanel Margin="0,10,0,0">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="60"
+                                                            Minimum="1"
+                                                            TickFrequency="1"
+                                                            Value="{Binding TargetFrameRate}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Target FPS" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding TargetFrameRate}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  JPEG Quality  -->
+                                                    <StackPanel Margin="0,10,0,0">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="50"
+                                                            TickFrequency="5"
+                                                            Value="{Binding JpegQuality}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="JPEG Quality" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding JpegQuality}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </StackPanel>
+                                    <StackPanel Margin="10,0,0,0">
+                                        <!--  Profile selection  -->
+                                        <ComboBox
+                                            Width="250"
+                                            Margin="0,0,0,0"
+                                            DisplayMemberPath="Name"
+                                            ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Profiles}"
+                                            SelectedValue="{Binding ProfileGuid}"
+                                            SelectedValuePath="Guid" />
+                                        <!--  Rotation  -->
+                                        <ComboBox
+                                            Margin="0,10,0,0"
+                                            ItemsSource="{Binding Path=ViewModel.RotationValues, RelativeSource={RelativeSource AncestorType=pages:UsbPanelsPage}}"
+                                            SelectedItem="{Binding Rotation}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Converter={StaticResource EnumToDescriptionConverter}}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <Grid Margin="20,0,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <!--  Enable toggle  -->
+                                        <ui:ToggleSwitch
+                                            Margin="0,0,0,0"
+                                            VerticalAlignment="Center"
+                                            IsChecked="{Binding Enabled}" />
+                                        <!--  Remove button  -->
+                                        <ui:Button
+                                            Grid.Row="1"
+                                            Width="32"
+                                            Height="32"
+                                            Margin="0,10,0,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Bottom"
+                                            Appearance="Danger"
+                                            BorderThickness="0"
+                                            Click="ButtonRemoveJlPanelDevice_Click"
+                                            Icon="{ui:SymbolIcon Delete20}"
+                                            Tag="{Binding}"
+                                            ToolTip="Remove Device" />
+                                    </Grid>
+                                </StackPanel>
+                            </ui:CardControl>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ui:CardExpander>
+        <!--  end JlPanel Multi-Device settings  -->
+
         <!--  Global Hotkeys  -->
         <ui:CardExpander Margin="0,20,0,0" IsExpanded="False">
             <ui:CardExpander.Icon>

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -4,6 +4,7 @@ using InfoPanel.Services;
 using InfoPanel.TuringPanel;
 using InfoPanel.ThermalrightPanel;
 using InfoPanel.ThermaltakePanel;
+using InfoPanel.JlPanel;
 using InfoPanel.ViewModels;
 using InfoPanel.Views.Windows;
 using LibUsbDotNet;
@@ -635,6 +636,90 @@ public partial class UsbPanelsPage : Page
                     }
 
                     settings.ThermaltakePanelDevices.Remove(deviceConfig);
+                }
+            });
+        }
+    }
+
+    // === JL (Jungle Leopard / Hongtai) Panel ===
+
+    private async void ButtonDiscoverJlPanelDevices_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button)
+        {
+            button.IsEnabled = false;
+            await UpdateJlPanelDeviceList();
+            button.IsEnabled = true;
+        }
+    }
+
+    private Task UpdateJlPanelDeviceList()
+    {
+        var discoveredDevices = JlPanelHelper.ScanDevices();
+
+        Logger.Information("JlPanel Discovery: Found {Count} devices", discoveredDevices.Count);
+
+        foreach (var discoveredDevice in discoveredDevices)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var device = settings.JlPanelDevices.FirstOrDefault(d =>
+                    d.IsMatching(discoveredDevice.DeviceId, discoveredDevice.DeviceLocation, discoveredDevice.Model));
+
+                if (device == null)
+                {
+                    var newDevice = new JlPanelDevice()
+                    {
+                        DeviceId = discoveredDevice.DeviceId,
+                        DeviceLocation = discoveredDevice.DeviceLocation,
+                        Model = discoveredDevice.Model,
+                        ProfileGuid = ConfigModel.Instance.Profiles.FirstOrDefault()?.Guid ?? Guid.Empty,
+                        TargetFrameRate = discoveredDevice.ModelInfo?.DefaultFrameRate ?? 30,
+                    };
+
+                    if (discoveredDevice.ModelInfo != null)
+                    {
+                        newDevice.RuntimeProperties.Name = discoveredDevice.ModelInfo.Name;
+                    }
+
+                    settings.JlPanelDevices.Add(newDevice);
+                    Logger.Information("JlPanel Discovery: Added new device '{DeviceId}' on {Port}",
+                        discoveredDevice.DeviceId, discoveredDevice.DeviceLocation);
+                }
+                else
+                {
+                    // COM port may have changed; refresh location.
+                    device.DeviceLocation = discoveredDevice.DeviceLocation;
+
+                    if (device.ModelInfo != null)
+                    {
+                        device.RuntimeProperties.Name = device.ModelInfo.Name;
+                    }
+
+                    Logger.Information("JlPanel Discovery: Device '{DeviceId}' already exists", discoveredDevice.DeviceId);
+                }
+            });
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ButtonRemoveJlPanelDevice_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is JlPanelDevice runtimeDevice)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var deviceConfig = settings.JlPanelDevices.FirstOrDefault(c => c.Id == runtimeDevice.Id);
+
+                if (deviceConfig != null)
+                {
+                    if (JlPanelTask.Instance.IsDeviceRunning(deviceConfig.Id))
+                    {
+                        _ = JlPanelTask.Instance.StopDevice(deviceConfig.Id);
+                    }
+
+                    settings.JlPanelDevices.Remove(deviceConfig);
                 }
             });
         }

--- a/JL-PROTOCOL.md
+++ b/JL-PROTOCOL.md
@@ -1,0 +1,168 @@
+# Jungle Leopard / Hongtai Cooler Display Protocol
+
+This document describes the wire protocol used by Jungle Leopard branded
+cooler displays and the ~80 white-label SKUs that share the same Hongtai
+reference firmware (MSI EZ Display, Thermaltake LCD, ZOTAC, Jonsbo, and
+many more).
+
+The protocol was reverse-engineered from `Jungle Leopard Display.exe`
+v1.0.52 (Electron app, unpacked from `resources/app.asar`).
+
+## Transport
+
+| Property | Value |
+| --- | --- |
+| Class | USB CDC ACM (virtual COM port) |
+| VID | `0x33C3` |
+| PID | `0x7788` (reference) — `0x7791..0x7810` for OEM SKUs |
+| Baud rate | **2 000 000** (`0x1E8480`) |
+| Flow control | none |
+| Resolution | 480×960 (Chill Arc 360) — also 1920×462 strip variant |
+
+There is also an unrelated CH340-based SPI variant (PID `0x7793` behind
+VID `0x1A86` / PID `0x8040`) that uses raw RGB565 at 921 600 baud. That
+one is **not** supported by this driver — it is a different transport.
+
+## Command frame format
+
+Every host-to-device command is wrapped in this frame:
+
+```
++--------+--------+----------------+--------+-------------------+----------------+
+| 0x55   | 0xAA   | length (LE u16)| cmd u8 | payload (N bytes) | checksum LE u16|
++--------+--------+----------------+--------+-------------------+----------------+
+   2 bytes magic     2 bytes         1 byte      N bytes               2 bytes
+```
+
+* `length` = total frame size in bytes = `N + 7`
+  (magic 2 + length 2 + cmd 1 + payload + checksum 2).
+* `checksum` = `sum(all_preceding_bytes) & 0xFFFF`, written little-endian.
+  It is a plain u16 sum, **not** a CRC.
+* No escaping — the fixed length field tells the parser when a frame ends.
+
+### Response frame
+The device replies with the same outer shape:
+
+```
+[0x55 0xAA] [len_lo len_hi] [cmd] [payload] [chk_lo chk_hi]
+```
+
+For successful informational replies the payload is UTF-8 JSON. Status /
+error replies are a single byte:
+
+| Byte | Meaning |
+| ---- | ------- |
+| `0x01` | operation failed |
+| `0x02` | out of memory |
+| `0x03` | internal storage full |
+| `0x04` | SD card full |
+| `0x05` | file not found |
+| `0x06` | file open failed |
+| `0x07` | file write failed |
+
+## Command opcode table
+
+| Opcode | Action | Payload | Notes |
+| -----: | --- | --- | --- |
+| `0x01` | restart | none | Soft reboot of the panel MCU |
+| `0x03` | setLight | `[brightness 0..100]` | Backlight; 1 byte |
+| `0x06` | getDeviceInfo | none | Reply is JSON: `{uid, model, version, width, height, angle, region, ...}` |
+| `0x0C` | OTA begin | `[0xF2,0xFF, size_le_u32, 0,0,0,0]` (10 B) | Followed immediately by raw `.bin` chunked write |
+| `0x11` | live frame ack / refresh | none | Sent before each live image and every 1500 ms while streaming |
+| `0x14` | setMotionBeforeOffScreen | `[mode, secs]` | Firmware ≥ 4.1 |
+| `0x15` | setMotionTimeout | `[mode, secs]` | Firmware ≥ 2.8 — auto-off |
+| `0x20` | setRegion | UTF-8 string (region/profile name) | Selects a firmware-side preset |
+| `0x21` | close | none | Graceful shutdown, firmware ≥ 3.1 |
+| `0x23` | setSerialNum | UTF-8 string | Followed by an `0x01` restart |
+| `0x25` | setMotor | `[0|1]` | Pump motor toggle (only for region `sulcs`) |
+| `0x26` | setRealTimePlayTimeout | `[secs]` | Firmware ≥ 4.1 |
+
+## Image upload (live streaming)
+
+Live mode is JPEG over the same serial port. After connecting, the host:
+
+1. Sends `0x11` (refresh) to wake the live pipeline.
+2. Captures and resizes a frame to `width × height` (480×960 for Chill Arc 360).
+3. Encodes as JPEG, dropping quality until it fits in the firmware's
+   `maxSize` budget (~80 KB for the Chill Arc).
+4. Wraps the JPEG in a *data* envelope (firmware ≥ 2.8):
+
+   ```
+   +----------------+-------------------+----------------+
+   | size LE u32    | JPEG bytes        | sum LE u16     |
+   +----------------+-------------------+----------------+
+      4 bytes          variable             2 bytes
+   ```
+
+   `sum = sumOf(size_field || jpeg_bytes) & 0xFFFF`, little-endian.
+
+5. Writes the envelope to the serial port (the JL Display app uses
+   20 KB chunks for non-live writes; for live, the whole envelope is
+   written in one go).
+6. Pings `0x11` again every 1500 ms; otherwise re-sends pictures
+   continuously at the configured frame rate.
+
+A frame is **terminated** by writing the literal bytes `FF D9 FF D9`
+(two JPEG end-of-image markers back-to-back). Connecting also flushes
+the parser with `FF D9 FF D9 00 00 00 00`.
+
+## Connect / handshake sequence
+
+```
+open serial @ 2 Mbaud
+sleep 200 ms
+write FF D9 FF D9 00 00 00 00       # pipeline reset
+sleep 200 ms
+send cmd 0x06 (getDeviceInfo)        # expect JSON reply with uid, w, h, ver
+   if status != 200:  abort and retry
+   else: store deviceInfo
+optionally send 0x03 (setLight)
+enter live loop (0x11 keep-alive + JPEG envelope per frame)
+```
+
+A successful `getDeviceInfo` reply looks like:
+
+```json
+{
+  "status": 200,
+  "uid": "<serial>",
+  "model": "TXW818-ST7701S-4.0inch",
+  "version": "Ver1.0",
+  "width": 480,
+  "height": 960,
+  "angle": 0,
+  "region": "sulcs"
+}
+```
+
+## Important constants
+
+* **Frame magic:** `0x55 0xAA` (host → device and device → host)
+* **Image envelope ≥ v2.8:** `[u32 size_le][bytes][u16 sum_le]`
+* **End-of-image marker:** `FF D9 FF D9`
+* **Pipeline reset:** `FF D9 FF D9 00 00 00 00`
+* **Keep-alive:** `0x55 0xAA 07 00 11 11 01` (cmd `0x11`, no payload, sum = `0x111`)
+* **Default live rate:** 60 fps for v ≥ 2.8 displays, 30 fps below
+* **Max JPEG size (Chill Arc 360):** 80 KB
+
+## Implementation notes for InfoPanel
+
+The driver lives under `InfoPanel/JlPanel/` (model definitions and
+serial communication) and `InfoPanel/Services/JlPanelDeviceTask.cs`
+(per-device render+send loop). The settings collection is
+`Settings.JlPanelDevices` and the multi-device toggle is
+`Settings.JlPanelMultiDeviceMode`.
+
+Key behaviors implemented:
+
+* The render thread produces JPEGs at the user's target frame rate;
+  the send thread drains them to the serial port.
+* When no frame is available for ≥1 s, the send thread issues a bare
+  `0x11` keep-alive so the firmware doesn't drop us back to the boot
+  animation.
+* Frame size is capped at ~80 KB; quality is automatically reduced
+  (down to 30) until the JPEG fits.
+* Brightness changes (0–100) are pushed via cmd `0x03` whenever the
+  user moves the slider, plus once on connect.
+* On disconnect/dispose, the driver sends cmd `0x21` (close) so the
+  firmware knows to release the live pipeline cleanly.

--- a/PANELS.md
+++ b/PANELS.md
@@ -6,6 +6,7 @@
 - [Display Types Comparison](#display-types-comparison)
 - [BeadaPanel Models](#beadapanel-models)
 - [Turing Smart Screen/TURZX Models](#turing-smart-screenturzx-models)
+- [Jungle Leopard / Hongtai Models](#jungle-leopard--hongtai-models)
 - [Connection and Setup](#connection-and-setup)
 - [Troubleshooting](#troubleshooting)
 - [Recommendations](#recommendations)
@@ -89,6 +90,29 @@ Turing Smart Screen (also known as TURZX) models are also supported by InfoPanel
 - Closed protocol with no official documentation (InfoPanel is compatible at best effort basis)
 - Turing's official software may provide better performance than third-party applications (e.g high FPS video backgrounds)
 
+## Jungle Leopard / Hongtai Models
+
+Jungle Leopard ("JL") cooler displays are produced by Dongguan Hongtai Technology Co. The same firmware/protocol is shared across roughly 80 white-label SKUs sold under brands such as MSI EZ Display, Thermaltake, ZOTAC, Jonsbo, and others. The reference platform is the **JL Chill Arc 360** (a 480×960 round-corner display embedded in CPU water blocks).
+
+| Model | Resolution | Connection | Performance | Notes |
+|-------|------------|------------|-------------|-------|
+| JL Chill Arc 360 | 480×960 | CDC Serial @ 2 Mbaud | ~30 FPS | Reference Hongtai 5" panel; same protocol as MSI EZ Display etc. |
+| JL Strip Display | 1920×462 | CDC Serial @ 2 Mbaud | ~60 FPS | Wide strip variant on the same firmware family |
+
+**Key Jungle Leopard Features**:
+- Enumerates as a **USB CDC ACM virtual COM port** (no special driver — Windows ships the inbox driver)
+- 2 Mbaud framed protocol with JPEG-encoded frames
+- Hardware brightness control (0–100)
+- Same protocol works across all OEM rebrands (MSI EZ Display, Thermaltake LCD, ZOTAC, Jonsbo, etc.) when the device exposes VID `0x33C3`
+- Open protocol: see [`JL-PROTOCOL.md`](./JL-PROTOCOL.md) for full wire format
+- Built-in keep-alive from InfoPanel ensures the live pipeline doesn't time out
+
+**Limitations**:
+- Single CDC channel for both image data and commands; brightness writes briefly interrupt streaming
+- If the protocol's keep-alive is missed for >1.5 s the firmware reverts to its built-in animation, requiring a reconnect
+- JPEG payload is capped at ~80 KB by the firmware — InfoPanel automatically lowers JPEG quality if a frame doesn't fit
+- The CH340/SPI variant (PID `0x7793`) uses a completely different transport (raw RGB565 over a CH340 USB-UART) and is **not** currently supported
+
 ## Connection and Setup
 
 > **Important Note**: Ensure no other software is actively using the panel when connecting with InfoPanel. Having multiple applications trying to control the display simultaneously can cause conflicts and unpredictable behavior.
@@ -117,6 +141,8 @@ Turing Smart Screen (also known as TURZX) models are also supported by InfoPanel
    - Turing Panel A (3.5")
    - Turing Panel C (5")
    - Turing Panel E (8.8" Rev 1.0)
+   - Thermaltake / ASRock LCD
+   - Jungle Leopard / Hongtai (Chill Arc 360, MSI EZ Display, etc.)
 4. Select a display profile for your panel
 5. Adjust rotation and brightness as needed
 


### PR DESCRIPTION
## Summary

Adds InfoPanel support for cooler-mounted LCD displays based on the Hongtai (Dongguan Hongtai Technology Co.) reference firmware. The reference platform is the **JL Chill Arc 360** (480x960). The same protocol is used by ~80 white-label SKUs sold under brands such as MSI EZ Display, Thermaltake LCD, ZOTAC, and Jonsbo.

The strip variant (1920x462) is also covered.

## Protocol

Reverse-engineered from `Jungle Leopard Display.exe` v1.0.52 (Electron app). Full details are in [`JL-PROTOCOL.md`](https://github.com/emaspa/infopanel/blob/jl-panel-support/JL-PROTOCOL.md).

- Transport: **USB CDC ACM virtual COM port @ 2 Mbaud** (Windows inbox driver, no Zadig)
- Reference VID/PID: `0x33C3:0x7788` (OEMs use other PIDs in `0x7791..0x7810` on the same VID)
- Command frame: `0x55 0xAA [len_LE16] [cmd] [payload] [sum_LE16]` (sum is plain u16, not CRC)
- Live JPEG envelope: `[size_LE32] [JPEG bytes] [sum_LE16]` followed by `FF D9 FF D9` terminator
- Pipeline reset on connect: `FF D9 FF D9 00 00 00 00`
- Keep-alive: cmd `0x11` at least every 1500 ms (otherwise the firmware drops back to its boot animation)
- Hardware brightness via cmd `0x03` (0..100), graceful close via cmd `0x21`
- `getDeviceInfo` (cmd `0x06`) returns JSON with the device's actual `width`/`height`/`angle`/`region`/`uid`/firmware version

## Implementation

```
InfoPanel/JlPanel/
  JlPanelModel.cs              -- enum (ChillArc360, StripDisplay)
  JlPanelModelInfo.cs          -- model metadata (resolution, max JPEG, default FPS)
  JlPanelModelDatabase.cs      -- VID/PID -> model lookup
  JlPanelHelper.cs             -- WMI Win32_SerialPort discovery
  JlSerialDevice.cs            -- protocol implementation (frame builder, JPEG envelope, response parser)

InfoPanel/Models/JlPanelDevice.cs        -- per-device config (ObservableObject)
InfoPanel/Services/JlPanelTask.cs        -- multi-device singleton manager
InfoPanel/Services/JlPanelDeviceTask.cs  -- per-device render+send loop
```

Per-device task highlights:
- Auto-detects resolution from `getDeviceInfo` (overrides the model database if the device reports something different)
- Two-thread render/send pipeline (matches the existing Thermaltake/Thermalright pattern)
- JPEG quality auto-fallback if a frame exceeds the firmware's ~80 KB budget
- 1-second fallback keep-alive when no new frame is being produced (e.g. fully-static profile)
- Pushes brightness changes live via cmd `0x03`
- Sends graceful `0x21` close on dispose

UI: new \"Jungle Leopard / Hongtai\" CardExpander on the USB Panels page with discovery, per-device profile/rotation pickers, and an Advanced popup for brightness/FPS/JPEG quality. Mirrors the existing Thermaltake/ASRock section layout.

## Documentation

- [`JL-PROTOCOL.md`](https://github.com/emaspa/infopanel/blob/jl-panel-support/JL-PROTOCOL.md) -- full wire protocol reference for future contributors
- [`PANELS.md`](https://github.com/emaspa/infopanel/blob/jl-panel-support/PANELS.md) -- new model table + feature/limitation summary in the user-facing guide

## Not in scope

- The CH340-based **SPI variant (PID `0x7793`)** uses raw RGB565 over a CH340 USB-UART at 921 600 baud. That is a completely different transport and is intentionally not handled by this driver.
- Per-device storage management / OTA firmware update commands are documented in `JL-PROTOCOL.md` but not exposed in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)