### PR TITLE
Register OBS Monitor plugin in registry

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -101,7 +101,7 @@
       "name": "Windows 11 Now Playing",
       "description": "Displays currently playing media information from Windows 11's Global Media Transport Controls",
       "category": "media"
-    }
+    },
     {
       "repo": "cueebb/InfoPanel.OBS",
       "name": "OBS Monitor",

--- a/plugins.json
+++ b/plugins.json
@@ -102,5 +102,11 @@
       "description": "Displays currently playing media information from Windows 11's Global Media Transport Controls",
       "category": "media"
     }
+    {
+      "repo": "cueebb/InfoPanel.OBS",
+      "name": "OBS Monitor",
+      "description": "Plugin that displays currently OBS status",
+      "category": "monitoring"
+    }
   ]
 }


### PR DESCRIPTION
Hi! I would like to add my new standalone plugin for **OBS Studio** to the InfoPanel registry. 

It connects to OBS via WebSockets and provides both text and numeric sensors for recording, streaming, and replay buffer states.

This is actually my very first programming project. Unfortunately, I don't know any programming languages. I've written this plugin with Gemini AI.

### PR Checklist:
- [x] Plugin builds and runs correctly with the latest InfoPanel release
- [x] Repository is public (`cueebb/InfoPanel.OBS`)
- [x] GitHub Release contains a properly structured ZIP asset (`InfoPanel.OBS.zip`)
- [x] `PluginInfo.ini` is included inside the release package

Thank you for maintaining this awesome project!