### PR TITLE
Add VMAX 4.6 LCD panel (AuyiHomu HY-001,HY-002) support

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -405,6 +405,7 @@ namespace InfoPanel
                 await TuringPanelTask.Instance.StopAsync(true);
                 await ThermalrightPanelTask.Instance.StopAsync(true);
                 await ThermaltakePanelTask.Instance.StopAsync(true);
+                await VmaxPanelTask.Instance.StopAsync(true);
             });
         }
 
@@ -426,6 +427,7 @@ namespace InfoPanel
                         await TuringPanelTask.Instance.StopAsync(true);
                         await ThermalrightPanelTask.Instance.StopAsync(true);
                         await ThermaltakePanelTask.Instance.StopAsync(true);
+                        await VmaxPanelTask.Instance.StopAsync(true);
                     });
                     break;
             }
@@ -453,6 +455,11 @@ namespace InfoPanel
                 await ThermaltakePanelTask.Instance.StartAsync();
             }
 
+            if (ConfigModel.Instance.Settings.VmaxPanelMultiDeviceMode)
+            {
+                await VmaxPanelTask.Instance.StartAsync();
+            }
+
             if (ConfigModel.Instance.Settings.WebServer)
             {
                 await WebServerTask.Instance.StartAsync();
@@ -466,6 +473,7 @@ namespace InfoPanel
             await TuringPanelTask.Instance.StopAsync();
             await ThermalrightPanelTask.Instance.StopAsync();
             await ThermaltakePanelTask.Instance.StopAsync();
+            await VmaxPanelTask.Instance.StopAsync();
         }
 
         private void App_Exit(object sender, ExitEventArgs e)

--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -273,7 +273,6 @@ namespace InfoPanel
         public void Initialize()
         {
             LoadProfiles();
-            AutoDiscoverVmaxPanelDevices();
 
             if (SharedModel.Instance.SelectedProfile is Profile p)
                 _currentSaveStateProfileGuid = p.Guid;
@@ -281,77 +280,6 @@ namespace InfoPanel
                 StartAutosaveTimer();
             if (Settings.ProgramSpecificPanelsEnabled)
                 _ = ForegroundAppMonitor.Instance.StartAsync();
-        }
-
-        private void AutoDiscoverVmaxPanelDevices()
-        {
-            try
-            {
-                var discoveredDevices = VmaxPanelHelper.ScanDevices();
-                Logger.Information("VmaxPanel Auto Discovery: Found {Count} device(s)", discoveredDevices.Count);
-
-                var registryDevice = discoveredDevices.FirstOrDefault(d =>
-                    d.DeviceId.StartsWith($@"USB\VID_{VmaxPanelModelDatabase.VMAX_VENDOR_ID:X4}&PID_{VmaxPanelModelDatabase.VMAX_PRODUCT_ID_46INCH:X4}", StringComparison.OrdinalIgnoreCase));
-
-                var settingsChanged = false;
-
-                if (registryDevice != null)
-                {
-                    var duplicateDevices = Settings.VmaxPanelDevices
-                        .Where(d => d.Model == registryDevice.Model
-                            && !string.Equals(d.DeviceId, registryDevice.DeviceId, StringComparison.OrdinalIgnoreCase))
-                        .ToList();
-
-                    foreach (var duplicateDevice in duplicateDevices)
-                    {
-                        Settings.VmaxPanelDevices.Remove(duplicateDevice);
-                        settingsChanged = true;
-                        Logger.Information("VmaxPanel Auto Discovery: Removed duplicate '{DeviceId}'", duplicateDevice.DeviceId);
-                    }
-                }
-
-                foreach (var discoveredDevice in discoveredDevices)
-                {
-                    var device = Settings.VmaxPanelDevices.FirstOrDefault(d =>
-                        d.IsMatching(discoveredDevice.DeviceId, discoveredDevice.DeviceLocation, discoveredDevice.Model));
-
-                    if (device != null)
-                    {
-                        device.DeviceLocation = discoveredDevice.DeviceLocation;
-                        if (device.ModelInfo != null)
-                        {
-                            device.RuntimeProperties.Name = device.ModelInfo.Name;
-                        }
-                        continue;
-                    }
-
-                    var newDevice = new VmaxPanelDevice
-                    {
-                        DeviceId = discoveredDevice.DeviceId,
-                        DeviceLocation = discoveredDevice.DeviceLocation,
-                        Model = discoveredDevice.Model,
-                        ProfileGuid = Profiles.FirstOrDefault()?.Guid ?? Guid.Empty,
-                    };
-
-                    if (discoveredDevice.ModelInfo != null)
-                    {
-                        newDevice.RuntimeProperties.Name = discoveredDevice.ModelInfo.Name;
-                    }
-
-                    Settings.VmaxPanelDevices.Add(newDevice);
-                    settingsChanged = true;
-                    Logger.Information("VmaxPanel Auto Discovery: Added '{DeviceId}'", discoveredDevice.DeviceId);
-                }
-
-                if (settingsChanged)
-                {
-                    _ = SaveSettingsAsync();
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger.Warning(ex, "VmaxPanel Auto Discovery failed");
-            }
         }
 
         public void AccessSettings(Action<Settings> action)

--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -24,6 +24,7 @@ using System.Xml.Serialization;
 using Task = System.Threading.Tasks.Task;
 using Timer = System.Threading.Timer;
 using InfoPanel.ThermalrightPanel;
+using InfoPanel.VmaxPanel;
 using HidSharp;
 
 namespace InfoPanel
@@ -272,12 +273,85 @@ namespace InfoPanel
         public void Initialize()
         {
             LoadProfiles();
+            AutoDiscoverVmaxPanelDevices();
+
             if (SharedModel.Instance.SelectedProfile is Profile p)
                 _currentSaveStateProfileGuid = p.Guid;
             if (Settings.AutosaveEnabled)
                 StartAutosaveTimer();
             if (Settings.ProgramSpecificPanelsEnabled)
                 _ = ForegroundAppMonitor.Instance.StartAsync();
+        }
+
+        private void AutoDiscoverVmaxPanelDevices()
+        {
+            try
+            {
+                var discoveredDevices = VmaxPanelHelper.ScanDevices();
+                Logger.Information("VmaxPanel Auto Discovery: Found {Count} device(s)", discoveredDevices.Count);
+
+                var registryDevice = discoveredDevices.FirstOrDefault(d =>
+                    d.DeviceId.StartsWith($@"USB\VID_{VmaxPanelModelDatabase.VMAX_VENDOR_ID:X4}&PID_{VmaxPanelModelDatabase.VMAX_PRODUCT_ID_46INCH:X4}", StringComparison.OrdinalIgnoreCase));
+
+                var settingsChanged = false;
+
+                if (registryDevice != null)
+                {
+                    var duplicateDevices = Settings.VmaxPanelDevices
+                        .Where(d => d.Model == registryDevice.Model
+                            && !string.Equals(d.DeviceId, registryDevice.DeviceId, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+
+                    foreach (var duplicateDevice in duplicateDevices)
+                    {
+                        Settings.VmaxPanelDevices.Remove(duplicateDevice);
+                        settingsChanged = true;
+                        Logger.Information("VmaxPanel Auto Discovery: Removed duplicate '{DeviceId}'", duplicateDevice.DeviceId);
+                    }
+                }
+
+                foreach (var discoveredDevice in discoveredDevices)
+                {
+                    var device = Settings.VmaxPanelDevices.FirstOrDefault(d =>
+                        d.IsMatching(discoveredDevice.DeviceId, discoveredDevice.DeviceLocation, discoveredDevice.Model));
+
+                    if (device != null)
+                    {
+                        device.DeviceLocation = discoveredDevice.DeviceLocation;
+                        if (device.ModelInfo != null)
+                        {
+                            device.RuntimeProperties.Name = device.ModelInfo.Name;
+                        }
+                        continue;
+                    }
+
+                    var newDevice = new VmaxPanelDevice
+                    {
+                        DeviceId = discoveredDevice.DeviceId,
+                        DeviceLocation = discoveredDevice.DeviceLocation,
+                        Model = discoveredDevice.Model,
+                        ProfileGuid = Profiles.FirstOrDefault()?.Guid ?? Guid.Empty,
+                    };
+
+                    if (discoveredDevice.ModelInfo != null)
+                    {
+                        newDevice.RuntimeProperties.Name = discoveredDevice.ModelInfo.Name;
+                    }
+
+                    Settings.VmaxPanelDevices.Add(newDevice);
+                    settingsChanged = true;
+                    Logger.Information("VmaxPanel Auto Discovery: Added '{DeviceId}'", discoveredDevice.DeviceId);
+                }
+
+                if (settingsChanged)
+                {
+                    _ = SaveSettingsAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "VmaxPanel Auto Discovery failed");
+            }
         }
 
         public void AccessSettings(Action<Settings> action)
@@ -502,6 +576,17 @@ namespace InfoPanel
                     await ThermaltakePanelTask.Instance.StopAsync();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.VmaxPanelMultiDeviceMode))
+            {
+                if (Settings.VmaxPanelMultiDeviceMode)
+                {
+                    await VmaxPanelTask.Instance.StartAsync();
+                }
+                else
+                {
+                    await VmaxPanelTask.Instance.StopAsync();
+                }
+            }
 
             await SaveSettingsAsync();
         }
@@ -711,6 +796,15 @@ namespace InfoPanel
                             foreach (var device in settings.ThermaltakePanelDevices)
                             {
                                 Settings.ThermaltakePanelDevices.Add(device);
+                            }
+
+                            // Load VMAX panel settings
+                            Settings.VmaxPanelMultiDeviceMode = settings.VmaxPanelMultiDeviceMode;
+
+                            Settings.VmaxPanelDevices.Clear();
+                            foreach (var device in settings.VmaxPanelDevices)
+                            {
+                                Settings.VmaxPanelDevices.Add(device);
                             }
 
                             // Load hotkey bindings

--- a/InfoPanel/Models/HotkeyBinding.cs
+++ b/InfoPanel/Models/HotkeyBinding.cs
@@ -16,7 +16,7 @@ namespace InfoPanel.Models
         private Key _key = Key.None;
 
         /// <summary>
-        /// Device type: "Beada", "Turing", or "Thermalright"
+        /// Device type: "Beada", "Turing", "Thermalright", or "Vmax"
         /// </summary>
         [ObservableProperty]
         private string _deviceType = string.Empty;
@@ -28,7 +28,7 @@ namespace InfoPanel.Models
         private string _deviceId = string.Empty;
 
         /// <summary>
-        /// Device location (used with DeviceId to disambiguate Beada/Thermalright devices).
+        /// Device location (used with DeviceId to disambiguate USB panel devices).
         /// </summary>
         [ObservableProperty]
         private string _deviceLocation = string.Empty;
@@ -92,6 +92,10 @@ namespace InfoPanel.Models
                     "Thermalright" => ConfigModel.Instance.Settings.ThermalrightPanelDevices
                         .Where(d => d.DeviceId == DeviceId)
                         .Select(d => d.RuntimeProperties?.Name ?? d.DeviceId)
+                        .FirstOrDefault() ?? DeviceId,
+                    "Vmax" => ConfigModel.Instance.Settings.VmaxPanelDevices
+                        .Where(d => d.DeviceId == DeviceId)
+                        .Select(d => d.RuntimeProperties?.Name ?? d.ModelInfo?.Name ?? d.DeviceId)
                         .FirstOrDefault() ?? DeviceId,
                     _ => DeviceId
                 };

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -93,6 +93,16 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _thermaltakePanelMultiDeviceMode = false;
 
+        private readonly ObservableCollection<VmaxPanelDevice> _vmaxPanelDevices = [];
+
+        public ObservableCollection<VmaxPanelDevice> VmaxPanelDevices
+        {
+            get { return _vmaxPanelDevices; }
+        }
+
+        [ObservableProperty]
+        private bool _vmaxPanelMultiDeviceMode = false;
+
         private readonly ObservableCollection<HotkeyBinding> _hotkeyBindings = [];
 
         public ObservableCollection<HotkeyBinding> HotkeyBindings
@@ -140,6 +150,7 @@ namespace InfoPanel.Models
             TuringPanelDevices.CollectionChanged += TuringPanelDevices_CollectionChanged;
             ThermalrightPanelDevices.CollectionChanged += ThermalrightPanelDevices_CollectionChanged;
             ThermaltakePanelDevices.CollectionChanged += ThermaltakePanelDevices_CollectionChanged;
+            VmaxPanelDevices.CollectionChanged += VmaxPanelDevices_CollectionChanged;
         }
 
         private void BeadaPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -232,6 +243,27 @@ namespace InfoPanel.Models
         {
             if (e.PropertyName != nameof(ThermaltakePanelDevice.RuntimeProperties))
                 OnPropertyChanged(nameof(ThermaltakePanelDevices));
+        }
+
+        private void VmaxPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (VmaxPanelDevice device in e.OldItems)
+                    device.PropertyChanged -= VmaxDevice_PropertyChanged;
+            }
+            if (e.NewItems != null)
+            {
+                foreach (VmaxPanelDevice device in e.NewItems)
+                    device.PropertyChanged += VmaxDevice_PropertyChanged;
+            }
+            OnPropertyChanged(nameof(VmaxPanelDevices));
+        }
+
+        private void VmaxDevice_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(VmaxPanelDevice.RuntimeProperties))
+                OnPropertyChanged(nameof(VmaxPanelDevices));
         }
 
     }

--- a/InfoPanel/Models/VmaxPanelDevice.cs
+++ b/InfoPanel/Models/VmaxPanelDevice.cs
@@ -52,6 +52,13 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private int _targetFrameRate = 1;
 
+        partial void OnTargetFrameRateChanged(int value)
+        {
+            var clamped = Math.Clamp(value, 1, 30);
+            if (value != clamped)
+                TargetFrameRate = clamped;
+        }
+
         [ObservableProperty]
         private int _jpegQuality = 85;
 

--- a/InfoPanel/Models/VmaxPanelDevice.cs
+++ b/InfoPanel/Models/VmaxPanelDevice.cs
@@ -1,0 +1,139 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using InfoPanel.ViewModels;
+using InfoPanel.VmaxPanel;
+using Serilog;
+using System;
+using System.Windows.Threading;
+
+namespace InfoPanel.Models
+{
+    public partial class VmaxPanelDevice : ObservableObject
+    {
+        private static readonly ILogger Logger = Log.ForContext<VmaxPanelDevice>();
+
+        [ObservableProperty]
+        private string _deviceId = string.Empty;
+
+        [ObservableProperty]
+        private string _deviceLocation = string.Empty;
+
+        [ObservableProperty]
+        private VmaxPanelModel _model = VmaxPanelModel.Vmax46Inch;
+
+        partial void OnModelChanged(VmaxPanelModel value)
+        {
+            OnPropertyChanged(nameof(ModelInfo));
+            OnPropertyChanged(nameof(DisplayWidth));
+            OnPropertyChanged(nameof(DisplayHeight));
+        }
+
+        [ObservableProperty]
+        private bool _enabled = false;
+
+        [ObservableProperty]
+        private Guid _profileGuid = Guid.Empty;
+
+        [ObservableProperty]
+        private LCD_ROTATION _rotation = LCD_ROTATION.RotateNone;
+
+        [ObservableProperty]
+        private int _brightness = 99;
+
+        partial void OnBrightnessChanged(int value)
+        {
+            var clamped = Math.Clamp(value, 0, 99);
+            if (value != clamped)
+                Brightness = clamped;
+        }
+
+        [ObservableProperty]
+        private bool _screenSwitch = true;
+
+        [ObservableProperty]
+        private int _targetFrameRate = 1;
+
+        [ObservableProperty]
+        private int _jpegQuality = 85;
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private string _id = Guid.NewGuid().ToString();
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private VmaxPanelDeviceRuntimeProperties _runtimeProperties;
+
+        public VmaxPanelDevice()
+        {
+            _runtimeProperties = new();
+        }
+
+        public VmaxPanelModelInfo? ModelInfo =>
+            VmaxPanelModelDatabase.Models.TryGetValue(Model, out var info) ? info : null;
+
+        public int DisplayWidth => ModelInfo?.Width ?? 0;
+        public int DisplayHeight => ModelInfo?.Height ?? 0;
+
+        public bool IsMatching(string deviceId, string deviceLocation, VmaxPanelModel model)
+        {
+            return DeviceId.Equals(deviceId, StringComparison.OrdinalIgnoreCase)
+                && (DeviceLocation.Equals(deviceLocation, StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(DeviceLocation))
+                && Model.Equals(model);
+        }
+
+        private DateTime _lastUpdate = DateTime.MinValue;
+        private readonly TimeSpan _throttleInterval = TimeSpan.FromSeconds(1);
+
+        public void UpdateRuntimeProperties(bool? isRunning = null, int? frameRate = null, long? frameTime = null, string? errorMessage = null)
+        {
+            var now = DateTime.UtcNow;
+
+            if (isRunning != null || errorMessage != null)
+            {
+                _lastUpdate = now;
+                DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+                return;
+            }
+
+            if (now - _lastUpdate < _throttleInterval)
+                return;
+
+            _lastUpdate = now;
+            DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+        }
+
+        private void DispatchUpdate(bool? isRunning, int? frameRate, long? frameTime, string? errorMessage)
+        {
+            if (System.Windows.Application.Current?.Dispatcher is Dispatcher dispatcher)
+            {
+                dispatcher.BeginInvoke(() =>
+                {
+                    if (isRunning != null) RuntimeProperties.IsRunning = isRunning.Value;
+                    if (frameRate != null) RuntimeProperties.FrameRate = frameRate.Value;
+                    if (frameTime != null) RuntimeProperties.FrameTime = frameTime.Value;
+                    if (errorMessage != null) RuntimeProperties.ErrorMessage = errorMessage;
+                });
+            }
+        }
+
+        public override string ToString() => DeviceLocation;
+
+        public partial class VmaxPanelDeviceRuntimeProperties : ObservableObject
+        {
+            [ObservableProperty]
+            private bool _isRunning = false;
+
+            [ObservableProperty]
+            private string _name = "VMAX LCD";
+
+            [ObservableProperty]
+            private int _frameRate = 0;
+
+            [ObservableProperty]
+            private long _frameTime = 0;
+
+            [ObservableProperty]
+            private string _errorMessage = string.Empty;
+        }
+    }
+}

--- a/InfoPanel/Services/GlobalHotkeyService.cs
+++ b/InfoPanel/Services/GlobalHotkeyService.cs
@@ -224,6 +224,18 @@ namespace InfoPanel.Services
                         }
                     }
                     break;
+
+                case "Vmax":
+                    foreach (var device in ConfigModel.Instance.Settings.VmaxPanelDevices)
+                    {
+                        if (device.DeviceId == binding.DeviceId)
+                        {
+                            device.ProfileGuid = binding.ProfileGuid;
+                            Logger.Information("Switched VMAX device {Device} to profile {Profile}", device.DeviceId, profile.Name);
+                            return;
+                        }
+                    }
+                    break;
             }
 
             Logger.Warning("Hotkey target device {DeviceType} {DeviceId} not found", binding.DeviceType, binding.DeviceId);

--- a/InfoPanel/Services/ThermaltakePanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermaltakePanelDeviceTask.cs
@@ -50,7 +50,6 @@ namespace InfoPanel.Services
                 try
                 {
                     Logger.Information("ThermaltakeDevice {Device}: Opening (attempt {Retry})", _device, retryCount + 1);
-
                     hidDevice = ThermaltakeHidDevice.Open(modelInfo.VendorId, modelInfo.ProductId);
 
                     if (hidDevice == null)

--- a/InfoPanel/Services/ThermaltakePanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermaltakePanelDeviceTask.cs
@@ -50,6 +50,7 @@ namespace InfoPanel.Services
                 try
                 {
                     Logger.Information("ThermaltakeDevice {Device}: Opening (attempt {Retry})", _device, retryCount + 1);
+
                     hidDevice = ThermaltakeHidDevice.Open(modelInfo.VendorId, modelInfo.ProductId);
 
                     if (hidDevice == null)

--- a/InfoPanel/Services/VmaxPanelDeviceTask.cs
+++ b/InfoPanel/Services/VmaxPanelDeviceTask.cs
@@ -1,0 +1,172 @@
+using InfoPanel.Drawing;
+using InfoPanel.Extensions;
+using InfoPanel.Models;
+using InfoPanel.Utils;
+using InfoPanel.VmaxPanel;
+using Serilog;
+using SkiaSharp;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class VmaxPanelDeviceTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<VmaxPanelDeviceTask>();
+
+        private readonly VmaxPanelDevice _device;
+        private int _panelWidth;
+        private int _panelHeight;
+
+        public VmaxPanelDeviceTask(VmaxPanelDevice device)
+        {
+            _device = device;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            var modelInfo = _device.ModelInfo;
+            if (modelInfo == null)
+            {
+                _device.UpdateRuntimeProperties(errorMessage: "Unknown model");
+                return;
+            }
+
+            _panelWidth = modelInfo.Width;
+            _panelHeight = modelInfo.Height;
+            _device.UpdateRuntimeProperties(isRunning: false, errorMessage: string.Empty);
+            _device.RuntimeProperties.Name = $"{modelInfo.Name} ({_panelWidth}x{_panelHeight})";
+
+            int retryCount = 0;
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    Logger.Information("VmaxPanelDevice {Device}: Opening USB device (attempt {Retry})",
+                        _device, retryCount + 1);
+
+                    using var vmaxDevice = VmaxUsbDevice.Open(_device.DeviceId);
+                    if (vmaxDevice == null)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: "Device not found");
+                        await Task.Delay(2000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    retryCount = 0;
+                    await RunRenderSendLoop(vmaxDevice, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "VmaxPanelDevice {Device}: Error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+                    retryCount++;
+                }
+                finally
+                {
+                    _device.UpdateRuntimeProperties(isRunning: false);
+                }
+
+                if (!token.IsCancellationRequested)
+                    await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+            }
+        }
+
+        private async Task RunRenderSendLoop(VmaxUsbDevice vmaxDevice, CancellationToken token)
+        {
+            FpsCounter fpsCounter = new(10);
+            _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
+
+            while (!token.IsCancellationRequested)
+            {
+                var stopwatch = Stopwatch.StartNew();
+                var rgbData = GenerateRgb888Buffer();
+
+                vmaxDevice.SendRgb888Frame(rgbData);
+                vmaxDevice.SetScreenSwitch(_device.ScreenSwitch);
+
+                fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+
+                var targetFrameTime = 1000 / Math.Max(1, Math.Min(_device.TargetFrameRate, 5));
+                var delay = targetFrameTime - (int)stopwatch.ElapsedMilliseconds;
+                if (delay > 0)
+                    await Task.Delay(delay, token);
+            }
+        }
+
+        private byte[] GenerateRgb888Buffer()
+        {
+            if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
+            {
+                using var bitmap = PanelDrawTask.RenderSK(profile, false,
+                    colorType: SKColorType.Rgba8888,
+                    alphaType: SKAlphaType.Opaque);
+
+                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, _device.Rotation);
+
+                SKBitmap? normalized = null;
+                try
+                {
+                    normalized = ApplyBrightness(resizedBitmap);
+                    return ToRgb888(normalized);
+                }
+                finally
+                {
+                    normalized?.Dispose();
+                }
+            }
+
+            return GenerateBlackRgb888();
+        }
+
+        private static byte[] ToRgb888(SKBitmap bitmap)
+        {
+            var output = new byte[bitmap.Width * bitmap.Height * 3];
+            int offset = 0;
+            for (int y = 0; y < bitmap.Height; y++)
+            {
+                for (int x = 0; x < bitmap.Width; x++)
+                {
+                    var color = bitmap.GetPixel(x, y);
+                    output[offset++] = color.Red;
+                    output[offset++] = color.Green;
+                    output[offset++] = color.Blue;
+                }
+            }
+            return output;
+        }
+
+        private SKBitmap ApplyBrightness(SKBitmap source)
+        {
+            float scale = Math.Clamp(_device.Brightness, 0, 99) / 100f;
+            var result = new SKBitmap(source.Width, source.Height, source.ColorType, source.AlphaType);
+            using var canvas = new SKCanvas(result);
+            using var paint = new SKPaint();
+            paint.ColorFilter = SKColorFilter.CreateColorMatrix(
+            [
+                scale, 0,     0,     0, 0,
+                0,     scale, 0,     0, 0,
+                0,     0,     scale, 0, 0,
+                0,     0,     0,     1, 0
+            ]);
+            canvas.DrawBitmap(source, 0, 0, paint);
+            return result;
+        }
+
+        private byte[]? _cachedBlackRgb888;
+
+        private byte[] GenerateBlackRgb888()
+        {
+            _cachedBlackRgb888 ??= new byte[_panelWidth * _panelHeight * 3];
+            return _cachedBlackRgb888;
+        }
+    }
+}

--- a/InfoPanel/Services/VmaxPanelDeviceTask.cs
+++ b/InfoPanel/Services/VmaxPanelDeviceTask.cs
@@ -87,9 +87,9 @@ namespace InfoPanel.Services
             while (!token.IsCancellationRequested)
             {
                 var stopwatch = Stopwatch.StartNew();
-                var rgbData = GenerateRgb888Buffer();
+                var bgrData = GenerateBgr888Buffer();
 
-                vmaxDevice.SendRgb888Frame(rgbData);
+                vmaxDevice.SendRgb888Frame(bgrData);
                 vmaxDevice.SetScreenSwitch(_device.ScreenSwitch);
 
                 fpsCounter.Update(stopwatch.ElapsedMilliseconds);
@@ -102,7 +102,7 @@ namespace InfoPanel.Services
             }
         }
 
-        private byte[] GenerateRgb888Buffer()
+        private byte[] GenerateBgr888Buffer()
         {
             if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
             {
@@ -116,7 +116,7 @@ namespace InfoPanel.Services
                 try
                 {
                     normalized = ApplyBrightness(resizedBitmap);
-                    return ToRgb888(normalized);
+                    return ToBgr888(normalized);
                 }
                 finally
                 {
@@ -127,7 +127,7 @@ namespace InfoPanel.Services
             return GenerateBlackRgb888();
         }
 
-        private static byte[] ToRgb888(SKBitmap bitmap)
+        private static byte[] ToBgr888(SKBitmap bitmap)
         {
             var output = new byte[bitmap.Width * bitmap.Height * 3];
             int offset = 0;
@@ -136,9 +136,9 @@ namespace InfoPanel.Services
                 for (int x = 0; x < bitmap.Width; x++)
                 {
                     var color = bitmap.GetPixel(x, y);
-                    output[offset++] = color.Red;
-                    output[offset++] = color.Green;
                     output[offset++] = color.Blue;
+                    output[offset++] = color.Green;
+                    output[offset++] = color.Red;
                 }
             }
             return output;

--- a/InfoPanel/Services/VmaxPanelDeviceTask.cs
+++ b/InfoPanel/Services/VmaxPanelDeviceTask.cs
@@ -6,8 +6,10 @@ using InfoPanel.VmaxPanel;
 using Serilog;
 using SkiaSharp;
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace InfoPanel.Services
@@ -81,84 +83,196 @@ namespace InfoPanel.Services
 
         private async Task RunRenderSendLoop(VmaxUsbDevice vmaxDevice, CancellationToken token)
         {
-            FpsCounter fpsCounter = new(10);
+            using var renderCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var renderToken = renderCts.Token;
+            var frames = Channel.CreateBounded<RenderedFrame>(new BoundedChannelOptions(2)
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+            var renderTask = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!renderToken.IsCancellationRequested)
+                    {
+                        var frame = GenerateBgr888Frame();
+                        try
+                        {
+                            await frames.Writer.WriteAsync(frame, renderToken);
+                        }
+                        catch
+                        {
+                            ReturnFrame(frame);
+                            throw;
+                        }
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    frames.Writer.TryComplete(ex);
+                    return;
+                }
+
+                frames.Writer.TryComplete();
+            }, System.Threading.CancellationToken.None);
+
+            FpsCounter fpsCounter = new(30);
+            var diagnosticsStopwatch = Stopwatch.StartNew();
+            var diagnosticFrames = 0;
+            long diagnosticFrameMs = 0;
+            long diagnosticRenderMs = 0;
+            long diagnosticResizeMs = 0;
+            long diagnosticConvertMs = 0;
+            long diagnosticSendMs = 0;
+            long diagnosticScreenSwitchMs = 0;
+            long diagnosticDelayMs = 0;
             _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
 
-            while (!token.IsCancellationRequested)
+            try
             {
-                var stopwatch = Stopwatch.StartNew();
-                var bgrData = GenerateBgr888Buffer();
+                await foreach (var frame in frames.Reader.ReadAllAsync(token))
+                {
+                    try
+                    {
+                        var stopwatch = Stopwatch.StartNew();
 
-                vmaxDevice.SendRgb888Frame(bgrData);
-                vmaxDevice.SetScreenSwitch(_device.ScreenSwitch);
+                        var sendStopwatch = Stopwatch.StartNew();
+                        vmaxDevice.SendRgb888Frame(frame.Buffer, frame.Length);
+                        var sendMs = sendStopwatch.ElapsedMilliseconds;
 
-                fpsCounter.Update(stopwatch.ElapsedMilliseconds);
-                _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+                        var screenSwitchStopwatch = Stopwatch.StartNew();
+                        vmaxDevice.SetScreenSwitch(_device.ScreenSwitch);
+                        var screenSwitchMs = screenSwitchStopwatch.ElapsedMilliseconds;
 
-                var targetFrameTime = 1000 / Math.Max(1, Math.Min(_device.TargetFrameRate, 5));
-                var delay = targetFrameTime - (int)stopwatch.ElapsedMilliseconds;
-                if (delay > 0)
-                    await Task.Delay(delay, token);
+                        fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                        _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+
+                        var targetFrameTime = 1000 / Math.Max(1, Math.Min(_device.TargetFrameRate, 30));
+                        var delay = targetFrameTime - (int)stopwatch.ElapsedMilliseconds;
+
+                        diagnosticFrames++;
+                        diagnosticFrameMs += stopwatch.ElapsedMilliseconds;
+                        diagnosticRenderMs += frame.RenderMs;
+                        diagnosticResizeMs += frame.ResizeMs;
+                        diagnosticConvertMs += frame.ConvertMs;
+                        diagnosticSendMs += sendMs;
+                        diagnosticScreenSwitchMs += screenSwitchMs;
+                        diagnosticDelayMs += Math.Max(0, delay);
+
+                        if (diagnosticsStopwatch.ElapsedMilliseconds >= 1000 && diagnosticFrames > 0)
+                        {
+                            Logger.Information(
+                                "VmaxPanelDevice perf: target={TargetFps}fps actual={ActualFps}fps frame={FrameMs:F1}ms render={RenderMs:F1}ms resize={ResizeMs:F1}ms convert={ConvertMs:F1}ms usbWrite={UsbWriteMs:F1}ms screenSwitch={ScreenSwitchMs:F1}ms delay={DelayMs:F1}ms payload={PayloadBytes}",
+                                _device.TargetFrameRate,
+                                fpsCounter.FramesPerSecond,
+                                (double)diagnosticFrameMs / diagnosticFrames,
+                                (double)diagnosticRenderMs / diagnosticFrames,
+                                (double)diagnosticResizeMs / diagnosticFrames,
+                                (double)diagnosticConvertMs / diagnosticFrames,
+                                (double)diagnosticSendMs / diagnosticFrames,
+                                (double)diagnosticScreenSwitchMs / diagnosticFrames,
+                                (double)diagnosticDelayMs / diagnosticFrames,
+                                frame.Length);
+
+                            diagnosticsStopwatch.Restart();
+                            diagnosticFrames = 0;
+                            diagnosticFrameMs = 0;
+                            diagnosticRenderMs = 0;
+                            diagnosticResizeMs = 0;
+                            diagnosticConvertMs = 0;
+                            diagnosticSendMs = 0;
+                            diagnosticScreenSwitchMs = 0;
+                            diagnosticDelayMs = 0;
+                        }
+
+                        if (delay > 0)
+                            await Task.Delay(delay, token);
+                    }
+                    finally
+                    {
+                        ReturnFrame(frame);
+                    }
+                }
+            }
+            finally
+            {
+                renderCts.Cancel();
+                while (frames.Reader.TryRead(out var pendingFrame))
+                    ReturnFrame(pendingFrame);
+
+                try
+                {
+                    await renderTask;
+                }
+                catch (OperationCanceledException)
+                {
+                }
             }
         }
 
-        private byte[] GenerateBgr888Buffer()
+        private static void ReturnFrame(RenderedFrame frame)
+        {
+            if (frame.ReturnToPool)
+                ArrayPool<byte>.Shared.Return(frame.Buffer);
+        }
+
+        private RenderedFrame GenerateBgr888Frame()
         {
             if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
             {
+                var renderStopwatch = Stopwatch.StartNew();
                 using var bitmap = PanelDrawTask.RenderSK(profile, false,
                     colorType: SKColorType.Rgba8888,
                     alphaType: SKAlphaType.Opaque);
+                var renderMs = renderStopwatch.ElapsedMilliseconds;
 
+                var resizeStopwatch = Stopwatch.StartNew();
                 using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, _device.Rotation);
+                var resizeMs = resizeStopwatch.ElapsedMilliseconds;
 
-                SKBitmap? normalized = null;
-                try
-                {
-                    normalized = ApplyBrightness(resizedBitmap);
-                    return ToBgr888(normalized);
-                }
-                finally
-                {
-                    normalized?.Dispose();
-                }
+                var convertStopwatch = Stopwatch.StartNew();
+                var length = resizedBitmap.Width * resizedBitmap.Height * 3;
+                var output = ArrayPool<byte>.Shared.Rent(length);
+                ToBgr888(resizedBitmap, output, _device.Brightness);
+                var convertMs = convertStopwatch.ElapsedMilliseconds;
+                return new RenderedFrame(output, length, renderMs, resizeMs, convertMs);
             }
 
-            return GenerateBlackRgb888();
+            var blackFrame = GenerateBlackRgb888();
+            return new RenderedFrame(blackFrame, blackFrame.Length, 0, 0, 0, ReturnToPool: false);
         }
 
-        private static byte[] ToBgr888(SKBitmap bitmap)
+        private static void ToBgr888(SKBitmap bitmap, byte[] output, int brightness)
         {
-            var output = new byte[bitmap.Width * bitmap.Height * 3];
+            var pixels = bitmap.GetPixelSpan();
+            var srcStride = bitmap.RowBytes;
+            var scale = Math.Clamp(brightness, 0, 99);
             int offset = 0;
-            for (int y = 0; y < bitmap.Height; y++)
+
+            unsafe
             {
-                for (int x = 0; x < bitmap.Width; x++)
+                fixed (byte* srcBase = pixels)
+                fixed (byte* dstBase = output)
                 {
-                    var color = bitmap.GetPixel(x, y);
-                    output[offset++] = color.Blue;
-                    output[offset++] = color.Green;
-                    output[offset++] = color.Red;
+                    for (int y = 0; y < bitmap.Height; y++)
+                    {
+                        byte* srcRow = srcBase + y * srcStride;
+                        for (int x = 0; x < bitmap.Width; x++)
+                        {
+                            int si = x * 4;
+                            dstBase[offset++] = (byte)(srcRow[si + 2] * scale / 100);
+                            dstBase[offset++] = (byte)(srcRow[si + 1] * scale / 100);
+                            dstBase[offset++] = (byte)(srcRow[si + 0] * scale / 100);
+                        }
+                    }
                 }
             }
-            return output;
-        }
-
-        private SKBitmap ApplyBrightness(SKBitmap source)
-        {
-            float scale = Math.Clamp(_device.Brightness, 0, 99) / 100f;
-            var result = new SKBitmap(source.Width, source.Height, source.ColorType, source.AlphaType);
-            using var canvas = new SKCanvas(result);
-            using var paint = new SKPaint();
-            paint.ColorFilter = SKColorFilter.CreateColorMatrix(
-            [
-                scale, 0,     0,     0, 0,
-                0,     scale, 0,     0, 0,
-                0,     0,     scale, 0, 0,
-                0,     0,     0,     1, 0
-            ]);
-            canvas.DrawBitmap(source, 0, 0, paint);
-            return result;
         }
 
         private byte[]? _cachedBlackRgb888;
@@ -168,5 +282,13 @@ namespace InfoPanel.Services
             _cachedBlackRgb888 ??= new byte[_panelWidth * _panelHeight * 3];
             return _cachedBlackRgb888;
         }
+
+        private readonly record struct RenderedFrame(
+            byte[] Buffer,
+            int Length,
+            long RenderMs,
+            long ResizeMs,
+            long ConvertMs,
+            bool ReturnToPool = true);
     }
 }

--- a/InfoPanel/Services/VmaxPanelDeviceTask.cs
+++ b/InfoPanel/Services/VmaxPanelDeviceTask.cs
@@ -123,15 +123,6 @@ namespace InfoPanel.Services
             }, System.Threading.CancellationToken.None);
 
             FpsCounter fpsCounter = new(30);
-            var diagnosticsStopwatch = Stopwatch.StartNew();
-            var diagnosticFrames = 0;
-            long diagnosticFrameMs = 0;
-            long diagnosticRenderMs = 0;
-            long diagnosticResizeMs = 0;
-            long diagnosticConvertMs = 0;
-            long diagnosticSendMs = 0;
-            long diagnosticScreenSwitchMs = 0;
-            long diagnosticDelayMs = 0;
             _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
 
             try
@@ -142,54 +133,15 @@ namespace InfoPanel.Services
                     {
                         var stopwatch = Stopwatch.StartNew();
 
-                        var sendStopwatch = Stopwatch.StartNew();
                         vmaxDevice.SendRgb888Frame(frame.Buffer, frame.Length);
-                        var sendMs = sendStopwatch.ElapsedMilliseconds;
 
-                        var screenSwitchStopwatch = Stopwatch.StartNew();
                         vmaxDevice.SetScreenSwitch(_device.ScreenSwitch);
-                        var screenSwitchMs = screenSwitchStopwatch.ElapsedMilliseconds;
 
                         fpsCounter.Update(stopwatch.ElapsedMilliseconds);
                         _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
 
                         var targetFrameTime = 1000 / Math.Max(1, Math.Min(_device.TargetFrameRate, 30));
                         var delay = targetFrameTime - (int)stopwatch.ElapsedMilliseconds;
-
-                        diagnosticFrames++;
-                        diagnosticFrameMs += stopwatch.ElapsedMilliseconds;
-                        diagnosticRenderMs += frame.RenderMs;
-                        diagnosticResizeMs += frame.ResizeMs;
-                        diagnosticConvertMs += frame.ConvertMs;
-                        diagnosticSendMs += sendMs;
-                        diagnosticScreenSwitchMs += screenSwitchMs;
-                        diagnosticDelayMs += Math.Max(0, delay);
-
-                        if (diagnosticsStopwatch.ElapsedMilliseconds >= 1000 && diagnosticFrames > 0)
-                        {
-                            Logger.Information(
-                                "VmaxPanelDevice perf: target={TargetFps}fps actual={ActualFps}fps frame={FrameMs:F1}ms render={RenderMs:F1}ms resize={ResizeMs:F1}ms convert={ConvertMs:F1}ms usbWrite={UsbWriteMs:F1}ms screenSwitch={ScreenSwitchMs:F1}ms delay={DelayMs:F1}ms payload={PayloadBytes}",
-                                _device.TargetFrameRate,
-                                fpsCounter.FramesPerSecond,
-                                (double)diagnosticFrameMs / diagnosticFrames,
-                                (double)diagnosticRenderMs / diagnosticFrames,
-                                (double)diagnosticResizeMs / diagnosticFrames,
-                                (double)diagnosticConvertMs / diagnosticFrames,
-                                (double)diagnosticSendMs / diagnosticFrames,
-                                (double)diagnosticScreenSwitchMs / diagnosticFrames,
-                                (double)diagnosticDelayMs / diagnosticFrames,
-                                frame.Length);
-
-                            diagnosticsStopwatch.Restart();
-                            diagnosticFrames = 0;
-                            diagnosticFrameMs = 0;
-                            diagnosticRenderMs = 0;
-                            diagnosticResizeMs = 0;
-                            diagnosticConvertMs = 0;
-                            diagnosticSendMs = 0;
-                            diagnosticScreenSwitchMs = 0;
-                            diagnosticDelayMs = 0;
-                        }
 
                         if (delay > 0)
                             await Task.Delay(delay, token);
@@ -226,26 +178,20 @@ namespace InfoPanel.Services
         {
             if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
             {
-                var renderStopwatch = Stopwatch.StartNew();
                 using var bitmap = PanelDrawTask.RenderSK(profile, false,
                     colorType: SKColorType.Rgba8888,
                     alphaType: SKAlphaType.Opaque);
-                var renderMs = renderStopwatch.ElapsedMilliseconds;
 
-                var resizeStopwatch = Stopwatch.StartNew();
                 using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, _device.Rotation);
-                var resizeMs = resizeStopwatch.ElapsedMilliseconds;
 
-                var convertStopwatch = Stopwatch.StartNew();
                 var length = resizedBitmap.Width * resizedBitmap.Height * 3;
                 var output = ArrayPool<byte>.Shared.Rent(length);
                 ToBgr888(resizedBitmap, output, _device.Brightness);
-                var convertMs = convertStopwatch.ElapsedMilliseconds;
-                return new RenderedFrame(output, length, renderMs, resizeMs, convertMs);
+                return new RenderedFrame(output, length);
             }
 
             var blackFrame = GenerateBlackRgb888();
-            return new RenderedFrame(blackFrame, blackFrame.Length, 0, 0, 0, ReturnToPool: false);
+            return new RenderedFrame(blackFrame, blackFrame.Length, ReturnToPool: false);
         }
 
         private static void ToBgr888(SKBitmap bitmap, byte[] output, int brightness)
@@ -286,9 +232,6 @@ namespace InfoPanel.Services
         private readonly record struct RenderedFrame(
             byte[] Buffer,
             int Length,
-            long RenderMs,
-            long ResizeMs,
-            long ConvertMs,
             bool ReturnToPool = true);
     }
 }

--- a/InfoPanel/Services/VmaxPanelTask.cs
+++ b/InfoPanel/Services/VmaxPanelTask.cs
@@ -1,0 +1,122 @@
+using InfoPanel.Models;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class VmaxPanelTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<VmaxPanelTask>();
+        private static readonly Lazy<VmaxPanelTask> _instance = new(() => new VmaxPanelTask());
+
+        private readonly ConcurrentDictionary<string, VmaxPanelDeviceTask> _deviceTasks = new();
+
+        public static VmaxPanelTask Instance => _instance.Value;
+
+        private VmaxPanelTask() { }
+
+        public override async Task StopAsync(bool shutdown = false)
+        {
+            await base.StopAsync(shutdown);
+            await StopAllDevices();
+        }
+
+        public async Task StartDevice(VmaxPanelDevice device)
+        {
+            if (_deviceTasks.TryGetValue(device.Id, out var task))
+            {
+                await task.StopAsync();
+                _deviceTasks.TryRemove(device.Id, out _);
+            }
+
+            var deviceTask = new VmaxPanelDeviceTask(device);
+            if (_deviceTasks.TryAdd(device.Id, deviceTask))
+            {
+                await deviceTask.StartAsync(CancellationToken);
+                Logger.Information("Started VMAX panel device {Device}", device);
+            }
+        }
+
+        public async Task StopDevice(string deviceId)
+        {
+            if (_deviceTasks.TryRemove(deviceId, out var deviceTask))
+            {
+                await deviceTask.StopAsync();
+                Logger.Information("Stopped VMAX panel device {DeviceId}", deviceId);
+            }
+        }
+
+        public async Task StopAllDevices()
+        {
+            var tasks = new List<Task>();
+            foreach (var kvp in _deviceTasks.ToList())
+            {
+                if (_deviceTasks.TryRemove(kvp.Key, out var deviceTask))
+                    tasks.Add(Task.Run(async () => await deviceTask.StopAsync()));
+            }
+            await Task.WhenAll(tasks);
+            Logger.Information("Stopped all VMAX panel devices");
+        }
+
+        public bool IsDeviceRunning(string deviceId)
+        {
+            return _deviceTasks.TryGetValue(deviceId, out var task) && task.IsRunning;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            await Task.Delay(300, token);
+
+            try
+            {
+                if (ConfigModel.Instance.Settings.VmaxPanelMultiDeviceMode)
+                    await RunMultiDeviceMode(token);
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception e)
+            {
+                Logger.Error(e, "VmaxPanel: Error in DoWorkAsync");
+            }
+        }
+
+        private async Task RunMultiDeviceMode(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var settings = ConfigModel.Instance.Settings;
+                    if (!settings.VmaxPanelMultiDeviceMode) break;
+
+                    var enabledConfigs = settings.VmaxPanelDevices.Where(d => d.Enabled).ToList();
+
+                    foreach (var config in enabledConfigs)
+                    {
+                        if (!IsDeviceRunning(config.Id))
+                            await StartDevice(config);
+                    }
+
+                    var runningDeviceIds = _deviceTasks.Keys.ToList();
+                    foreach (var deviceId in runningDeviceIds)
+                    {
+                        if (!enabledConfigs.Any(c => c.Id == deviceId))
+                            await StopDevice(deviceId);
+                    }
+
+                    await Task.Delay(1000, token);
+                }
+                catch (TaskCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "VmaxPanel: Error in RunMultiDeviceMode");
+                    await Task.Delay(1000, token);
+                }
+            }
+        }
+    }
+}

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -1375,7 +1375,7 @@
                                                     <StackPanel Margin="0,10,0,0">
                                                         <Slider
                                                             IsSnapToTickEnabled="True"
-                                                            Maximum="5"
+                                                            Maximum="30"
                                                             Minimum="1"
                                                             TickFrequency="1"
                                                             Value="{Binding TargetFrameRate}" />

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -1206,6 +1206,275 @@
         </ui:CardExpander>
         <!--  end ThermaltakePanel Multi-Device settings  -->
 
+        <!--  VMAX Panel Multi-Device settings  -->
+        <ui:CardExpander Margin="0,10,0,0" IsExpanded="True">
+            <ui:CardExpander.Icon>
+                <ui:SymbolIcon Symbol="Whiteboard24" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock
+                            FontSize="13"
+                            FontWeight="Medium"
+                            Text="VMAX Displays" />
+                        <TextBlock
+                            Margin="0,5,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                            Text="Configure and run VMAX serial LCD panels." />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,10,0" Orientation="Horizontal">
+                            <ui:ToggleSwitch
+                                Grid.Column="1"
+                                Margin="0,0,10,0"
+                                IsChecked="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.VmaxPanelMultiDeviceMode}" />
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <ui:Button
+                        Grid.Column="1"
+                        HorizontalAlignment="Right"
+                        Appearance="Primary"
+                        Click="ButtonDiscoverVmaxPanelDevices_Click"
+                        Content="Discover Devices"
+                        Icon="{ui:SymbolIcon Search20}"
+                        Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.VmaxPanelMultiDeviceMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+
+                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.VmaxPanelDevices}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ui:CardControl Margin="0,0,0,10">
+                                <ui:CardControl.Header>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock
+                                                FontSize="13"
+                                                FontWeight="Medium"
+                                                Text="{Binding RuntimeProperties.Name}" />
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                TextWrapping="Wrap">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                                        <Binding Path="DeviceId" />
+                                                        <Binding Path="DeviceLocation" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}Dimensions: {0}x{1}">
+                                                        <Binding Path="DisplayWidth" />
+                                                        <Binding Path="DisplayHeight" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+                                            <StackPanel Visibility="{Binding Enabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Orientation="Horizontal"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="SeaGreen"
+                                                        Text="Panel is running:" />
+                                                    <TextBlock
+                                                        Margin="10,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="SeaGreen"
+                                                        Text="{Binding RuntimeProperties.FrameRate, StringFormat='{}{0} FPS'}" />
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="SeaGreen"
+                                                        Text="{Binding RuntimeProperties.FrameTime, StringFormat=' @ {0}ms'}" />
+                                                </StackPanel>
+
+                                                <TextBlock
+                                                    Margin="0,5,0,0"
+                                                    FontSize="12"
+                                                    Foreground="Orange"
+                                                    Text="{Binding RuntimeProperties.ErrorMessage}"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                </ui:CardControl.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Margin="10,0,0,0" VerticalAlignment="Top">
+                                        <ui:Button
+                                            Width="160"
+                                            Appearance="Secondary"
+                                            Click="ButtonAdvancedPopup_Click"
+                                            Content="Advanced"
+                                            Icon="{ui:SymbolIcon Settings20}" />
+                                        <Popup
+                                            AllowsTransparency="True"
+                                            Placement="Bottom"
+                                            StaysOpen="False">
+                                            <Border
+                                                Padding="15"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8">
+                                                <StackPanel Width="250">
+                                                    <StackPanel>
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="0"
+                                                            TickFrequency="1"
+                                                            Value="{Binding Brightness}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Brightness" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding Brightness}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <ui:ToggleSwitch
+                                                        Margin="5,10,0,0"
+                                                        Content="ScreenSwitch"
+                                                        IsChecked="{Binding ScreenSwitch}" />
+                                                    <StackPanel Margin="0,10,0,0">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="5"
+                                                            Minimum="1"
+                                                            TickFrequency="1"
+                                                            Value="{Binding TargetFrameRate}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Target FPS" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding TargetFrameRate}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <StackPanel Margin="0,10,0,0">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="50"
+                                                            TickFrequency="5"
+                                                            Value="{Binding JpegQuality}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="JPEG Quality" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding JpegQuality}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </StackPanel>
+                                    <StackPanel Margin="10,0,0,0">
+                                        <ComboBox
+                                            Width="250"
+                                            DisplayMemberPath="Name"
+                                            ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Profiles}"
+                                            SelectedValue="{Binding ProfileGuid}"
+                                            SelectedValuePath="Guid" />
+                                        <ComboBox
+                                            Margin="0,10,0,0"
+                                            ItemsSource="{Binding Path=ViewModel.RotationValues, RelativeSource={RelativeSource AncestorType=pages:UsbPanelsPage}}"
+                                            SelectedItem="{Binding Rotation}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Converter={StaticResource EnumToDescriptionConverter}}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <Grid Margin="20,0,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <ui:ToggleSwitch
+                                            VerticalAlignment="Center"
+                                            IsChecked="{Binding Enabled}" />
+                                        <ui:Button
+                                            Grid.Row="1"
+                                            Width="32"
+                                            Height="32"
+                                            Margin="0,10,0,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Bottom"
+                                            Appearance="Danger"
+                                            BorderThickness="0"
+                                            Click="ButtonRemoveVmaxPanelDevice_Click"
+                                            Icon="{ui:SymbolIcon Delete20}"
+                                            Tag="{Binding}"
+                                            ToolTip="Remove Device" />
+                                    </Grid>
+                                </StackPanel>
+                            </ui:CardControl>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ui:CardExpander>
+        <!--  end VMAX Panel Multi-Device settings  -->
+
         <!--  Global Hotkeys  -->
         <ui:CardExpander Margin="0,20,0,0" IsExpanded="False">
             <ui:CardExpander.Icon>

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -666,16 +666,6 @@ public partial class UsbPanelsPage : Page
 
         Logger.Information("VmaxPanel Discovery: Found {Count} devices", discoveredDevices.Count);
 
-        if (discoveredDevices.Count == 0)
-        {
-            _snackbarService.Show(
-                "VMAX Display Not Found",
-                "No VID_345F&PID_9132 device was found. Check Device Manager and reconnect the display.",
-                Wpf.Ui.Controls.ControlAppearance.Caution,
-                null,
-                TimeSpan.FromSeconds(6));
-        }
-
         foreach (var discoveredDevice in discoveredDevices)
         {
             ConfigModel.Instance.AccessSettings(settings =>

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -4,6 +4,7 @@ using InfoPanel.Services;
 using InfoPanel.TuringPanel;
 using InfoPanel.ThermalrightPanel;
 using InfoPanel.ThermaltakePanel;
+using InfoPanel.VmaxPanel;
 using InfoPanel.ViewModels;
 using InfoPanel.Views.Windows;
 using LibUsbDotNet;
@@ -48,6 +49,7 @@ public partial class UsbPanelsPage : Page
         ConfigModel.Instance.Settings.BeadaPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
         ConfigModel.Instance.Settings.TuringPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
         ConfigModel.Instance.Settings.ThermalrightPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
+        ConfigModel.Instance.Settings.VmaxPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
     }
 
     private async Task UpdateBeadaPanelDeviceList()
@@ -251,6 +253,12 @@ public partial class UsbPanelsPage : Page
         {
             var name = d.RuntimeProperties?.Name ?? d.DeviceId;
             items.Add(Tuple.Create($"Thermalright|{d.DeviceId}|{d.DeviceLocation}", name));
+        }
+
+        foreach (var d in ConfigModel.Instance.Settings.VmaxPanelDevices)
+        {
+            var name = d.RuntimeProperties?.Name ?? d.ModelInfo?.Name ?? d.DeviceId;
+            items.Add(Tuple.Create($"Vmax|{d.DeviceId}|{d.DeviceLocation}", name));
         }
 
         HotkeyDeviceCombo.ItemsSource = items;
@@ -635,6 +643,97 @@ public partial class UsbPanelsPage : Page
                     }
 
                     settings.ThermaltakePanelDevices.Remove(deviceConfig);
+                }
+            });
+        }
+    }
+
+    // === VMAX Panel ===
+
+    private async void ButtonDiscoverVmaxPanelDevices_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button)
+        {
+            button.IsEnabled = false;
+            await UpdateVmaxPanelDeviceList();
+            button.IsEnabled = true;
+        }
+    }
+
+    private Task UpdateVmaxPanelDeviceList()
+    {
+        var discoveredDevices = VmaxPanelHelper.ScanDevices();
+
+        Logger.Information("VmaxPanel Discovery: Found {Count} devices", discoveredDevices.Count);
+
+        if (discoveredDevices.Count == 0)
+        {
+            _snackbarService.Show(
+                "VMAX Display Not Found",
+                "No VID_345F&PID_9132 device was found. Check Device Manager and reconnect the display.",
+                Wpf.Ui.Controls.ControlAppearance.Caution,
+                null,
+                TimeSpan.FromSeconds(6));
+        }
+
+        foreach (var discoveredDevice in discoveredDevices)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var device = settings.VmaxPanelDevices.FirstOrDefault(d =>
+                    d.IsMatching(discoveredDevice.DeviceId, discoveredDevice.DeviceLocation, discoveredDevice.Model));
+
+                if (device == null)
+                {
+                    var newDevice = new VmaxPanelDevice()
+                    {
+                        DeviceId = discoveredDevice.DeviceId,
+                        DeviceLocation = discoveredDevice.DeviceLocation,
+                        Model = discoveredDevice.Model,
+                        ProfileGuid = ConfigModel.Instance.Profiles.FirstOrDefault()?.Guid ?? Guid.Empty
+                    };
+
+                    if (discoveredDevice.ModelInfo != null)
+                    {
+                        newDevice.RuntimeProperties.Name = discoveredDevice.ModelInfo.Name;
+                    }
+
+                    settings.VmaxPanelDevices.Add(newDevice);
+                    Logger.Information("VmaxPanel Discovery: Added new device '{DeviceId}'", discoveredDevice.DeviceId);
+                }
+                else
+                {
+                    device.DeviceLocation = discoveredDevice.DeviceLocation;
+
+                    if (device.ModelInfo != null)
+                    {
+                        device.RuntimeProperties.Name = device.ModelInfo.Name;
+                    }
+
+                    Logger.Information("VmaxPanel Discovery: Device '{DeviceId}' already exists", discoveredDevice.DeviceId);
+                }
+            });
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ButtonRemoveVmaxPanelDevice_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is VmaxPanelDevice runtimeDevice)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var deviceConfig = settings.VmaxPanelDevices.FirstOrDefault(c => c.Id == runtimeDevice.Id);
+
+                if (deviceConfig != null)
+                {
+                    if (VmaxPanelTask.Instance.IsDeviceRunning(deviceConfig.Id))
+                    {
+                        _ = VmaxPanelTask.Instance.StopDevice(deviceConfig.Id);
+                    }
+
+                    settings.VmaxPanelDevices.Remove(deviceConfig);
                 }
             });
         }

--- a/InfoPanel/VmaxPanel/VmaxPanelHelper.cs
+++ b/InfoPanel/VmaxPanel/VmaxPanelHelper.cs
@@ -1,0 +1,142 @@
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Microsoft.Win32;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InfoPanel.VmaxPanel
+{
+    public class VmaxPanelDiscoveryInfo
+    {
+        public string DeviceId { get; set; } = "";
+        public string DeviceLocation { get; set; } = "";
+        public string DevicePath { get; set; } = "";
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
+        public VmaxPanelModel Model { get; set; }
+        public VmaxPanelModelInfo? ModelInfo { get; set; }
+    }
+
+    public static class VmaxPanelHelper
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(VmaxPanelHelper));
+
+        public static List<VmaxPanelDiscoveryInfo> ScanDevices()
+        {
+            var devices = new List<VmaxPanelDiscoveryInfo>();
+
+            foreach (var (vendorId, productId) in VmaxPanelModelDatabase.SupportedDevices)
+            {
+                var windowsDevices = ScanWindowsUsbDevices(vendorId, productId, devices);
+                if (windowsDevices.Count > 0)
+                {
+                    devices.AddRange(windowsDevices);
+                    continue;
+                }
+
+                try
+                {
+                    devices.AddRange(ScanUsbDevices(vendorId, productId));
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "VmaxPanelHelper: LibUsb scan failed for VID_{VendorId:X4}&PID_{ProductId:X4}", vendorId, productId);
+                }
+            }
+
+            Logger.Information("VmaxPanelHelper: Found {Count} device(s)", devices.Count);
+            return devices;
+        }
+
+        private static List<VmaxPanelDiscoveryInfo> ScanUsbDevices(int vendorId, int productId)
+        {
+            var devices = new List<VmaxPanelDiscoveryInfo>();
+            var modelInfo = VmaxPanelModelDatabase.GetModelByVidPid(vendorId, productId);
+            if (modelInfo == null) return devices;
+
+            foreach (UsbRegistry deviceReg in UsbDevice.AllDevices)
+            {
+                if (deviceReg.Vid != vendorId || deviceReg.Pid != productId)
+                    continue;
+
+                deviceReg.DeviceProperties.TryGetValue("DeviceID", out var deviceIdValue);
+                deviceReg.DeviceProperties.TryGetValue("LocationInformation", out var locationValue);
+
+                var deviceId = deviceIdValue as string ?? deviceReg.DevicePath;
+                var location = locationValue as string ?? deviceReg.SymbolicName ?? string.Empty;
+
+                Logger.Information("VmaxPanelHelper: Found {Model} at {DeviceId}", modelInfo.Name, deviceId);
+
+                devices.Add(new VmaxPanelDiscoveryInfo
+                {
+                    DeviceId = deviceId,
+                    DeviceLocation = location,
+                    DevicePath = deviceReg.DevicePath,
+                    VendorId = vendorId,
+                    ProductId = productId,
+                    Model = modelInfo.Model,
+                    ModelInfo = modelInfo,
+                });
+            }
+
+            return devices;
+        }
+
+        private static List<VmaxPanelDiscoveryInfo> ScanWindowsUsbDevices(
+            int vendorId,
+            int productId,
+            IReadOnlyCollection<VmaxPanelDiscoveryInfo> existingDevices)
+        {
+            var devices = new List<VmaxPanelDiscoveryInfo>();
+            var modelInfo = VmaxPanelModelDatabase.GetModelByVidPid(vendorId, productId);
+            if (modelInfo == null) return devices;
+
+            var deviceKeyName = $@"SYSTEM\CurrentControlSet\Enum\USB\VID_{vendorId:X4}&PID_{productId:X4}";
+
+            try
+            {
+                using var deviceKey = Registry.LocalMachine.OpenSubKey(deviceKeyName);
+                if (deviceKey == null)
+                    return devices;
+
+                foreach (var instanceId in deviceKey.GetSubKeyNames())
+                {
+                    var deviceId = $@"USB\VID_{vendorId:X4}&PID_{productId:X4}\{instanceId}";
+                    if (existingDevices.Any(device => string.Equals(device.DeviceId, deviceId, StringComparison.OrdinalIgnoreCase))
+                        || devices.Any(device => string.Equals(device.DeviceId, deviceId, StringComparison.OrdinalIgnoreCase)))
+                        continue;
+
+                    using var instanceKey = deviceKey.OpenSubKey(instanceId);
+                    var location = instanceKey?.GetValue("LocationInformation") as string ?? string.Empty;
+                    var friendlyName = instanceKey?.GetValue("FriendlyName") as string;
+                    var deviceDesc = instanceKey?.GetValue("DeviceDesc") as string;
+
+                    Logger.Information(
+                        "VmaxPanelHelper: Found {Model} via Windows USB registry at {DeviceId} ({Description})",
+                        modelInfo.Name,
+                        deviceId,
+                        friendlyName ?? deviceDesc ?? "USB device");
+
+                    devices.Add(new VmaxPanelDiscoveryInfo
+                    {
+                        DeviceId = deviceId,
+                        DeviceLocation = location,
+                        DevicePath = deviceId,
+                        VendorId = vendorId,
+                        ProductId = productId,
+                        Model = modelInfo.Model,
+                        ModelInfo = modelInfo,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "VmaxPanelHelper: Failed to scan Windows USB registry for VID_{VendorId:X4}&PID_{ProductId:X4}", vendorId, productId);
+            }
+
+            return devices;
+        }
+    }
+}

--- a/InfoPanel/VmaxPanel/VmaxPanelHelper.cs
+++ b/InfoPanel/VmaxPanel/VmaxPanelHelper.cs
@@ -1,3 +1,4 @@
+using HidSharp;
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
 using Microsoft.Win32;
@@ -93,6 +94,16 @@ namespace InfoPanel.VmaxPanel
             var modelInfo = VmaxPanelModelDatabase.GetModelByVidPid(vendorId, productId);
             if (modelInfo == null) return devices;
 
+            var hidDevices = DeviceList.Local.GetHidDevices(vendorId, productId).ToList();
+            if (hidDevices.Count == 0)
+            {
+                Logger.Information(
+                    "VmaxPanelHelper: Skipping Windows USB registry entries for VID_{VendorId:X4}&PID_{ProductId:X4}; no connected HID control interface was found",
+                    vendorId,
+                    productId);
+                return devices;
+            }
+
             var deviceKeyName = $@"SYSTEM\CurrentControlSet\Enum\USB\VID_{vendorId:X4}&PID_{productId:X4}";
 
             try
@@ -103,6 +114,9 @@ namespace InfoPanel.VmaxPanel
 
                 foreach (var instanceId in deviceKey.GetSubKeyNames())
                 {
+                    if (devices.Count >= hidDevices.Count)
+                        break;
+
                     var deviceId = $@"USB\VID_{vendorId:X4}&PID_{productId:X4}\{instanceId}";
                     if (existingDevices.Any(device => string.Equals(device.DeviceId, deviceId, StringComparison.OrdinalIgnoreCase))
                         || devices.Any(device => string.Equals(device.DeviceId, deviceId, StringComparison.OrdinalIgnoreCase)))

--- a/InfoPanel/VmaxPanel/VmaxPanelModel.cs
+++ b/InfoPanel/VmaxPanel/VmaxPanelModel.cs
@@ -1,0 +1,8 @@
+namespace InfoPanel.VmaxPanel
+{
+    public enum VmaxPanelModel
+    {
+        Unknown,
+        Vmax46Inch,
+    }
+}

--- a/InfoPanel/VmaxPanel/VmaxPanelModelDatabase.cs
+++ b/InfoPanel/VmaxPanel/VmaxPanelModelDatabase.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InfoPanel.VmaxPanel
+{
+    public static class VmaxPanelModelDatabase
+    {
+        public const int VMAX_VENDOR_ID = 0x345F;
+        public const int VMAX_PRODUCT_ID_46INCH = 0x9132;
+
+        public static readonly (int Vid, int Pid)[] SupportedDevices =
+        [
+            (VMAX_VENDOR_ID, VMAX_PRODUCT_ID_46INCH),
+        ];
+
+        public static readonly Dictionary<VmaxPanelModel, VmaxPanelModelInfo> Models = new()
+        {
+            [VmaxPanelModel.Vmax46Inch] = new VmaxPanelModelInfo
+            {
+                Model = VmaxPanelModel.Vmax46Inch,
+                Name = "VMAX 4.6\" LCD",
+                Width = 320,
+                Height = 960,
+                VendorId = VMAX_VENDOR_ID,
+                ProductId = VMAX_PRODUCT_ID_46INCH,
+            },
+        };
+
+        public static VmaxPanelModelInfo? GetModelByVidPid(int vid, int pid)
+        {
+            return Models.Values.FirstOrDefault(m => m.VendorId == vid && m.ProductId == pid);
+        }
+    }
+}

--- a/InfoPanel/VmaxPanel/VmaxPanelModelInfo.cs
+++ b/InfoPanel/VmaxPanel/VmaxPanelModelInfo.cs
@@ -1,0 +1,12 @@
+namespace InfoPanel.VmaxPanel
+{
+    public class VmaxPanelModelInfo
+    {
+        public VmaxPanelModel Model { get; init; }
+        public string Name { get; init; } = "Unknown Model";
+        public int Width { get; init; }
+        public int Height { get; init; }
+        public int VendorId { get; init; }
+        public int ProductId { get; init; }
+    }
+}

--- a/InfoPanel/VmaxPanel/VmaxUsbDevice.cs
+++ b/InfoPanel/VmaxPanel/VmaxUsbDevice.cs
@@ -96,7 +96,6 @@ namespace InfoPanel.VmaxPanel
         private HidStream? _hidStream;
         private DateTime _lastStreamingStatusPolled = DateTime.MinValue;
         private byte[]? _frameBuffer;
-        private bool _loggedFirstFrame;
         private bool _hasSentFrame;
         private bool? _currentScreenSwitch;
         private bool _disposed;
@@ -333,18 +332,6 @@ namespace InfoPanel.VmaxPanel
                 }
 
                 offset += bytesWritten;
-            }
-
-            if (!_loggedFirstFrame)
-            {
-                _loggedFirstFrame = true;
-                Logger.Information(
-                    "VmaxUsbDevice: First RGB888 frame sent. Payload={PayloadLength}, Frame={FrameLength}, Prefix={Prefix}, FirstPixels={FirstPixels}, Suffix={Suffix}",
-                    rgbDataLength,
-                    _frameBuffer.Length,
-                    BitConverter.ToString(_frameBuffer.Take(FramePrefix.Length).ToArray()),
-                    BitConverter.ToString(rgbData.Take(Math.Min(24, rgbDataLength)).ToArray()),
-                    BitConverter.ToString(_frameBuffer.Skip(_frameBuffer.Length - FrameSuffix.Length).ToArray()));
             }
 
             _hasSentFrame = true;

--- a/InfoPanel/VmaxPanel/VmaxUsbDevice.cs
+++ b/InfoPanel/VmaxPanel/VmaxUsbDevice.cs
@@ -95,6 +95,7 @@ namespace InfoPanel.VmaxPanel
         private IUsbDevice? _wholeUsbDevice;
         private HidStream? _hidStream;
         private DateTime _lastStreamingStatusPolled = DateTime.MinValue;
+        private byte[]? _frameBuffer;
         private bool _loggedFirstFrame;
         private bool _hasSentFrame;
         private bool? _currentScreenSwitch;
@@ -302,21 +303,33 @@ namespace InfoPanel.VmaxPanel
 
         public void SendRgb888Frame(byte[] rgbData)
         {
-            if (_writer == null) throw new InvalidOperationException("VMAX USB device is not open.");
+            SendRgb888Frame(rgbData, rgbData.Length);
+        }
 
-            var frame = new byte[FramePrefix.Length + rgbData.Length + FrameSuffix.Length];
-            Buffer.BlockCopy(FramePrefix, 0, frame, 0, FramePrefix.Length);
-            Buffer.BlockCopy(rgbData, 0, frame, FramePrefix.Length, rgbData.Length);
-            Buffer.BlockCopy(FrameSuffix, 0, frame, FramePrefix.Length + rgbData.Length, FrameSuffix.Length);
+        public void SendRgb888Frame(byte[] rgbData, int rgbDataLength)
+        {
+            if (_writer == null) throw new InvalidOperationException("VMAX USB device is not open.");
+            if (rgbDataLength < 0 || rgbDataLength > rgbData.Length)
+                throw new ArgumentOutOfRangeException(nameof(rgbDataLength));
+
+            var frameLength = FramePrefix.Length + rgbDataLength + FrameSuffix.Length;
+            if (_frameBuffer == null || _frameBuffer.Length != frameLength)
+            {
+                _frameBuffer = new byte[frameLength];
+                Buffer.BlockCopy(FramePrefix, 0, _frameBuffer, 0, FramePrefix.Length);
+                Buffer.BlockCopy(FrameSuffix, 0, _frameBuffer, FramePrefix.Length + rgbDataLength, FrameSuffix.Length);
+            }
+
+            Buffer.BlockCopy(rgbData, 0, _frameBuffer, FramePrefix.Length, rgbDataLength);
 
             var offset = 0;
-            while (offset < frame.Length)
+            while (offset < _frameBuffer.Length)
             {
-                var writeSize = Math.Min(UsbWriteChunkSize, frame.Length - offset);
-                var result = _writer.Write(frame, offset, writeSize, UsbWriteTimeoutMs, out var bytesWritten);
+                var writeSize = Math.Min(UsbWriteChunkSize, _frameBuffer.Length - offset);
+                var result = _writer.Write(_frameBuffer, offset, writeSize, UsbWriteTimeoutMs, out var bytesWritten);
                 if (result != ErrorCode.None || bytesWritten != writeSize)
                 {
-                    throw new InvalidOperationException($"VMAX USB write failed: {result}, wrote {bytesWritten}/{writeSize} bytes at offset {offset}/{frame.Length}.");
+                    throw new InvalidOperationException($"VMAX USB write failed: {result}, wrote {bytesWritten}/{writeSize} bytes at offset {offset}/{_frameBuffer.Length}.");
                 }
 
                 offset += bytesWritten;
@@ -327,11 +340,11 @@ namespace InfoPanel.VmaxPanel
                 _loggedFirstFrame = true;
                 Logger.Information(
                     "VmaxUsbDevice: First RGB888 frame sent. Payload={PayloadLength}, Frame={FrameLength}, Prefix={Prefix}, FirstPixels={FirstPixels}, Suffix={Suffix}",
-                    rgbData.Length,
-                    frame.Length,
-                    BitConverter.ToString(frame.Take(FramePrefix.Length).ToArray()),
-                    BitConverter.ToString(rgbData.Take(24).ToArray()),
-                    BitConverter.ToString(frame.Skip(frame.Length - FrameSuffix.Length).ToArray()));
+                    rgbDataLength,
+                    _frameBuffer.Length,
+                    BitConverter.ToString(_frameBuffer.Take(FramePrefix.Length).ToArray()),
+                    BitConverter.ToString(rgbData.Take(Math.Min(24, rgbDataLength)).ToArray()),
+                    BitConverter.ToString(_frameBuffer.Skip(_frameBuffer.Length - FrameSuffix.Length).ToArray()));
             }
 
             _hasSentFrame = true;

--- a/InfoPanel/VmaxPanel/VmaxUsbDevice.cs
+++ b/InfoPanel/VmaxPanel/VmaxUsbDevice.cs
@@ -1,0 +1,418 @@
+using HidSharp;
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Serilog;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace InfoPanel.VmaxPanel
+{
+    public sealed class VmaxUsbDevice : IDisposable
+    {
+        private static readonly ILogger Logger = Log.ForContext<VmaxUsbDevice>();
+
+        private static readonly byte[] FramePrefix = [0xFF, 0x00, 0x00, 0x00, 0x00, 0x14, 0x03, 0xC0];
+        private static readonly byte[] FrameSuffix = [0xFF, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        private static readonly byte[] StreamingStatusFeatureReport = [0xB5, 0x00, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00];
+        private static readonly byte[] StreamingPulseFeatureReport = [0xB5, 0xC5, 0x57, 0x00, 0x00, 0x00, 0x00, 0x00];
+        private static readonly byte[] DisplayEnableFeatureReport = [0xA6, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00];
+        private static readonly byte[][] StreamingStartupFeatureReports =
+        [
+            [0xB5, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0x00, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xF2, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xF4, 0x39, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xF5, 0x00, 0x1F, 0xE0, 0x00, 0x00, 0x00, 0x00],
+            [0xF5, 0x00, 0x1F, 0xE8, 0x00, 0x00, 0x00, 0x00],
+            [0xF5, 0x00, 0x1F, 0xF0, 0x00, 0x00, 0x00, 0x00],
+            [0xF5, 0x00, 0x1F, 0xF8, 0x00, 0x00, 0x00, 0x00],
+            [0xA6, 0x07, 0x01, 0x02, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC4, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xA6, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC5, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xF0, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB6, 0xF0, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xC5, 0xB0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xC6, 0xB0, 0xDF, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xC5, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xC6, 0xA0, 0xE4, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xC5, 0xA0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xC6, 0xA0, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xF0, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB6, 0xF0, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0x00, 0x32, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x0C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x14, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x1C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x28, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x2C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x30, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x34, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x38, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x3C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x44, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x48, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x4C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x50, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x54, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x5C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x60, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x64, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x68, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x6C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x74, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x78, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC0, 0x7C, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xF4, 0x39, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xA6, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC5, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xA6, 0x01, 0x01, 0x40, 0x03, 0xC0, 0x11, 0x00],
+            [0xB5, 0xC5, 0x56, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xA6, 0x02, 0xB2, 0x00, 0x01, 0x40, 0x03, 0xC0],
+            [0xB5, 0xC5, 0x57, 0x00, 0x00, 0x00, 0x00, 0x00],
+        ];
+
+        private const int InterfaceNumber = 3;
+        private const int UsbWriteTimeoutMs = 1000;
+        private const int UsbWriteChunkSize = 65536;
+        private const int StreamingInitDelayMs = 25;
+
+        private UsbDevice? _usbDevice;
+        private UsbEndpointWriter? _writer;
+        private IUsbDevice? _wholeUsbDevice;
+        private HidStream? _hidStream;
+        private DateTime _lastStreamingStatusPolled = DateTime.MinValue;
+        private bool _loggedFirstFrame;
+        private bool _hasSentFrame;
+        private bool? _currentScreenSwitch;
+        private bool _disposed;
+
+        private VmaxUsbDevice() { }
+
+        public static VmaxUsbDevice? Open(string deviceId)
+        {
+            foreach (UsbRegistry deviceReg in UsbDevice.AllDevices)
+            {
+                if (deviceReg.Vid != VmaxPanelModelDatabase.VMAX_VENDOR_ID
+                    || deviceReg.Pid != VmaxPanelModelDatabase.VMAX_PRODUCT_ID_46INCH)
+                    continue;
+
+                deviceReg.DeviceProperties.TryGetValue("DeviceID", out var registryDeviceIdValue);
+                var registryDeviceId = registryDeviceIdValue as string;
+                if (!string.IsNullOrEmpty(deviceId)
+                    && !IsMatchingDevice(deviceId, registryDeviceId, deviceReg.DevicePath))
+                    continue;
+
+                var usbDevice = deviceReg.Device;
+                if (usbDevice == null)
+                {
+                    Logger.Warning("VmaxUsbDevice: Could not open {DeviceId}", registryDeviceId ?? deviceReg.DevicePath);
+                    continue;
+                }
+
+                var device = new VmaxUsbDevice { _usbDevice = usbDevice };
+
+                if (usbDevice is IUsbDevice wholeUsbDevice)
+                {
+                    device._wholeUsbDevice = wholeUsbDevice;
+                    var claimed = wholeUsbDevice.ClaimInterface(InterfaceNumber);
+                    Logger.Information(
+                        "VmaxUsbDevice: ClaimInterface({Interface})={Claimed}",
+                        InterfaceNumber,
+                        claimed);
+                }
+
+                device._hidStream = InitializeStreamingMode();
+
+                var writeEndpoint = FindWriteEndpoint(usbDevice);
+                device._writer = usbDevice.OpenEndpointWriter(writeEndpoint);
+                Logger.Information("VmaxUsbDevice: Opened {DeviceId} using endpoint 0x{Endpoint:X2}", registryDeviceId ?? deviceReg.DevicePath, (byte)writeEndpoint);
+                return device;
+            }
+
+            Logger.Warning(
+                "VmaxUsbDevice: No VMAX device found for {DeviceId}. The device may need a WinUSB/libusb-compatible driver on interface {InterfaceNumber}.",
+                deviceId,
+                InterfaceNumber);
+            return null;
+        }
+
+        private static bool IsMatchingDevice(string requestedDeviceId, string? registryDeviceId, string? devicePath)
+        {
+            if (string.Equals(registryDeviceId, requestedDeviceId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(devicePath, requestedDeviceId, StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            return requestedDeviceId.StartsWith(
+                $@"USB\VID_{VmaxPanelModelDatabase.VMAX_VENDOR_ID:X4}&PID_{VmaxPanelModelDatabase.VMAX_PRODUCT_ID_46INCH:X4}",
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static WriteEndpointID FindWriteEndpoint(UsbDevice usbDevice)
+        {
+            WriteEndpointID endpoint = WriteEndpointID.Ep04;
+
+            foreach (var config in usbDevice.Configs)
+            {
+                foreach (var iface in config.InterfaceInfoList)
+                {
+                    foreach (var ep in iface.EndpointInfoList)
+                    {
+                        var endpointId = (byte)ep.Descriptor.EndpointID;
+                        if ((endpointId & 0x80) != 0)
+                            continue;
+
+                        Logger.Information(
+                            "VmaxUsbDevice: Found OUT endpoint 0x{Endpoint:X2} on interface {Interface}",
+                            endpointId,
+                            iface.Descriptor.InterfaceID);
+
+                        if (endpointId == 0x04)
+                            return (WriteEndpointID)endpointId;
+
+                        endpoint = (WriteEndpointID)endpointId;
+                    }
+                }
+            }
+
+            return endpoint;
+        }
+
+        private static HidStream InitializeStreamingMode()
+        {
+            var hidDevices = DeviceList.Local
+                .GetHidDevices(VmaxPanelModelDatabase.VMAX_VENDOR_ID, VmaxPanelModelDatabase.VMAX_PRODUCT_ID_46INCH)
+                .ToList();
+
+            Logger.Information("VmaxUsbDevice: Found {Count} HID interface(s) for streaming init", hidDevices.Count);
+
+            foreach (var hidDevice in hidDevices)
+            {
+                try
+                {
+                    Logger.Information(
+                        "VmaxUsbDevice: Trying HID init via {Path}, FeatureLen={FeatureLength}, InputLen={InputLength}, OutputLen={OutputLength}",
+                        hidDevice.DevicePath,
+                        hidDevice.GetMaxFeatureReportLength(),
+                        hidDevice.GetMaxInputReportLength(),
+                        hidDevice.GetMaxOutputReportLength());
+
+                    var stream = hidDevice.Open();
+                    stream.WriteTimeout = UsbWriteTimeoutMs;
+                    stream.ReadTimeout = UsbWriteTimeoutMs;
+
+                    try
+                    {
+                        byte[] response = [];
+                        foreach (var featureReport in StreamingStartupFeatureReports)
+                        {
+                            response = SendFeatureReport(stream, featureReport);
+                            ApplyStartupDelay(featureReport);
+                        }
+
+                        for (var i = 0; i < 42; i++)
+                        {
+                            response = SendFeatureReport(stream, StreamingPulseFeatureReport);
+                            Thread.Sleep(2);
+                        }
+
+                        response = SendFeatureReport(stream, DisplayEnableFeatureReport);
+                        Thread.Sleep(StreamingInitDelayMs);
+                        response = SendFeatureReport(stream, StreamingStatusFeatureReport);
+
+                        Logger.Information(
+                            "VmaxUsbDevice: Streaming startup init completed with {CommandCount} feature reports, last response {Response}",
+                            StreamingStartupFeatureReports.Length + 44,
+                            BitConverter.ToString(response));
+                        Thread.Sleep(StreamingInitDelayMs);
+                        return stream;
+                    }
+                    catch
+                    {
+                        stream.Dispose();
+                        throw;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning(ex, "VmaxUsbDevice: HID streaming init failed for {Path}", hidDevice.DevicePath);
+                }
+            }
+
+            throw new InvalidOperationException("VMAX streaming init failed: no HID interface accepted the feature report.");
+        }
+
+        private static byte[] SendFeatureReport(HidStream stream, byte[] payload)
+        {
+            var report = new byte[payload.Length + 1];
+            report[0] = 0x00;
+            Buffer.BlockCopy(payload, 0, report, 1, payload.Length);
+
+            stream.SetFeature(report);
+
+            var response = new byte[report.Length];
+            response[0] = 0x00;
+            stream.GetFeature(response);
+            return response;
+        }
+
+        private static void ApplyStartupDelay(byte[] featureReport)
+        {
+            if (IsFeatureReport(featureReport, 0xA6, 0x07, 0x01))
+            {
+                Thread.Sleep(105);
+                return;
+            }
+
+            if (IsFeatureReport(featureReport, 0xA6, 0x05, 0x00))
+            {
+                Thread.Sleep(15);
+                return;
+            }
+
+            if (IsFeatureReport(featureReport, 0xB5, 0x00, 0x32))
+            {
+                Thread.Sleep(108);
+                return;
+            }
+
+            Thread.Sleep(1);
+        }
+
+        private static bool IsFeatureReport(byte[] featureReport, byte first, byte second, byte third)
+        {
+            return featureReport.Length >= 3
+                && featureReport[0] == first
+                && featureReport[1] == second
+                && featureReport[2] == third;
+        }
+
+        public void SendRgb888Frame(byte[] rgbData)
+        {
+            if (_writer == null) throw new InvalidOperationException("VMAX USB device is not open.");
+
+            var frame = new byte[FramePrefix.Length + rgbData.Length + FrameSuffix.Length];
+            Buffer.BlockCopy(FramePrefix, 0, frame, 0, FramePrefix.Length);
+            Buffer.BlockCopy(rgbData, 0, frame, FramePrefix.Length, rgbData.Length);
+            Buffer.BlockCopy(FrameSuffix, 0, frame, FramePrefix.Length + rgbData.Length, FrameSuffix.Length);
+
+            var offset = 0;
+            while (offset < frame.Length)
+            {
+                var writeSize = Math.Min(UsbWriteChunkSize, frame.Length - offset);
+                var result = _writer.Write(frame, offset, writeSize, UsbWriteTimeoutMs, out var bytesWritten);
+                if (result != ErrorCode.None || bytesWritten != writeSize)
+                {
+                    throw new InvalidOperationException($"VMAX USB write failed: {result}, wrote {bytesWritten}/{writeSize} bytes at offset {offset}/{frame.Length}.");
+                }
+
+                offset += bytesWritten;
+            }
+
+            if (!_loggedFirstFrame)
+            {
+                _loggedFirstFrame = true;
+                Logger.Information(
+                    "VmaxUsbDevice: First RGB888 frame sent. Payload={PayloadLength}, Frame={FrameLength}, Prefix={Prefix}, FirstPixels={FirstPixels}, Suffix={Suffix}",
+                    rgbData.Length,
+                    frame.Length,
+                    BitConverter.ToString(frame.Take(FramePrefix.Length).ToArray()),
+                    BitConverter.ToString(rgbData.Take(24).ToArray()),
+                    BitConverter.ToString(frame.Skip(frame.Length - FrameSuffix.Length).ToArray()));
+            }
+
+            _hasSentFrame = true;
+            PollStreamingStatusIfDue();
+        }
+
+        public void SetScreenSwitch(bool enabled)
+        {
+            if (_hidStream == null || !_hasSentFrame || _currentScreenSwitch == enabled)
+                return;
+
+            try
+            {
+                byte[] response = [];
+                foreach (var featureReport in GetScreenSwitchFeatureReports(enabled))
+                {
+                    response = SendFeatureReport(_hidStream, featureReport);
+                    ApplyStartupDelay(featureReport);
+                }
+
+                _currentScreenSwitch = enabled;
+                Logger.Information(
+                    "VmaxUsbDevice: ScreenSwitch set to {Enabled}, last response {Response}",
+                    enabled,
+                    BitConverter.ToString(response));
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "VmaxUsbDevice: ScreenSwitch command failed; continuing frame transfer.");
+            }
+        }
+
+        private static byte[][] GetScreenSwitchFeatureReports(bool enabled) =>
+        [
+            [0xB5, 0xF0, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB6, 0xF0, 0x05, enabled ? (byte)0x10 : (byte)0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xA6, 0x05, enabled ? (byte)0x01 : (byte)0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            [0xB5, 0xC5, 0x55, 0x00, 0x00, 0x00, 0x00, 0x00],
+        ];
+
+        private void PollStreamingStatusIfDue()
+        {
+            if (_hidStream == null)
+                return;
+
+            var now = DateTime.UtcNow;
+            if ((now - _lastStreamingStatusPolled).TotalMilliseconds < 500)
+                return;
+
+            _lastStreamingStatusPolled = now;
+
+            try
+            {
+                var response = SendFeatureReport(_hidStream, StreamingStatusFeatureReport);
+                Logger.Debug("VmaxUsbDevice: Streaming status response {Response}", BitConverter.ToString(response));
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "VmaxUsbDevice: Streaming status poll failed; continuing frame transfer.");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            _writer?.Dispose();
+            _writer = null;
+
+            _hidStream?.Dispose();
+            _hidStream = null;
+
+            try
+            {
+                _wholeUsbDevice?.ReleaseInterface(InterfaceNumber);
+            }
+            catch { }
+
+            _usbDevice?.Close();
+            _usbDevice = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for VMAX 4.6" LCD panels AuyiHomu HY-001,HY-002 (VID `0x345F`, PID `0x9132`, 320x960)
- Protocol reverse-engineered from USB/HID captures of the official VMAX software
- Uses the HID interface for startup/control commands and the USB display interface for RGB frame streaming
- Achieves up to 30 FPS on the tested device with a pipelined render/send loop

## Device details

- Tested product: VMAX 4.6" LCD display  (AuyiHomu HY-002)  purchased from AliExpress: <https://ja.aliexpress.com/item/1005012027699095.html>
- USB composite device with separate HID and USB display/vendor interfaces
- HID is used for startup initialization, ScreenSwitch control, and periodic status commands
- Frame streaming uses raw BGR888 payloads wrapped with VMAX-specific prefix/suffix bytes
- ScreenSwitch must be enabled after streaming starts before the display shows output
- Brightness value 100 causes timeout/jitter on the tested device, so output brightness is clamped to 99 internally

## Changes

**New VMAX driver files:**
- `InfoPanel/VmaxPanel/` - model database, discovery helper, and USB/HID communication
- `InfoPanel/Models/VmaxPanelDevice.cs` - per-device configuration model
- `InfoPanel/Services/VmaxPanelTask.cs` - multi-device task manager
- `InfoPanel/Services/VmaxPanelDeviceTask.cs` - render/convert/send loop

**Modified integration files:**
- `Settings.cs`, `ConfigModel.cs` - persistence for VMAX panel devices
- `App.xaml.cs` - lifecycle integration
- `UsbPanelsPage.xaml/.cs` - VMAX discovery, configuration, Advanced settings, ScreenSwitch UI
- `GlobalHotkeyService.cs` - VMAX hotkey target support

## Tested

 - continuous 30 FPS operation without visible jitter, flicker, or display noise on the tested device
- Built successfully with:

```powershell
dotnet build .\InfoPanel\InfoPanel.csproj -c Debug -p:Platform=x64 --no-restore -m:1
