### PR TITLE
Add Thermalright SPISCRM-V2 panels + Wonder Vision 360 v2, harden ChiZhu detection

### DIFF
--- a/InfoPanel/Models/ThermalrightPanelDevice.cs
+++ b/InfoPanel/Models/ThermalrightPanelDevice.cs
@@ -87,6 +87,7 @@ namespace InfoPanel.Models
             get
             {
                 return Model == ThermalrightPanelModel.WonderVision360
+                    || Model == ThermalrightPanelModel.WonderVision360V2
                     || Model == ThermalrightPanelModel.RainbowVision360
                     || Model == ThermalrightPanelModel.LevitaVision360;
             }

--- a/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
@@ -716,8 +716,32 @@ namespace InfoPanel.Services
                 if (sub.HasValue)
                     Logger.Information("ThermalrightPanelDevice {Device}: ChiZhu SUB byte at [28]: 0x{SUB:X2} ({SUBDec})", _device, sub.Value, sub.Value);
 
-                // Try ChiZhu PM+SUB table first (covers ~35 SSCRM bulk models)
-                if (pm.HasValue && sub.HasValue)
+                // Try identifier-based detection first (SSCRM-V1/V3/V4, SPISCRM-V2).
+                // Identifier wins over PM+SUB because some panels (e.g. SPISCRM-V2 Elite Vision 360) report
+                // the same PM+SUB as a generic ChiZhu Vision 320x320 but use a different pixel format.
+                // The identifier table is sparse, so unknown identifiers fall through to the PM+SUB lookup.
+                string? deviceIdentifier = null;
+                if (bytesRead >= 12)
+                {
+                    deviceIdentifier = System.Text.Encoding.ASCII.GetString(responseBuffer, 4, 8).TrimEnd('\0');
+                    Logger.Information("ThermalrightPanelDevice {Device}: Device identifier: {Id}", _device, deviceIdentifier);
+
+                    if (!string.IsNullOrEmpty(deviceIdentifier))
+                    {
+                        _detectedModel = ThermalrightPanelModelDatabase.GetModelByIdentifier(deviceIdentifier, sub);
+                        if (_detectedModel != null)
+                        {
+                            _panelWidth = _detectedModel.RenderWidth;
+                            _panelHeight = _detectedModel.RenderHeight;
+                            _device.Model = _detectedModel.Model;
+                            Logger.Information("ThermalrightPanelDevice {Device}: Identifier {Id} -> {Model} ({Width}x{Height})",
+                                _device, deviceIdentifier, _detectedModel.Name, _panelWidth, _panelHeight);
+                        }
+                    }
+                }
+
+                // Fall back to ChiZhu PM+SUB table (covers ~35 SSCRM bulk models without a known identifier)
+                if (_detectedModel == null && pm.HasValue && sub.HasValue)
                 {
                     var chizhuModel = ThermalrightPanelModelDatabase.GetModelByChiZhuPM(pm.Value, sub.Value);
                     if (chizhuModel != null)
@@ -729,26 +753,9 @@ namespace InfoPanel.Services
                         Logger.Information("ThermalrightPanelDevice {Device}: ChiZhu PM 0x{PM:X2} sub 0x{SUB:X2} -> {Model} ({Width}x{Height})",
                             _device, pm.Value, sub.Value, chizhuModel.Name, _panelWidth, _panelHeight);
                     }
-                }
-
-                // Fall back to identifier-based detection (SSCRM-V1/V3/V4)
-                if (_detectedModel == null && bytesRead >= 12)
-                {
-                    var deviceIdentifier = System.Text.Encoding.ASCII.GetString(responseBuffer, 4, 8).TrimEnd('\0');
-                    Logger.Information("ThermalrightPanelDevice {Device}: Device identifier: {Id}", _device, deviceIdentifier);
-
-                    _detectedModel = ThermalrightPanelModelDatabase.GetModelByIdentifier(deviceIdentifier, sub);
-                    if (_detectedModel != null)
+                    else if (!string.IsNullOrEmpty(deviceIdentifier))
                     {
-                        _panelWidth = _detectedModel.RenderWidth;
-                        _panelHeight = _detectedModel.RenderHeight;
-                        _device.Model = _detectedModel.Model;
-                        Logger.Information("ThermalrightPanelDevice {Device}: Detected {Model} - using {Width}x{Height}",
-                            _device, _detectedModel.Name, _panelWidth, _panelHeight);
-                    }
-                    else
-                    {
-                        Logger.Warning("ThermalrightPanelDevice {Device}: Unknown identifier '{Id}', using default {Width}x{Height}",
+                        Logger.Warning("ThermalrightPanelDevice {Device}: Unknown identifier '{Id}' and no PM+SUB match, using default {Width}x{Height}",
                             _device, deviceIdentifier, _panelWidth, _panelHeight);
                     }
                 }

--- a/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
@@ -122,8 +122,10 @@ namespace InfoPanel.Services
 
             // Bytes 16-55: Zero padding (already zeroed)
 
-            // Bytes 56-59: Command repeated
-            BitConverter.GetBytes(cmd).CopyTo(header, 56);
+            // Bytes 56-59: Frame type (SSCRM_CMD_TYPE_PICTURE = 2). Constant regardless
+            // of pixel format — TRCC writes 2 here even when the data-format byte at offset
+            // 4 is 3 (RGB565). Without this, RGB565 panels (PM=0x20 / SPISCRM-V2) reject frames.
+            BitConverter.GetBytes(0x02).CopyTo(header, 56);
 
             // Bytes 60-63: Data size (little-endian)
             BitConverter.GetBytes(dataSize).CopyTo(header, 60);
@@ -251,10 +253,7 @@ namespace InfoPanel.Services
                         dimmed = ApplyBrightness(resizedBitmap);
                         convertBitmap = dimmed;
                     }
-                    using var rgb565Bitmap = convertBitmap.Copy(SKColorType.Rgb565);
-                    var bytes = rgb565Bitmap.Bytes;
-                    if (bigEndian) SwapRgb565Endianness(bytes);
-                    return bytes;
+                    return ConvertRgba8888ToRgb565(convertBitmap, bigEndian);
                 }
                 finally
                 {
@@ -342,13 +341,53 @@ namespace InfoPanel.Services
         }
 
         /// <summary>
-        /// Byte-swaps each 16-bit pixel in-place for big-endian RGB565.
-        /// Required for 320x320 panels.
+        /// Converts an RGBA8888 bitmap to RGB565 by truncation (no dithering).
+        /// SkiaSharp's Copy(SKColorType.Rgb565) applies ordered dithering, which produces
+        /// a fine mesh pattern visible on smooth gradients. TRCC's reference implementation
+        /// (FormCZTV.ImageTo565) drops the low bits with no dithering, so we match that.
+        /// Reads the bitmap row-by-row honoring RowBytes to avoid any row padding bleed.
         /// </summary>
-        private static void SwapRgb565Endianness(byte[] data)
+        private static byte[] ConvertRgba8888ToRgb565(SKBitmap bitmap, bool bigEndian)
         {
-            for (int i = 0; i < data.Length - 1; i += 2)
-                (data[i], data[i + 1]) = (data[i + 1], data[i]);
+            int width = bitmap.Width;
+            int height = bitmap.Height;
+            int srcRowBytes = bitmap.RowBytes;
+            byte[] dst = new byte[width * height * 2];
+
+            unsafe
+            {
+                byte* srcBase = (byte*)bitmap.GetPixels().ToPointer();
+                fixed (byte* dstBase = dst)
+                {
+                    for (int y = 0; y < height; y++)
+                    {
+                        byte* srcRow = srcBase + y * srcRowBytes;
+                        byte* dstRow = dstBase + y * width * 2;
+                        for (int x = 0; x < width; x++)
+                        {
+                            byte r = srcRow[x * 4];      // Rgba8888: R, G, B, A
+                            byte g = srcRow[x * 4 + 1];
+                            byte b = srcRow[x * 4 + 2];
+
+                            // Truncate to 5/6/5 — exact match to TRCC FormCZTV.ImageTo565
+                            byte hi = (byte)((r & 0xF8) | (g >> 5));        // RRRRR_GGG
+                            byte lo = (byte)(((g & 0x1C) << 3) | (b >> 3)); // GGG_BBBBB
+
+                            if (bigEndian)
+                            {
+                                dstRow[x * 2]     = hi;
+                                dstRow[x * 2 + 1] = lo;
+                            }
+                            else
+                            {
+                                dstRow[x * 2]     = lo;
+                                dstRow[x * 2 + 1] = hi;
+                            }
+                        }
+                    }
+                }
+            }
+            return dst;
         }
 
         private byte[]? _blackFrame;
@@ -723,7 +762,10 @@ namespace InfoPanel.Services
                 string? deviceIdentifier = null;
                 if (bytesRead >= 12)
                 {
-                    deviceIdentifier = System.Text.Encoding.ASCII.GetString(responseBuffer, 4, 8).TrimEnd('\0');
+                    // Identifier zone is bytes 4..19 (flags byte is at offset 20). Length varies:
+                    // SSCRM-V1/V3/V4 = 8 chars, SPISCRM-V2 = 10 chars, all null-padded.
+                    int idLen = Math.Min(16, bytesRead - 4);
+                    deviceIdentifier = System.Text.Encoding.ASCII.GetString(responseBuffer, 4, idLen).TrimEnd('\0');
                     Logger.Information("ThermalrightPanelDevice {Device}: Device identifier: {Id}", _device, deviceIdentifier);
 
                     if (!string.IsNullOrEmpty(deviceIdentifier))

--- a/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
@@ -755,10 +755,11 @@ namespace InfoPanel.Services
                 if (sub.HasValue)
                     Logger.Information("ThermalrightPanelDevice {Device}: ChiZhu SUB byte at [28]: 0x{SUB:X2} ({SUBDec})", _device, sub.Value, sub.Value);
 
-                // Try identifier-based detection first (SSCRM-V1/V3/V4, SPISCRM-V2).
-                // Identifier wins over PM+SUB because some panels (e.g. SPISCRM-V2 Elite Vision 360) report
-                // the same PM+SUB as a generic ChiZhu Vision 320x320 but use a different pixel format.
-                // The identifier table is sparse, so unknown identifiers fall through to the PM+SUB lookup.
+                // Three-pass ChiZhu detection. The identifier alone is not unique: SSCRM-V1
+                // firmware ships on both 480x480 (Grand/Hydro/Hyper/Peerless, PM=1/3/4) and
+                // 640x480 (Stream Vision, PM=7). PM+SUB resolves those. Identifier+SUB is only
+                // used to OVERRIDE a wrong PM+SUB entry (e.g. SPISCRM-V2 at PM=0x20 SUB=0x20
+                // overrides the legacy generic ChiZhuVision320x320).
                 string? deviceIdentifier = null;
                 if (bytesRead >= 12)
                 {
@@ -767,22 +768,23 @@ namespace InfoPanel.Services
                     int idLen = Math.Min(16, bytesRead - 4);
                     deviceIdentifier = System.Text.Encoding.ASCII.GetString(responseBuffer, 4, idLen).TrimEnd('\0');
                     Logger.Information("ThermalrightPanelDevice {Device}: Device identifier: {Id}", _device, deviceIdentifier);
+                }
 
-                    if (!string.IsNullOrEmpty(deviceIdentifier))
+                // Pass 1: strict identifier+SUB override (Wonder/Rainbow/Levita SSCRM-V3, SPISCRM-V2)
+                if (!string.IsNullOrEmpty(deviceIdentifier) && sub.HasValue)
+                {
+                    _detectedModel = ThermalrightPanelModelDatabase.GetModelByIdentifierAndSub(deviceIdentifier, sub.Value);
+                    if (_detectedModel != null)
                     {
-                        _detectedModel = ThermalrightPanelModelDatabase.GetModelByIdentifier(deviceIdentifier, sub);
-                        if (_detectedModel != null)
-                        {
-                            _panelWidth = _detectedModel.RenderWidth;
-                            _panelHeight = _detectedModel.RenderHeight;
-                            _device.Model = _detectedModel.Model;
-                            Logger.Information("ThermalrightPanelDevice {Device}: Identifier {Id} -> {Model} ({Width}x{Height})",
-                                _device, deviceIdentifier, _detectedModel.Name, _panelWidth, _panelHeight);
-                        }
+                        _panelWidth = _detectedModel.RenderWidth;
+                        _panelHeight = _detectedModel.RenderHeight;
+                        _device.Model = _detectedModel.Model;
+                        Logger.Information("ThermalrightPanelDevice {Device}: Identifier {Id}+SUB 0x{SUB:X2} -> {Model} ({Width}x{Height})",
+                            _device, deviceIdentifier, sub.Value, _detectedModel.Name, _panelWidth, _panelHeight);
                     }
                 }
 
-                // Fall back to ChiZhu PM+SUB table (covers ~35 SSCRM bulk models without a known identifier)
+                // Pass 2: PM+SUB table (covers most ChiZhu panels by hardware variant)
                 if (_detectedModel == null && pm.HasValue && sub.HasValue)
                 {
                     var chizhuModel = ThermalrightPanelModelDatabase.GetModelByChiZhuPM(pm.Value, sub.Value);
@@ -795,7 +797,22 @@ namespace InfoPanel.Services
                         Logger.Information("ThermalrightPanelDevice {Device}: ChiZhu PM 0x{PM:X2} sub 0x{SUB:X2} -> {Model} ({Width}x{Height})",
                             _device, pm.Value, sub.Value, chizhuModel.Name, _panelWidth, _panelHeight);
                     }
-                    else if (!string.IsNullOrEmpty(deviceIdentifier))
+                }
+
+                // Pass 3: identifier-only catch-all for legacy panels not in the PM+SUB switch
+                // (e.g. PM=1 SUB=0 Grand Vision: identifier SSCRM-V1 routes to the 480x480 entry).
+                if (_detectedModel == null && !string.IsNullOrEmpty(deviceIdentifier))
+                {
+                    _detectedModel = ThermalrightPanelModelDatabase.GetModelByIdentifier(deviceIdentifier);
+                    if (_detectedModel != null)
+                    {
+                        _panelWidth = _detectedModel.RenderWidth;
+                        _panelHeight = _detectedModel.RenderHeight;
+                        _device.Model = _detectedModel.Model;
+                        Logger.Information("ThermalrightPanelDevice {Device}: Identifier {Id} (fallback) -> {Model} ({Width}x{Height})",
+                            _device, deviceIdentifier, _detectedModel.Name, _panelWidth, _panelHeight);
+                    }
+                    else
                     {
                         Logger.Warning("ThermalrightPanelDevice {Device}: Unknown identifier '{Id}' and no PM+SUB match, using default {Width}x{Height}",
                             _device, deviceIdentifier, _panelWidth, _panelHeight);

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
@@ -53,6 +53,10 @@ namespace InfoPanel.ThermalrightPanel
         // ChiZhu bulk (87AD:70DB) PM=0x20 variant — 320x320, RGB565
         ChiZhuVision320x320,
 
+        // ChiZhu bulk (87AD:70DB) responding with SPISCRM-V2 identifier — Elite Vision 360 ARGB Black
+        // SPI-driven 320x320 panel, RGB565 little-endian (unlike the generic PM=0x20 entry which is BE)
+        EliteVision360,
+
         // SCSI pass-through — resolution detected at runtime from poll response
         EliteVisionScsi,      // VID 0x0402 / PID 0x3922 — Frozen Warframe, Elite Vision 360
         ThermalrightScsi,     // VID 0x87CD / PID 0x70DB — Frozen Horizon Pro, Core Vision, Elite Vision, Wonder Vision

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
@@ -7,6 +7,8 @@ namespace InfoPanel.ThermalrightPanel
         PeerlessVision360,
         // Wonder Vision 360 - 6.67" (2400x1080) - responds with SSCRM-V3, SUB=0x01
         WonderVision360,
+        // Wonder Vision 360 v2 - 6.67" (2400x1080) - responds with SSCRM-V3, SUB=0x20, PM=0x07. Same panel, newer firmware batch.
+        WonderVision360V2,
         // Rainbow Vision 360 - 6.67" (2400x1080) - responds with SSCRM-V3, SUB=0x02
         RainbowVision360,
         // Levita Vision 360 - 6.67" (2400x1080) - responds with SSCRM-V3, SUB=0x03

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
@@ -78,9 +78,10 @@ namespace InfoPanel.ThermalrightPanel
         public const string IDENTIFIER_V3 = "SSCRM-V3"; // Wonder / Rainbow Vision 360 (2400x1080) — SUB byte differentiates
 
         // SUB byte (init response byte[28]) for SSCRM-V3 models
-        public const byte WONDER_360_SUB_BYTE  = 0x01; // Wonder Vision 360
-        public const byte RAINBOW_360_SUB_BYTE = 0x02; // Rainbow Vision 360
-        public const byte LEVITA_360_SUB_BYTE  = 0x03; // Levita Vision 360
+        public const byte WONDER_360_SUB_BYTE    = 0x01; // Wonder Vision 360
+        public const byte RAINBOW_360_SUB_BYTE   = 0x02; // Rainbow Vision 360
+        public const byte LEVITA_360_SUB_BYTE    = 0x03; // Levita Vision 360
+        public const byte WONDER_360_V2_SUB_BYTE = 0x20; // Wonder Vision 360 v2 (newer firmware batch, PM=0x07)
         public const string IDENTIFIER_V4 = "SSCRM-V4"; // TL-M10 Vision (1920x462)
         public const string IDENTIFIER_SPI_V2 = "SPISCRM-V2"; // Elite Vision 360 ARGB Black (SPI 320x320, RGB565 LE)
 
@@ -110,6 +111,22 @@ namespace InfoPanel.ThermalrightPanel
                 VendorId = THERMALRIGHT_VENDOR_ID,
                 ProductId = THERMALRIGHT_PRODUCT_ID,
                 SubByte = WONDER_360_SUB_BYTE
+            },
+            // Wonder Vision 360 v2: same physical 6.67" 2400x1080 panel, newer firmware reports
+            // SSCRM-V3 with SUB=0x20 (and PM=0x07). The strict identifier+SUB detection pass picks
+            // this up before the PM+SUB table would mis-route PM=7 to the 640x480 Stream Vision entry.
+            [ThermalrightPanelModel.WonderVision360V2] = new ThermalrightPanelModelInfo
+            {
+                Model = ThermalrightPanelModel.WonderVision360V2,
+                Name = "Wonder Vision 360 6.67\" v2",
+                DeviceIdentifier = IDENTIFIER_V3,
+                Width = 2400,
+                Height = 1080,
+                RenderWidth = 1600,  // Same panel/render size as Wonder Vision 360
+                RenderHeight = 720,
+                VendorId = THERMALRIGHT_VENDOR_ID,
+                ProductId = THERMALRIGHT_PRODUCT_ID,
+                SubByte = WONDER_360_V2_SUB_BYTE
             },
             [ThermalrightPanelModel.RainbowVision360] = new ThermalrightPanelModelInfo
             {

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
@@ -82,6 +82,7 @@ namespace InfoPanel.ThermalrightPanel
         public const byte RAINBOW_360_SUB_BYTE = 0x02; // Rainbow Vision 360
         public const byte LEVITA_360_SUB_BYTE  = 0x03; // Levita Vision 360
         public const string IDENTIFIER_V4 = "SSCRM-V4"; // TL-M10 Vision (1920x462)
+        public const string IDENTIFIER_SPI_V2 = "SPISCRM-V2"; // Elite Vision 360 ARGB Black (SPI 320x320, RGB565 LE)
 
         public static readonly Dictionary<ThermalrightPanelModel, ThermalrightPanelModelInfo> Models = new()
         {
@@ -460,6 +461,24 @@ namespace InfoPanel.ThermalrightPanel
                 ProductId = THERMALRIGHT_PRODUCT_ID,
                 ProtocolType = ThermalrightProtocolType.ChiZhu,
                 PixelFormat = ThermalrightPixelFormat.Rgb565BigEndian
+            },
+            // SPISCRM-V2 identifier: Elite Vision 360 ARGB Black (and likely other SPI-driven 320x320 panels)
+            // Reports PM=0x20 / SUB=0x20 at the same offsets as the generic ChiZhu 320x320, but is NOT
+            // big-endian — every other SPI panel in our database is RGB565 little-endian, and the PM=0x20/BE
+            // entry produces a stuck Thermalright boot logo on this device.
+            [ThermalrightPanelModel.EliteVision360] = new ThermalrightPanelModelInfo
+            {
+                Model = ThermalrightPanelModel.EliteVision360,
+                Name = "Elite Vision 360 ARGB",
+                DeviceIdentifier = IDENTIFIER_SPI_V2,
+                Width = 320,
+                Height = 320,
+                RenderWidth = 320,
+                RenderHeight = 320,
+                VendorId = THERMALRIGHT_VENDOR_ID,
+                ProductId = THERMALRIGHT_PRODUCT_ID,
+                ProtocolType = ThermalrightProtocolType.ChiZhu,
+                PixelFormat = ThermalrightPixelFormat.Rgb565
             },
             [ThermalrightPanelModel.EliteVisionScsi] = new ThermalrightPanelModelInfo
             {

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
@@ -462,14 +462,15 @@ namespace InfoPanel.ThermalrightPanel
                 ProtocolType = ThermalrightProtocolType.ChiZhu,
                 PixelFormat = ThermalrightPixelFormat.Rgb565BigEndian
             },
-            // SPISCRM-V2 identifier: Elite Vision 360 ARGB Black (and likely other SPI-driven 320x320 panels)
-            // Reports PM=0x20 / SUB=0x20 at the same offsets as the generic ChiZhu 320x320, but is NOT
-            // big-endian — every other SPI panel in our database is RGB565 little-endian, and the PM=0x20/BE
-            // entry produces a stuck Thermalright boot logo on this device.
+            // SPISCRM-V2 identifier: Elite Vision 360 ARGB Black, Frozen Warframe PRO 360, etc.
+            // PM=0x20 / SUB=0x20. TRCC FormCZTV.cs maps PM=32 to myDeviceMode=4, which
+            // sends RGB565 big-endian frames (cmd=3 at offset 4) and packs RGB565 with
+            // high byte first (RRRRRGGG / GGGBBBBB). The matching frame-type byte at
+            // offset 56 is always 2 (SSCRM_CMD_TYPE_PICTURE) — see BuildDisplayHeader.
             [ThermalrightPanelModel.EliteVision360] = new ThermalrightPanelModelInfo
             {
                 Model = ThermalrightPanelModel.EliteVision360,
-                Name = "Elite Vision 360 ARGB",
+                Name = "Thermalright 320x320 (SPISCRM-V2)",
                 DeviceIdentifier = IDENTIFIER_SPI_V2,
                 Width = 320,
                 Height = 320,
@@ -478,7 +479,7 @@ namespace InfoPanel.ThermalrightPanel
                 VendorId = THERMALRIGHT_VENDOR_ID,
                 ProductId = THERMALRIGHT_PRODUCT_ID,
                 ProtocolType = ThermalrightProtocolType.ChiZhu,
-                PixelFormat = ThermalrightPixelFormat.Rgb565
+                PixelFormat = ThermalrightPixelFormat.Rgb565BigEndian
             },
             [ThermalrightPanelModel.EliteVisionScsi] = new ThermalrightPanelModelInfo
             {

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
@@ -479,7 +479,9 @@ namespace InfoPanel.ThermalrightPanel
                 VendorId = THERMALRIGHT_VENDOR_ID,
                 ProductId = THERMALRIGHT_PRODUCT_ID,
                 ProtocolType = ThermalrightProtocolType.ChiZhu,
-                PixelFormat = ThermalrightPixelFormat.Rgb565BigEndian
+                PixelFormat = ThermalrightPixelFormat.Rgb565BigEndian,
+                SubByte = 0x20  // Required for the strict identifier+SUB lookup to win over the
+                                // generic PM=0x20 ChiZhuVision320x320 PM+SUB entry.
             },
             [ThermalrightPanelModel.EliteVisionScsi] = new ThermalrightPanelModelInfo
             {
@@ -972,23 +974,34 @@ namespace InfoPanel.ThermalrightPanel
         }
 
         /// <summary>
-        /// Get model info by device identifier string (e.g., "SSCRM-V1", "SSCRM-V3", "SSCRM-V4")
-        /// and optional SUB byte for disambiguation (e.g., SSCRM-V3 + SUB=0x01 = Wonder, SUB=0x02 = Rainbow).
+        /// Strict identifier+SUB lookup: only returns entries whose DeviceIdentifier matches AND
+        /// whose SubByte equals the device's SUB. Used as the first detection pass for ChiZhu
+        /// devices where the identifier alone isn't enough (e.g. SSCRM-V1 firmware ships on
+        /// both 480x480 Grand-family and 640x480 Stream Vision; only PM byte distinguishes them).
+        /// </summary>
+        public static ThermalrightPanelModelInfo? GetModelByIdentifierAndSub(string identifier, byte subByte)
+        {
+            foreach (var model in Models.Values)
+            {
+                if (model.DeviceIdentifier == identifier && model.SubByte.HasValue && model.SubByte.Value == subByte)
+                    return model;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Identifier-only fallback for legacy panels not covered by the PM+SUB switch
+        /// (e.g. PM=1 SUB=0 Grand Vision is not in GetModelByChiZhuPM). First match wins.
+        /// Callers should attempt PM+SUB first; only fall back to this when PM+SUB returns null.
         /// </summary>
         public static ThermalrightPanelModelInfo? GetModelByIdentifier(string identifier, byte? subByte = null)
         {
-            // If SUB byte provided, try exact match first (identifier + SUB)
             if (subByte.HasValue)
             {
-                foreach (var model in Models.Values)
-                {
-                    if (model.DeviceIdentifier == identifier && model.SubByte.HasValue && model.SubByte.Value == subByte.Value)
-                        return model;
-                }
+                var strict = GetModelByIdentifierAndSub(identifier, subByte.Value);
+                if (strict != null) return strict;
             }
 
-            // Fallback: match by identifier only (first match wins — for unique identifiers like V1/V4,
-            // or when SUB byte is unknown/not in database)
             foreach (var model in Models.Values)
             {
                 if (model.DeviceIdentifier == identifier)


### PR DESCRIPTION
## Why?

Several Thermalright ChiZhu panels were misdetected because the model identity is encoded across an init-response identifier string **and** PM/SUB bytes, and the identifier alone is not unique:

1. **SPISCRM-V2 320x320 panels** (Elite Vision 360 ARGB Black, Frozen Warframe PRO 360, rebadges) showed only the boot logo: wrong detection and wrong pixel handling.
2. **Wonder Vision 360 v2** (a newer firmware batch) reports `SSCRM-V3` with `SUB=0x20` / `PM=0x07`, so it was misdetected as a 640x480 Stream Vision instead of the 1600x720 widescreen panel.
3. Shared-firmware panels (e.g. `SSCRM-V1` ships on both 480x480 Grand-family and 640x480 Stream Vision) need the PM byte to disambiguate, which an identifier-first lookup broke.

## How?

Add the new model entries and replace the single-pass detection with a deterministic three-pass lookup.

### Three-pass ChiZhu detection

1. **Strict identifier + SUB**: only matches an entry whose `DeviceIdentifier` *and* `SubByte` both equal the device's values. This is the override path for SPISCRM-V2 and the `SSCRM-V3` SUB variants (Wonder/Rainbow/Levita + the new Wonder v2).
2. **PM + SUB table**: resolves all hardware variants by PM byte (Stream Vision PM=7, etc.).
3. **Identifier-only catch-all**: for legacy panels missing from the PM+SUB switch (e.g. PM=1 Grand Vision via `SSCRM-V1`).

`GetModelByIdentifier` was split into `GetModelByIdentifierAndSub` (strict) + the identifier-only fallback.

### SPISCRM-V2 (Elite Vision 360 ARGB / Frozen Warframe PRO 360)

Four bugs fixed:
- **Identifier parser truncated to 8 bytes**: `SPISCRM-V2` is 10 chars, parsed as `SPISCRM-`; now reads up to 16 bytes from offset 4.
- **Header byte 56** was written as the data-format byte; per TRCC it is the frame type and is always `0x02` (`SSCRM_CMD_TYPE_PICTURE`) regardless of pixel format. With `0x03` there the controller silently rejected every RGB565 frame.
- **Pixel format** is `Rgb565BigEndian` (TRCC `myDeviceMode=4`, PM=0x20), packed high-byte-first.
- **Skia dither mesh**: `Copy(SKColorType.Rgb565)` applies ordered dithering, visible as a fine mesh on gradients. Replaced with a manual truncating `ConvertRgba8888ToRgb565` matching TRCC's `FormCZTV.ImageTo565`.

Model named generically (`Thermalright 320x320 (SPISCRM-V2)`) since multiple SKUs share the hardware. Confirmed working on a real Elite Vision 360 ARGB Black.

### Wonder Vision 360 v2

New `WonderVision360V2` entry: identifier `SSCRM-V3`, `SubByte=0x20`, renders **1600x720** (same as the original Wonder Vision 360), with the camera punch-hole display-mask option. The strict identifier+SUB pass picks it up before PM=7 would mis-route it to Stream Vision. Confirmed working on real hardware.

<sub>Generated with Claude Code</sub>
