### PR TITLE
Add Trofeo Vision 11.3" support and render 9.16" v2 at 480 like v1

### DIFF
--- a/InfoPanel/Models/ThermalrightPanelDevice.cs
+++ b/InfoPanel/Models/ThermalrightPanelDevice.cs
@@ -106,10 +106,12 @@ namespace InfoPanel.Models
         }
 
         /// <summary>
-        /// TrofeoBulk 5408 panels may need a flicker fix (crop JPEG to 462 rows).
-        /// Show the toggle only for that model.
+        /// TrofeoBulk 5408 9.16" panels may need a flicker fix (crop JPEG to 462 rows).
+        /// Both v1 (reports 480) and v2 (reports 599) render at 480 by default and offer
+        /// the 462 crop as an opt-in. The 11.3" has its own 400-row target and is excluded.
         /// </summary>
-        public bool HasFlickerFix => Model == ThermalrightPanelModel.TrofeoVision916;
+        public bool HasFlickerFix => Model == ThermalrightPanelModel.TrofeoVision916
+            || Model == ThermalrightPanelModel.TrofeoVision916V2;
 
         /// <summary>
         /// Effective display height accounting for flicker fix crop.

--- a/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
@@ -996,10 +996,32 @@ namespace InfoPanel.Services
                 Logger.Warning("ThermalrightPanelDevice {Device}: No TrofeoBulk response (ec={Error}), continuing anyway", _device, readEc);
             }
 
-            // Re-identify model variant based on device-reported resolution.
+            // Re-identify model variant based on byte[20] discriminator + reported resolution.
+            // All 0x5408 panels share the same VID/PID but report different byte[20] values:
+            //   byte[20]=0x01: 9.16" v1   (firmware reports 480, framebuffer is 462 — flicker fix crops)
+            //   byte[20]<=3:   9.16" v2   (firmware reports 599 — see TRCC pm=65 path)
+            //   byte[20]=0x05: 11.3"      (firmware reports 480, actual panel is 1920x400)
+            byte? trofeoB20 = readBytes >= 21 ? (byte?)responseBuffer[20] : null;
+
+            if (trofeoB20 == 0x05
+                && ThermalrightPanelModelDatabase.Models.TryGetValue(ThermalrightPanelModel.TrofeoVision113, out var v113Model))
+            {
+                _detectedModel = v113Model;
+                _device.Model = v113Model.Model;
+                _panelWidth = v113Model.RenderWidth;
+                _panelHeight = v113Model.RenderHeight;
+                Logger.Information("ThermalrightPanelDevice {Device}: byte[20]=0x05 detected as Trofeo Vision 11.3\" ({Width}x{Height})",
+                    _device, _panelWidth, _panelHeight);
+            }
+            // On restart, model is already 11.3" but device still reports 480. Override to model's render size.
+            else if (_device.Model == ThermalrightPanelModel.TrofeoVision113 && _device.ModelInfo != null)
+            {
+                _panelWidth = _device.ModelInfo.RenderWidth;
+                _panelHeight = _device.ModelInfo.RenderHeight;
+            }
             // v1 (480) and v2 (599) share the same VID/PID but have different panels.
             // TRCC forces 462 for all 5408 variants (byte[20] <= 3 -> pm=65 -> 1920x462).
-            if (_panelHeight != 480 && _device.Model == ThermalrightPanelModel.TrofeoVision916
+            else if (_panelHeight != 480 && _device.Model == ThermalrightPanelModel.TrofeoVision916
                 && ThermalrightPanelModelDatabase.Models.TryGetValue(ThermalrightPanelModel.TrofeoVision916V2, out var v2Model))
             {
                 _detectedModel = v2Model;
@@ -1019,7 +1041,8 @@ namespace InfoPanel.Services
             // Some panel units have a 462-row framebuffer; sending 480-height JPEGs overflows
             // by 18 rows, wrapping to the top of the display.
             // Flicker fix is toggled live via _device.FlickerFix, checked each frame in GenerateJpegBuffer.
-            if (_panelHeight == 480)
+            // Skip for 11.3" — that panel has its own 400-row target, not a 462 crop.
+            if (_panelHeight == 480 && _device.Model != ThermalrightPanelModel.TrofeoVision113)
             {
                 _flickerFixCropHeight = 462;
             }

--- a/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
@@ -1019,8 +1019,11 @@ namespace InfoPanel.Services
                 _panelWidth = _device.ModelInfo.RenderWidth;
                 _panelHeight = _device.ModelInfo.RenderHeight;
             }
-            // v1 (480) and v2 (599) share the same VID/PID but have different panels.
-            // TRCC forces 462 for all 5408 variants (byte[20] <= 3 -> pm=65 -> 1920x462).
+            // v1 (reports 480) and v2 (reports 599) share the same VID/PID but report
+            // different heights. They are the same physical 9.16" panel, so v2 renders at
+            // the same 1920x480 default as v1 (overriding the bogus 599 the firmware reports;
+            // sending 599-height JPEGs is stretched). Flicker fix then crops to 462 if the
+            // user's unit needs it — identical opt-in behavior to v1.
             else if (_panelHeight != 480 && _device.Model == ThermalrightPanelModel.TrofeoVision916
                 && ThermalrightPanelModelDatabase.Models.TryGetValue(ThermalrightPanelModel.TrofeoVision916V2, out var v2Model))
             {
@@ -1036,11 +1039,12 @@ namespace InfoPanel.Services
                 _panelHeight = _device.ModelInfo.RenderHeight;
             }
 
-            // TRCC sends 1920x462 JPEGs for v1, NOT 1920x480 as reported by the device.
-            // The JPEG SOF0 in USB captures confirms height=0x01CE=462.
-            // Some panel units have a 462-row framebuffer; sending 480-height JPEGs overflows
-            // by 18 rows, wrapping to the top of the display.
-            // Flicker fix is toggled live via _device.FlickerFix, checked each frame in GenerateJpegBuffer.
+            // Both 9.16" v1 and v2 render at 1920x480 by default. Some units have a 462-row
+            // framebuffer; sending 480-height JPEGs overflows by 18 rows and wraps to the top
+            // of the display (TRCC works around this by always sending 462 — JPEG SOF0 in USB
+            // captures confirms height=0x01CE=462). We default to the full 480 and let the user
+            // enable the Flicker Fix toggle to crop to 462 if their unit shows the overflow.
+            // Flicker fix is checked live each frame in GenerateJpegBuffer.
             // Skip for 11.3" — that panel has its own 400-row target, not a 462 crop.
             if (_panelHeight == 480 && _device.Model != ThermalrightPanelModel.TrofeoVision113)
             {

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelHelper.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelHelper.cs
@@ -86,6 +86,14 @@ namespace InfoPanel.ThermalrightPanel
                             {
                                 modelInfo = ProbeWinUsbModel(deviceReg);
                             }
+                            // Trofeo 0x0416:0x5408 is also ambiguous — same PID for 9.16" v1, 9.16" v2, and 11.3".
+                            // Refine the VID/PID result by probing byte[20] of the TrofeoBulk init response.
+                            else if (vendorId == ThermalrightPanelModelDatabase.TROFEO_VENDOR_ID
+                                  && productId == ThermalrightPanelModelDatabase.TROFEO_PRODUCT_ID_916)
+                            {
+                                var refined = ProbeTrofeoBulkModel(deviceReg);
+                                if (refined != null) modelInfo = refined;
+                            }
                         }
                         else
                         {
@@ -371,6 +379,117 @@ namespace InfoPanel.ThermalrightPanel
             var identifier = Encoding.ASCII.GetString(response, 4, 8).TrimEnd('\0');
             Logger.Information("ThermalrightPanelHelper: Probe identifier: {Id}", identifier);
             return ThermalrightPanelModelDatabase.GetModelByIdentifier(identifier, sub);
+        }
+
+        /// <summary>
+        /// TrofeoBulk init probe for VID/PID 0x0416:0x5408. Sends the 2048-byte init packet,
+        /// reads the 512-byte response, and discriminates by byte[20]:
+        ///   0x01 → 9.16" v1, 0x02/0x03 → 9.16" v2, 0x05 → 11.3".
+        /// Returns null on any failure (device busy, wrong driver, timeout); caller keeps the
+        /// VID/PID-based default.
+        /// </summary>
+        private static ThermalrightPanelModelInfo? ProbeTrofeoBulkModel(UsbRegistry deviceReg)
+        {
+            const int PROBE_TIMEOUT_MS = 5000;
+            using var cts = new CancellationTokenSource(PROBE_TIMEOUT_MS);
+            try
+            {
+                var probeTask = Task.Run(() => ProbeTrofeoBulkModelInner(deviceReg, cts.Token), cts.Token);
+                probeTask.Wait(cts.Token);
+                return probeTask.Result;
+            }
+            catch (OperationCanceledException)
+            {
+                Logger.Warning("ThermalrightPanelHelper: TrofeoBulk probe timed out after {Timeout}ms", PROBE_TIMEOUT_MS);
+                return null;
+            }
+            catch (AggregateException ae) when (ae.InnerException is OperationCanceledException)
+            {
+                Logger.Warning("ThermalrightPanelHelper: TrofeoBulk probe timed out after {Timeout}ms", PROBE_TIMEOUT_MS);
+                return null;
+            }
+            catch (AggregateException ae)
+            {
+                Logger.Debug(ae.InnerException ?? ae, "ThermalrightPanelHelper: TrofeoBulk probe failed");
+                return null;
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "ThermalrightPanelHelper: TrofeoBulk probe failed");
+                return null;
+            }
+        }
+
+        private static ThermalrightPanelModelInfo? ProbeTrofeoBulkModelInner(UsbRegistry deviceReg, CancellationToken token)
+        {
+            token.ThrowIfCancellationRequested();
+            using var usbDevice = deviceReg.Device;
+            if (usbDevice == null)
+            {
+                Logger.Debug("ThermalrightPanelHelper: TrofeoBulk probe could not open device");
+                return null;
+            }
+
+            if (usbDevice is IUsbDevice wholeUsbDevice)
+            {
+                wholeUsbDevice.SetConfiguration(1);
+                wholeUsbDevice.ClaimInterface(0);
+            }
+
+            // Trofeo 0x5408: write EP 0x09 OUT, read EP 0x81 IN (set in DeviceTask too).
+            WriteEndpointID writeEp = WriteEndpointID.Ep09;
+            ReadEndpointID readEp = ReadEndpointID.Ep01;
+            foreach (var config in usbDevice.Configs)
+            {
+                foreach (var iface in config.InterfaceInfoList)
+                {
+                    foreach (var ep in iface.EndpointInfoList)
+                    {
+                        var addr = (byte)ep.Descriptor.EndpointID;
+                        if ((addr & 0x80) == 0) writeEp = (WriteEndpointID)addr;
+                        else readEp = (ReadEndpointID)addr;
+                    }
+                }
+            }
+
+            using var writer = usbDevice.OpenEndpointWriter(writeEp);
+            using var reader = usbDevice.OpenEndpointReader(readEp);
+
+            // Build TrofeoBulk init: 2048 bytes, byte[0]=0x02, byte[1]=0xFF, byte[8]=0x01.
+            var initPacket = new byte[2048];
+            initPacket[0] = 0x02;
+            initPacket[1] = 0xFF;
+            initPacket[8] = 0x01;
+
+            var ec = writer.Write(initPacket, 3000, out _);
+            if (ec != ErrorCode.None)
+            {
+                Logger.Debug("ThermalrightPanelHelper: TrofeoBulk probe write failed: {Error}", ec);
+                return null;
+            }
+
+            var response = new byte[512];
+            ec = reader.Read(response, 3000, out int bytesRead);
+            if (ec != ErrorCode.None || bytesRead < 21)
+            {
+                Logger.Debug("ThermalrightPanelHelper: TrofeoBulk probe read failed: {Error}, bytes={Bytes}", ec, bytesRead);
+                return null;
+            }
+
+            byte b20 = response[20];
+            Logger.Information("ThermalrightPanelHelper: TrofeoBulk probe byte[20]=0x{B20:X2}", b20);
+
+            // 0x05 → 11.3". 0x02/0x03 → 9.16" v2. 0x01 (and anything else) → 9.16" v1 default.
+            var targetModel = b20 switch
+            {
+                0x05 => ThermalrightPanelModel.TrofeoVision113,
+                >= 0x02 and <= 0x03 => ThermalrightPanelModel.TrofeoVision916V2,
+                _ => ThermalrightPanelModel.TrofeoVision916,
+            };
+
+            if (ThermalrightPanelModelDatabase.Models.TryGetValue(targetModel, out var info))
+                return info;
+            return null;
         }
     }
 

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
@@ -18,7 +18,7 @@ namespace InfoPanel.ThermalrightPanel
         TrofeoVision,
         // Trofeo Vision 9.16" - USB bulk (VID 0x0416 / PID 0x5408, LY chipset)
         TrofeoVision916,
-        // Trofeo Vision 9.16" v2 - USB bulk (VID 0x0416 / PID 0x5408, reports 1920x599, renders at 1920x462)
+        // Trofeo Vision 9.16" v2 - USB bulk (VID 0x0416 / PID 0x5408, reports 1920x599, renders at 1920x480 + optional 462 flicker-fix crop, same as v1)
         TrofeoVision916V2,
         // Trofeo Vision 11.3" - USB bulk (VID 0x0416 / PID 0x5408, byte[20]=0x05, reports 1920x480 but renders at 1920x400)
         TrofeoVision113,

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModel.cs
@@ -20,6 +20,8 @@ namespace InfoPanel.ThermalrightPanel
         TrofeoVision916,
         // Trofeo Vision 9.16" v2 - USB bulk (VID 0x0416 / PID 0x5408, reports 1920x599, renders at 1920x462)
         TrofeoVision916V2,
+        // Trofeo Vision 11.3" - USB bulk (VID 0x0416 / PID 0x5408, byte[20]=0x05, reports 1920x480 but renders at 1920x400)
+        TrofeoVision113,
         // Trofeo Vision 9.16" - USB bulk (VID 0x0416 / PID 0x5409, LY1 chipset)
         TrofeoVision916LY1,
 

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
@@ -224,6 +224,21 @@ namespace InfoPanel.ThermalrightPanel
                 TransportType = ThermalrightTransportType.WinUsb,
                 ProtocolType = ThermalrightProtocolType.TrofeoBulk
             },
+            // 11.3" is NOT in the VID/PID lookup (same PID 0x5408 as 9.16").
+            // Detected at runtime by byte[20]=0x05 in the TrofeoBulk init response.
+            // Device firmware still reports 1920x480 but the actual panel is 1920x400.
+            [ThermalrightPanelModel.TrofeoVision113] = new ThermalrightPanelModelInfo
+            {
+                Model = ThermalrightPanelModel.TrofeoVision113,
+                Name = "Trofeo Vision 11.3\"",
+                DeviceIdentifier = "",
+                Width = 1920,
+                Height = 400,
+                RenderWidth = 1920,
+                RenderHeight = 400,
+                TransportType = ThermalrightTransportType.WinUsb,
+                ProtocolType = ThermalrightProtocolType.TrofeoBulk
+            },
             [ThermalrightPanelModel.TrofeoVision320] = new ThermalrightPanelModelInfo
             {
                 Model = ThermalrightPanelModel.TrofeoVision320,

--- a/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
+++ b/InfoPanel/ThermalrightPanel/ThermalrightPanelModelDatabase.cs
@@ -217,10 +217,12 @@ namespace InfoPanel.ThermalrightPanel
                 Model = ThermalrightPanelModel.TrofeoVision916V2,
                 Name = "Trofeo Vision 9.16\" v2",
                 DeviceIdentifier = "",
+                // Same physical 9.16" panel as v1; firmware just reports 599 instead of 480.
+                // Render at the v1 default (480), Flicker Fix crops to 462 if the unit needs it.
                 Width = 1920,
-                Height = 462,
+                Height = 480,
                 RenderWidth = 1920,
-                RenderHeight = 462,
+                RenderHeight = 480,
                 TransportType = ThermalrightTransportType.WinUsb,
                 ProtocolType = ThermalrightProtocolType.TrofeoBulk
             },


### PR DESCRIPTION
## Why?

Two Trofeo Vision panel fixes on the shared `0x0416:0x5408` PID, both about getting the render resolution right:

1. The new **Trofeo Vision 11.3"** LCD (272×70×14 mm, 1920×400, USB-C) ships on the same VID/PID as the 9.16", so it was misdetected as Trofeo Vision 9.16" and rendered at the wrong height.
2. The **9.16" "v2"** variant (the firmware batch that self-reports 1920x599) was hard-pinned to 1920x462, while the original 9.16" renders at 1920x480 by default with Flicker Fix as an opt-in 462 crop. They are the same physical panel, so an undamaged v2 unit should fill the full 480 just like v1.

## How?

All three 5408 panels share the same VID/PID and are disambiguated by `byte[20]` of the TrofeoBulk init response. Add an 11.3" model + discovery probe, and align the v2 render path with v1.

### Supported panels

| Model | Size | Resolution | `byte[20]` | Notes |
|-------|------|------------|-----------:|-------|
| **Trofeo Vision 9.16"** | 9.16" | 1920x480 | `0x01` | reports 480; Flicker Fix crops to 462 |
| **Trofeo Vision 9.16" v2** | 9.16" | 1920x480 | `0x02`–`0x03` | reports 599; now renders 480 like v1, Flicker Fix crops to 462 |
| **Trofeo Vision 11.3"** | 11.3" | 1920x400 | `0x05` | reports 480; actual panel is 400 |

### Detection

- **Per-device init**: after the 2048-byte `02 FF ... 01` init and 512-byte response, `byte[20]==0x05` → 11.3" (1920x400); `byte[20]` reporting a non-480 height → 9.16" v2 (now 1920x480, was 462).
- **Discovery scan** (new): `ProbeTrofeoBulkModel` runs the same init handshake and reads `byte[20]`, so the panel is labelled correctly before activation instead of defaulting to 9.16". 5-second timeout, returns null on any failure so the VID/PID default is kept. Only runs for `0x0416:0x5408`.

### 9.16" v2 alignment

- `TrofeoVision916V2` model entry: `1920x462` → `1920x480`.
- `HasFlickerFix` now true for v2 as well as v1, so users whose unit shows the 18-row overflow can opt into the 462 crop.
- The bogus 599 the firmware reports is still ignored (sending 599-height JPEGs is stretched).

### Notes

- `TrofeoVision113` and `TrofeoVision916V2` are runtime-variant entries with no VID/PID set, the same pattern used to keep `GetModelByVidPid` unique on the shared PID.

<sub>Generated with Claude Code</sub>