### PR TITLE
Editor UX improvements: multi-select operations, axis lock, alignment guides, drag-to-group

### DIFF
--- a/InfoPanel/Drawing/PanelDraw.cs
+++ b/InfoPanel/Drawing/PanelDraw.cs
@@ -46,6 +46,7 @@ namespace InfoPanel.Drawing
                 Draw(g, preview, scale, cache, cacheHint, displayItem, selectedRectangles);
             }
 
+
             if (!preview && SharedModel.Instance.SelectedProfile == profile && selectedRectangles.Count != 0)
             {
                 if (ConfigModel.Instance.Settings.ShowGridLines)
@@ -96,6 +97,20 @@ namespace InfoPanel.Drawing
                 else
                 {
                     Logger.Warning("Failed to parse selected item color: {Color}", ConfigModel.Instance.Settings.SelectedItemColor);
+                }
+            }
+
+            if (!preview && SharedModel.Instance.SelectedProfile == profile && SharedModel.Instance.DragHoverGroup is GroupDisplayItem dragHoverGroup)
+            {
+                var hoverBounds = SharedModel.Instance.GetGroupBounds(dragHoverGroup);
+                if (hoverBounds is SKRect hb)
+                {
+                    using var path = RectToPath(hb, 0, profile.Width, profile.Height, 3);
+
+                    if (path != null)
+                    {
+                        g.DrawPath(path, SKColor.Parse("#FFFFA500"), 3);
+                    }
                 }
             }
 
@@ -632,6 +647,21 @@ namespace InfoPanel.Drawing
                             }
                         }
 
+                        break;
+                    }
+                case GuideDisplayItem guideDisplayItem:
+                    {
+                        if (SKColor.TryParse(guideDisplayItem.Color, out _))
+                        {
+                            var centerX = guideDisplayItem.X * scale;
+                            var centerY = guideDisplayItem.Y * scale;
+                            var halfLength = guideDisplayItem.Length * scale / 2f;
+                            var radians = guideDisplayItem.Rotation * Math.PI / 180.0;
+                            var dx = (float)(Math.Cos(radians) * halfLength);
+                            var dy = (float)(Math.Sin(radians) * halfLength);
+
+                            g.DrawLine(centerX - dx, centerY - dy, centerX + dx, centerY + dy, guideDisplayItem.Color, 1);
+                        }
                         break;
                     }
             }

--- a/InfoPanel/Models/DisplayItem.cs
+++ b/InfoPanel/Models/DisplayItem.cs
@@ -87,6 +87,8 @@ public abstract partial class DisplayItem : ObservableObject, ICloneable
                     return "Donut";
                 case ShapeDisplayItem:
                     return "Shape";
+                case GuideDisplayItem:
+                    return "Guide";
                 default:
                     return "";
             }

--- a/InfoPanel/Models/GuideDisplayItem.cs
+++ b/InfoPanel/Models/GuideDisplayItem.cs
@@ -1,0 +1,57 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using SkiaSharp;
+
+namespace InfoPanel.Models
+{
+    public partial class GuideDisplayItem : DisplayItem
+    {
+        /// <summary>Click/snap tolerance perpendicular to the guide line, in profile pixels.</summary>
+        private const float HitTestPadding = 10f;
+
+        [ObservableProperty]
+        private int _length = 200;
+
+        [ObservableProperty]
+        private string _color = "#FF00FFFF";
+
+        public GuideDisplayItem()
+        {
+        }
+
+        public GuideDisplayItem(string name, Profile profile) : base(name, profile)
+        {
+        }
+
+        public override object Clone()
+        {
+            var clone = (DisplayItem)MemberwiseClone();
+            clone.Guid = System.Guid.NewGuid();
+            return clone;
+        }
+
+        public override SKRect EvaluateBounds()
+        {
+            return new SKRect(X - Length / 2f, Y - HitTestPadding / 2f, X + Length / 2f, Y + HitTestPadding / 2f);
+        }
+
+        public override string EvaluateColor()
+        {
+            return Color;
+        }
+
+        public override SKSize EvaluateSize()
+        {
+            return new SKSize(Length, HitTestPadding);
+        }
+
+        public override string EvaluateText()
+        {
+            return Name;
+        }
+
+        public override (string, string) EvaluateTextAndColor()
+        {
+            return (EvaluateText(), EvaluateColor());
+        }
+    }
+}

--- a/InfoPanel/Models/SharedModel.cs
+++ b/InfoPanel/Models/SharedModel.cs
@@ -494,8 +494,44 @@ namespace InfoPanel
         public bool IsItemSelected => SelectedItem != null;
         public bool IsSingleItemSelected => SelectedItems.Count == 1;
 
+        /// <summary>
+        /// Topmost selected entities: a selected group counts as one unit (its children are not
+        /// also returned, even though they carry Selected=true for visual highlighting); children
+        /// individually selected within an unselected group are returned as their own units.
+        /// </summary>
+        private List<DisplayItem> GetSelectedRootItems()
+        {
+            var roots = new List<DisplayItem>();
+            AccessDisplayItems(items =>
+            {
+                foreach (var item in items)
+                {
+                    if (item is GroupDisplayItem group)
+                    {
+                        if (group.Selected)
+                            roots.Add(group);
+                        else
+                            roots.AddRange(group.DisplayItems.Where(child => child.Selected));
+                    }
+                    else if (item.Selected)
+                    {
+                        roots.Add(item);
+                    }
+                }
+            });
+            return roots;
+        }
+
         [ObservableProperty]
         private int _moveValue = 5;
+
+        /// <summary>
+        /// The group currently being hovered over as a drop target while dragging item(s) on the
+        /// design canvas. Set by <c>DisplayWindow</c> during a canvas drag so <c>PanelDraw</c> can
+        /// render a highlight around it.
+        /// </summary>
+        [ObservableProperty]
+        private GroupDisplayItem? _dragHoverGroup;
 
         private SharedModel() { }
 
@@ -572,6 +608,33 @@ namespace InfoPanel
             });
         }
 
+        /// <summary>
+        /// Removes all currently-selected items (or just SelectedItem if none/one are selected),
+        /// sharing one undo snapshot. A selected group is removed as a single unit together with all
+        /// its children; children individually selected within an unselected group are removed
+        /// individually instead.
+        /// </summary>
+        public void RemoveSelectedItems()
+        {
+            if (SelectedProfile is not Profile profile) return;
+            var roots = GetSelectedRootItems();
+            if (roots.Count == 0) return;
+
+            AccessDisplayItems(profile, displayItems =>
+            {
+                PushUndoSnapshot(profile, displayItems);
+
+                foreach (var item in roots)
+                {
+                    FindParentCollection(item, out _)?.Remove(item);
+                }
+
+                UpdateLastStateSnapshot();
+            });
+
+            SelectedItem = null;
+        }
+
         public GroupDisplayItem? GetParent(DisplayItem displayItem)
         {
             FindParentCollection(displayItem, out var result);
@@ -598,6 +661,116 @@ namespace InfoPanel
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// Computes the union of the bounds of a group's visible children, for use as the group's
+        /// "drop zone" on the design canvas. Returns null for an empty/fully-excluded/hidden group,
+        /// since such a group has no canvas footprint to drop onto.
+        /// </summary>
+        public SKRect? GetGroupBounds(GroupDisplayItem group, IEnumerable<DisplayItem>? exclude = null)
+        {
+            HashSet<DisplayItem>? excludeSet = exclude != null ? new HashSet<DisplayItem>(exclude) : null;
+            SKRect? union = null;
+            foreach (var item in group.DisplayItemsCopy)
+            {
+                if (item.Hidden) continue;
+                if (excludeSet != null && excludeSet.Contains(item)) continue;
+                var bounds = item.EvaluateBounds();
+                union = union is SKRect existing ? SKRect.Union(existing, bounds) : bounds;
+            }
+            return union;
+        }
+
+        /// <summary>
+        /// Moves each item into its paired target group (or to the root level if null), removing it
+        /// from its current parent collection. Used for drag-and-drop grouping on the design canvas;
+        /// callers are expected to have already filtered out no-op moves.
+        /// </summary>
+        public void MoveItemsToGroup(IEnumerable<(DisplayItem Item, GroupDisplayItem? TargetGroup)> moves)
+        {
+            if (SelectedProfile is not Profile profile) return;
+            var moveList = moves.ToList();
+            if (moveList.Count == 0) return;
+
+            AccessDisplayItems(profile, displayItems =>
+            {
+                PushUndoSnapshot(profile, displayItems);
+
+                foreach (var (item, targetGroup) in moveList)
+                {
+                    var currentParent = FindParentCollection(item, out _);
+                    currentParent?.Remove(item);
+
+                    if (targetGroup != null)
+                    {
+                        targetGroup.DisplayItems.Add(item);
+                        targetGroup.IsExpanded = true;
+                    }
+                    else
+                    {
+                        displayItems.Add(item);
+                    }
+                }
+
+                UpdateLastStateSnapshot();
+            });
+        }
+
+        /// <summary>
+        /// Moves all currently-selected items one slot in the given direction (-1 = up, +1 = down),
+        /// keeping their relative order intact. Each selection root only moves within its own parent
+        /// collection (root or group) and is skipped once it's adjacent to another selected sibling in
+        /// the direction of travel, so a contiguous block of selected items moves together as one unit.
+        /// </summary>
+        public void MoveSelectedItemsBy(int direction)
+        {
+            if (SelectedProfile is not Profile profile) return;
+            var roots = GetSelectedRootItems();
+            if (roots.Count == 0) return;
+
+            AccessDisplayItems(profile, displayItems =>
+            {
+                PushUndoSnapshot(profile, displayItems);
+
+                var byParent = roots
+                    .Select(item => (item, parent: FindParentCollection(item, out _)))
+                    .Where(x => x.parent != null)
+                    .GroupBy(x => x.parent);
+
+                foreach (var group in byParent)
+                {
+                    var parentCollection = group.Key!;
+                    var ordered = group.Select(x => x.item)
+                        .OrderBy(parentCollection.IndexOf)
+                        .ToList();
+
+                    if (direction < 0)
+                    {
+                        foreach (var item in ordered)
+                        {
+                            int index = parentCollection.IndexOf(item);
+                            int newIndex = index - 1;
+                            if (newIndex < 0 || parentCollection[newIndex].Selected) continue;
+                            parentCollection.Move(index, newIndex);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var item in ordered.AsEnumerable().Reverse())
+                        {
+                            int index = parentCollection.IndexOf(item);
+                            int newIndex = index + 1;
+                            if (newIndex >= parentCollection.Count || parentCollection[newIndex].Selected) continue;
+                            parentCollection.Move(index, newIndex);
+                        }
+                    }
+                }
+
+                UpdateLastStateSnapshot();
+            });
+
+            NotifySelectedItemChange();
         }
 
         public void PushDisplayItemBy(DisplayItem displayItem, int count)
@@ -656,6 +829,57 @@ namespace InfoPanel
                 }
                 UpdateLastStateSnapshot();
             });
+        }
+
+        /// <summary>
+        /// Duplicates all currently-selected items (or just SelectedItem if none/one are selected).
+        /// Each clone is inserted immediately after its original within the same parent collection
+        /// (root or group), offset by (10,10) so it's visibly distinct, and only the clones end up selected.
+        /// </summary>
+        public void DuplicateSelectedItems()
+        {
+            if (SelectedProfile is not Profile profile) return;
+            var roots = GetSelectedRootItems();
+            if (roots.Count == 0) return;
+
+            AccessDisplayItems(profile, displayItems =>
+            {
+                PushUndoSnapshot(profile, displayItems);
+
+                var clones = new List<DisplayItem>();
+                var byParent = roots
+                    .Select(item => (item, parent: FindParentCollection(item, out _)))
+                    .Where(x => x.parent != null)
+                    .GroupBy(x => x.parent);
+
+                foreach (var group in byParent)
+                {
+                    var parentCollection = group.Key!;
+                    var ordered = group.Select(x => x.item)
+                        .OrderBy(parentCollection.IndexOf)
+                        .ToList();
+
+                    foreach (var original in ordered)
+                    {
+                        var clone = (DisplayItem)original.Clone();
+                        clone.X = original.X + 10;
+                        clone.Y = original.Y + 10;
+                        clone.Selected = false;
+                        original.Selected = false;
+
+                        int insertIndex = parentCollection.IndexOf(original) + 1;
+                        parentCollection.Insert(insertIndex, clone);
+                        clones.Add(clone);
+                    }
+                }
+
+                foreach (var clone in clones)
+                    clone.Selected = true;
+
+                UpdateLastStateSnapshot();
+            });
+
+            NotifySelectedItemChange();
         }
 
         public void PushDisplayItemTo(DisplayItem displayItem, DisplayItem target)
@@ -772,7 +996,7 @@ namespace InfoPanel
             var fileName = Path.Combine(profileFolder, profile.Guid + ".xml");
             var tempFileName = fileName + ".tmp";
             var backupFileName = fileName + ".bak";
-            var xs = new XmlSerializer(typeof(List<DisplayItem>), [typeof(GroupDisplayItem), typeof(BarDisplayItem), typeof(GraphDisplayItem), typeof(DonutDisplayItem), typeof(TableSensorDisplayItem), typeof(SensorDisplayItem), typeof(ClockDisplayItem), typeof(CalendarDisplayItem), typeof(TextDisplayItem), typeof(SensorImageDisplayItem), typeof(ImageDisplayItem), typeof(HttpImageDisplayItem), typeof(GaugeDisplayItem), typeof(ShapeDisplayItem)]);
+            var xs = new XmlSerializer(typeof(List<DisplayItem>), [typeof(GroupDisplayItem), typeof(BarDisplayItem), typeof(GraphDisplayItem), typeof(DonutDisplayItem), typeof(TableSensorDisplayItem), typeof(SensorDisplayItem), typeof(ClockDisplayItem), typeof(CalendarDisplayItem), typeof(TextDisplayItem), typeof(SensorImageDisplayItem), typeof(ImageDisplayItem), typeof(HttpImageDisplayItem), typeof(GaugeDisplayItem), typeof(ShapeDisplayItem), typeof(GuideDisplayItem)]);
             var settings = new XmlWriterSettings() { Encoding = Encoding.UTF8, Indent = true };
             using (var wr = XmlWriter.Create(tempFileName, settings))
                 xs.Serialize(wr, displayItems.ToList());
@@ -836,7 +1060,7 @@ namespace InfoPanel
         private static List<DisplayItem> LoadDisplayItemsFromFilePath(Profile profile, string fullPathToXml)
         {
             if (!File.Exists(fullPathToXml)) return [];
-            var xs = new XmlSerializer(typeof(List<DisplayItem>), [typeof(GroupDisplayItem), typeof(BarDisplayItem), typeof(GraphDisplayItem), typeof(DonutDisplayItem), typeof(TableSensorDisplayItem), typeof(SensorDisplayItem), typeof(ClockDisplayItem), typeof(CalendarDisplayItem), typeof(TextDisplayItem), typeof(SensorImageDisplayItem), typeof(ImageDisplayItem), typeof(HttpImageDisplayItem), typeof(GaugeDisplayItem), typeof(ShapeDisplayItem)]);
+            var xs = new XmlSerializer(typeof(List<DisplayItem>), [typeof(GroupDisplayItem), typeof(BarDisplayItem), typeof(GraphDisplayItem), typeof(DonutDisplayItem), typeof(TableSensorDisplayItem), typeof(SensorDisplayItem), typeof(ClockDisplayItem), typeof(CalendarDisplayItem), typeof(TextDisplayItem), typeof(SensorImageDisplayItem), typeof(ImageDisplayItem), typeof(HttpImageDisplayItem), typeof(GaugeDisplayItem), typeof(ShapeDisplayItem), typeof(GuideDisplayItem)]);
             using var rd = XmlReader.Create(fullPathToXml);
             try
             {

--- a/InfoPanel/Services/UndoManager.cs
+++ b/InfoPanel/Services/UndoManager.cs
@@ -30,7 +30,7 @@ public sealed class UndoManager
         typeof(GroupDisplayItem), typeof(BarDisplayItem), typeof(GraphDisplayItem), typeof(DonutDisplayItem),
         typeof(TableSensorDisplayItem), typeof(SensorDisplayItem), typeof(ClockDisplayItem), typeof(CalendarDisplayItem),
         typeof(TextDisplayItem), typeof(SensorImageDisplayItem), typeof(ImageDisplayItem), typeof(HttpImageDisplayItem),
-        typeof(GaugeDisplayItem), typeof(ShapeDisplayItem)
+        typeof(GaugeDisplayItem), typeof(ShapeDisplayItem), typeof(GuideDisplayItem)
     ];
 
     private static readonly XmlSerializer Serializer = new(typeof(List<DisplayItem>), DisplayItemTypes);

--- a/InfoPanel/Views/Components/DisplayItemView.xaml
+++ b/InfoPanel/Views/Components/DisplayItemView.xaml
@@ -66,6 +66,9 @@
                         <DataTrigger Binding="{Binding Kind}" Value="Shape">
                             <Setter Property="Symbol" Value="DrawShape20" />
                         </DataTrigger>
+                        <DataTrigger Binding="{Binding Kind}" Value="Guide">
+                            <Setter Property="Symbol" Value="SubGrid20" />
+                        </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </ui:SymbolIcon.Style>

--- a/InfoPanel/Views/Components/DisplayItems.xaml
+++ b/InfoPanel/Views/Components/DisplayItems.xaml
@@ -46,6 +46,11 @@
                             Grid.Column="0"
                             Background="#00FFFFFF"
                             PreviewMouseLeftButtonDown="Border_MouseDown">
+                            <Border.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Click="MenuItemDeleteGroup_Click" Header="Delete Group and Children" />
+                                </ContextMenu>
+                            </Border.ContextMenu>
                             <Grid HorizontalAlignment="Stretch">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="auto" />
@@ -309,16 +314,16 @@
                     Click="ButtonPushUp_Click"
                     Content=""
                     Icon="{ui:SymbolIcon ArrowUp20}"
-                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSingleItemSelected}"
-                    ToolTip="Push selected item up (overlapped by items below)" />
+                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
+                    ToolTip="Move selected item(s) up (overlapped by items below)" />
                 <ui:Button
                     x:Name="ButtonPushDown"
                     Margin="0,10,0,0"
                     Click="ButtonPushDown_Click"
                     Content=""
                     Icon="{ui:SymbolIcon ArrowDown20}"
-                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSingleItemSelected}"
-                    ToolTip="Bring selected item down (overlap items above)" />
+                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
+                    ToolTip="Move selected item(s) down (overlap items above)" />
                 <ui:Button
                     x:Name="ButtonPushFront"
                     Margin="0,10,0,0"
@@ -333,8 +338,8 @@
                     Click="ButtonDuplicate_Click"
                     Content=""
                     Icon="{ui:SymbolIcon Copy20}"
-                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSingleItemSelected}"
-                    ToolTip="Duplicate selected item" />
+                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
+                    ToolTip="Duplicate selected item(s)" />
                 <ui:Button
                     x:Name="ButtonDelete"
                     Margin="0,10,0,0"
@@ -342,8 +347,8 @@
                     Click="ButtonDelete_Click"
                     Content=""
                     Icon="{ui:SymbolIcon Delete20}"
-                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsSingleItemSelected}"
-                    ToolTip="Delete selected item" />
+                    IsEnabled="{Binding Source={x:Static app:SharedModel.Instance}, Path=IsItemSelected}"
+                    ToolTip="Delete selected item(s)" />
             </StackPanel>
 
         </Grid>

--- a/InfoPanel/Views/Components/DisplayItems.xaml.cs
+++ b/InfoPanel/Views/Components/DisplayItems.xaml.cs
@@ -261,6 +261,12 @@ namespace InfoPanel.Views.Components
 
         private void ButtonPushUp_Click(object sender, RoutedEventArgs e)
         {
+            if (SharedModel.Instance.SelectedItems.Count > 1)
+            {
+                SharedModel.Instance.MoveSelectedItemsBy(-1);
+                return;
+            }
+
             if (SelectedItem is DisplayItem item)
             {
                 _isHandlingSelection = true;
@@ -289,6 +295,12 @@ namespace InfoPanel.Views.Components
 
         private void ButtonPushDown_Click(object sender, RoutedEventArgs e)
         {
+            if (SharedModel.Instance.SelectedItems.Count > 1)
+            {
+                SharedModel.Instance.MoveSelectedItemsBy(1);
+                return;
+            }
+
             if (SelectedItem is DisplayItem item)
             {
                 _isHandlingSelection = true;
@@ -367,9 +379,23 @@ namespace InfoPanel.Views.Components
 
         private void ButtonDelete_Click(object sender, RoutedEventArgs e)
         {
+            if (SharedModel.Instance.SelectedItems.Count > 1)
+            {
+                SharedModel.Instance.RemoveSelectedItems();
+                return;
+            }
+
             if (SelectedItem != null)
             {
                 SharedModel.Instance.RemoveDisplayItem(SelectedItem);
+            }
+        }
+
+        private void MenuItemDeleteGroup_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is System.Windows.Controls.MenuItem { Parent: ContextMenu { PlacementTarget: FrameworkElement { DataContext: GroupDisplayItem group } } })
+            {
+                SharedModel.Instance.RemoveDisplayItem(group);
             }
         }
 
@@ -459,13 +485,7 @@ namespace InfoPanel.Views.Components
 
         private void ButtonDuplicate_Click(object sender, RoutedEventArgs e)
         {
-            if (SharedModel.Instance.SelectedItem is DisplayItem selectedItem)
-            {
-                var item = (DisplayItem)selectedItem.Clone();
-                SharedModel.Instance.AddDisplayItem(item);
-                SharedModel.Instance.PushDisplayItemTo(item, selectedItem);
-                item.Selected = true;
-            }
+            SharedModel.Instance.DuplicateSelectedItems();
         }
 
         private bool _isHandlingSelection;
@@ -704,194 +724,223 @@ namespace InfoPanel.Views.Components
             return result;
         }
 
+        /// <summary>
+        /// Normalizes drag data to a list of dragged items: GongSolutions passes a single
+        /// DisplayItem when one item is dragged, or a typed IEnumerable when multiple are dragged.
+        /// </summary>
+        private static List<DisplayItem> GetSourceItems(IDropInfo dropInfo)
+        {
+            if (dropInfo.Data is DisplayItem single)
+                return [single];
+
+            if (dropInfo.Data is System.Collections.IEnumerable multi)
+                return multi.OfType<DisplayItem>().ToList();
+
+            return [];
+        }
+
         void IDropTarget.DragOver(IDropInfo dropInfo)
         {
-            if (dropInfo.Data is DisplayItem sourceItem)
+            var sourceItems = GetSourceItems(dropInfo);
+            if (sourceItems.Count == 0)
             {
-                var targetItem = dropInfo.TargetItem as DisplayItem;
-
-                // Don't allow dropping an item onto itself
-                if (targetItem != null && sourceItem == targetItem)
-                {
-                    dropInfo.Effects = DragDropEffects.None;
-                    return;
-                }
-
-                // Get parent groups
-                var sourceParent = SharedModel.Instance.GetParent(sourceItem);
-                var targetParentGroup = GetGroupFromCollection(dropInfo.TargetCollection);
-
-                // Check if source item is from a locked group
-                if (sourceParent is GroupDisplayItem sourceGroup && sourceGroup.IsLocked)
-                {
-                    // Allow reordering within the same locked group
-                    if (targetParentGroup == sourceGroup)
-                    {
-                        dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
-                        dropInfo.Effects = DragDropEffects.Move;
-                        return;
-                    }
-
-                    // Don't allow dragging items out of locked groups
-                    dropInfo.Effects = DragDropEffects.None;
-                    return;
-                }
-
-                // Check if target is in a locked group
-                if (targetParentGroup != null && targetParentGroup.IsLocked)
-                {
-                    // Don't allow dropping items into locked groups
-                    dropInfo.Effects = DragDropEffects.None;
-                    return;
-                }
-
-                // Check if we're dragging a group
-                if (sourceItem is GroupDisplayItem)
-                {
-                    // If target is also a group, prevent drop
-                    if (targetItem is GroupDisplayItem)
-                    {
-                        dropInfo.Effects = DragDropEffects.None;
-                        return;
-                    }
-
-                    // Check if the target collection is not the main collection
-                    // If it's not, then it must be a group's inner collection
-                    if (dropInfo.TargetCollection != null &&
-                        dropInfo.TargetCollection != SharedModel.Instance.DisplayItems &&
-                        !(dropInfo.TargetCollection is ListCollectionView view && view.SourceCollection == SharedModel.Instance.DisplayItems))
-                    {
-                        // We're trying to drop a group inside another group
-                        dropInfo.Effects = DragDropEffects.None;
-                        return;
-                    }
-                }
-                else
-                {
-                    // We're dragging a regular item (not a group)
-                    // Allow dropping into groups (even empty ones)
-                    if (targetItem is GroupDisplayItem groupItem)
-                    {
-                        // Check if the group is locked
-                        if (groupItem.IsLocked)
-                        {
-                            dropInfo.Effects = DragDropEffects.None;
-                            return;
-                        }
-
-                        // Allow dropping items into groups
-                        dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
-                        dropInfo.Effects = DragDropEffects.Move;
-                        return;
-                    }
-                }
-
-                // Allow the drop for all other cases
-                dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
-                dropInfo.Effects = DragDropEffects.Move;
+                return;
             }
+
+            var targetItem = dropInfo.TargetItem as DisplayItem;
+
+            // Don't allow dropping an item onto itself
+            if (targetItem != null && sourceItems.Contains(targetItem))
+            {
+                dropInfo.Effects = DragDropEffects.None;
+                return;
+            }
+
+            // Get parent groups
+            var targetParentGroup = GetGroupFromCollection(dropInfo.TargetCollection);
+            var lockedSourceGroups = sourceItems
+                .Select(SharedModel.Instance.GetParent)
+                .OfType<GroupDisplayItem>()
+                .Where(g => g.IsLocked)
+                .Distinct()
+                .ToList();
+
+            // Check if any dragged item is from a locked group
+            if (lockedSourceGroups.Count > 0)
+            {
+                // Allow reordering within the same locked group
+                if (lockedSourceGroups.Count == 1 && targetParentGroup == lockedSourceGroups[0])
+                {
+                    dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+                    dropInfo.Effects = DragDropEffects.Move;
+                    return;
+                }
+
+                // Don't allow dragging items out of locked groups
+                dropInfo.Effects = DragDropEffects.None;
+                return;
+            }
+
+            // Check if target is in a locked group
+            if (targetParentGroup != null && targetParentGroup.IsLocked)
+            {
+                // Don't allow dropping items into locked groups
+                dropInfo.Effects = DragDropEffects.None;
+                return;
+            }
+
+            // Check if we're dragging a group
+            if (sourceItems.Any(item => item is GroupDisplayItem))
+            {
+                // Groups can't be combined with other items, dropped onto another group, or nested
+                if (sourceItems.Count > 1 || targetItem is GroupDisplayItem)
+                {
+                    dropInfo.Effects = DragDropEffects.None;
+                    return;
+                }
+
+                // Check if the target collection is not the main collection
+                // If it's not, then it must be a group's inner collection
+                if (dropInfo.TargetCollection != null &&
+                    dropInfo.TargetCollection != SharedModel.Instance.DisplayItems &&
+                    !(dropInfo.TargetCollection is ListCollectionView view && view.SourceCollection == SharedModel.Instance.DisplayItems))
+                {
+                    // We're trying to drop a group inside another group
+                    dropInfo.Effects = DragDropEffects.None;
+                    return;
+                }
+            }
+            else
+            {
+                // We're dragging regular item(s) (not a group)
+                // Allow dropping into groups (even empty ones)
+                if (targetItem is GroupDisplayItem groupItem)
+                {
+                    // Check if the group is locked
+                    if (groupItem.IsLocked)
+                    {
+                        dropInfo.Effects = DragDropEffects.None;
+                        return;
+                    }
+
+                    // Allow dropping items into groups
+                    dropInfo.DropTargetAdorner = DropTargetAdorners.Highlight;
+                    dropInfo.Effects = DragDropEffects.Move;
+                    return;
+                }
+            }
+
+            // Allow the drop for all other cases
+            dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+            dropInfo.Effects = DragDropEffects.Move;
         }
 
         private readonly DefaultDropHandler dropHandler = new();
 
+        private static void PushDropUndo()
+        {
+            if (SharedModel.Instance.SelectedProfile is Profile profile)
+            {
+                var copy = SharedModel.Instance.GetProfileDisplayItemsCopy(profile);
+                if (copy.Count > 0)
+                    InfoPanel.Services.UndoManager.Instance.PushUndo(profile, copy.ToList());
+            }
+        }
+
         void IDropTarget.Drop(IDropInfo dropInfo)
         {
-            if (dropInfo.Data is DisplayItem sourceItem)
+            var sourceItems = GetSourceItems(dropInfo);
+            if (sourceItems.Count == 0)
             {
-                var targetItem = dropInfo.TargetItem as DisplayItem;
-
-                // Don't allow dropping an item onto itself
-                if (targetItem != null && sourceItem == targetItem)
-                {
-                    return;
-                }
-
-                // Get parent groups and validate before pushing undo
-                var sourceParent = SharedModel.Instance.GetParent(sourceItem);
-                var targetParentGroup = GetGroupFromCollection(dropInfo.TargetCollection);
-
-                // Check if source item is from a locked group
-                if (sourceParent is GroupDisplayItem sourceGroup && sourceGroup.IsLocked)
-                {
-                    // Allow reordering within the same locked group
-                    if (targetParentGroup == sourceGroup)
-                    {
-                        if (SharedModel.Instance.SelectedProfile is Profile p)
-                        {
-                            var copy = SharedModel.Instance.GetProfileDisplayItemsCopy(p);
-                            if (copy.Count > 0)
-                                InfoPanel.Services.UndoManager.Instance.PushUndo(p, copy.ToList());
-                        }
-                        dropHandler.Drop(dropInfo);
-                        SharedModel.Instance.UpdateLastStateSnapshot();
-                        SharedModel.Instance.MarkDirty();
-                        return;
-                    }
-
-                    // Don't allow dragging items out of locked groups
-                    return;
-                }
-
-                // Check if target is in a locked group
-                if (targetParentGroup != null && targetParentGroup.IsLocked)
-                {
-                    // Don't allow dropping items into locked groups
-                    return;
-                }
-
-                // Check if we're dragging a group
-                if (sourceItem is GroupDisplayItem)
-                {
-                    // If target is also a group, prevent drop
-                    if (targetItem is GroupDisplayItem)
-                    {
-                        return;
-                    }
-
-                    // Check if the target collection is not the main collection
-                    // If it's not, then it must be a group's inner collection
-                    if (dropInfo.TargetCollection != null &&
-                        dropInfo.TargetCollection != SharedModel.Instance.DisplayItems &&
-                        !(dropInfo.TargetCollection is ListCollectionView view && view.SourceCollection == SharedModel.Instance.DisplayItems))
-                    {
-                        // We're trying to drop a group inside another group
-                        return;
-                    }
-                }
-                else
-                {
-                    // We're dragging a regular item (not a group)
-                    // Special handling for dropping into groups: move directly to avoid duplicate undo from RemoveDisplayItem
-                    if (targetItem is GroupDisplayItem groupItem)
-                    {
-                        if (groupItem.IsLocked)
-                            return;
-
-                        if (SharedModel.Instance.SelectedProfile is Profile profile)
-                        {
-                            var copy = SharedModel.Instance.GetProfileDisplayItemsCopy(profile);
-                            if (copy.Count > 0)
-                                InfoPanel.Services.UndoManager.Instance.PushUndo(profile, copy.ToList());
-                        }
-                        SharedModel.Instance.GetParentCollection(sourceItem)?.Remove(sourceItem);
-                        groupItem.DisplayItems.Add(sourceItem);
-                        SharedModel.Instance.UpdateLastStateSnapshot();
-                        SharedModel.Instance.MarkDirty();
-                        return;
-                    }
-                }
-
-                // Push undo after validation, then perform drop
-                if (SharedModel.Instance.SelectedProfile is Profile profile2)
-                {
-                    var copy = SharedModel.Instance.GetProfileDisplayItemsCopy(profile2);
-                    if (copy.Count > 0)
-                        InfoPanel.Services.UndoManager.Instance.PushUndo(profile2, copy.ToList());
-                }
-                dropHandler.Drop(dropInfo);
-                SharedModel.Instance.UpdateLastStateSnapshot();
-                SharedModel.Instance.MarkDirty();
+                return;
             }
+
+            var targetItem = dropInfo.TargetItem as DisplayItem;
+
+            // Don't allow dropping an item onto itself
+            if (targetItem != null && sourceItems.Contains(targetItem))
+            {
+                return;
+            }
+
+            // Get parent groups and validate before pushing undo
+            var targetParentGroup = GetGroupFromCollection(dropInfo.TargetCollection);
+            var lockedSourceGroups = sourceItems
+                .Select(SharedModel.Instance.GetParent)
+                .OfType<GroupDisplayItem>()
+                .Where(g => g.IsLocked)
+                .Distinct()
+                .ToList();
+
+            // Check if any dragged item is from a locked group
+            if (lockedSourceGroups.Count > 0)
+            {
+                // Allow reordering within the same locked group
+                if (lockedSourceGroups.Count == 1 && targetParentGroup == lockedSourceGroups[0])
+                {
+                    PushDropUndo();
+                    dropHandler.Drop(dropInfo);
+                    SharedModel.Instance.UpdateLastStateSnapshot();
+                    SharedModel.Instance.MarkDirty();
+                }
+
+                // Don't allow dragging items out of locked groups
+                return;
+            }
+
+            // Check if target is in a locked group
+            if (targetParentGroup != null && targetParentGroup.IsLocked)
+            {
+                // Don't allow dropping items into locked groups
+                return;
+            }
+
+            // Check if we're dragging a group
+            if (sourceItems.Any(item => item is GroupDisplayItem))
+            {
+                // Groups can't be combined with other items, dropped onto another group, or nested
+                if (sourceItems.Count > 1 || targetItem is GroupDisplayItem)
+                {
+                    return;
+                }
+
+                // Check if the target collection is not the main collection
+                // If it's not, then it must be a group's inner collection
+                if (dropInfo.TargetCollection != null &&
+                    dropInfo.TargetCollection != SharedModel.Instance.DisplayItems &&
+                    !(dropInfo.TargetCollection is ListCollectionView view && view.SourceCollection == SharedModel.Instance.DisplayItems))
+                {
+                    // We're trying to drop a group inside another group
+                    return;
+                }
+            }
+            else
+            {
+                // We're dragging regular item(s) (not a group)
+                // Special handling for dropping into groups: move directly to avoid duplicate undo from RemoveDisplayItem
+                if (targetItem is GroupDisplayItem groupItem)
+                {
+                    if (groupItem.IsLocked)
+                        return;
+
+                    PushDropUndo();
+                    foreach (var item in sourceItems)
+                    {
+                        SharedModel.Instance.GetParentCollection(item)?.Remove(item);
+                        groupItem.DisplayItems.Add(item);
+                    }
+                    groupItem.IsExpanded = true;
+                    SharedModel.Instance.UpdateLastStateSnapshot();
+                    SharedModel.Instance.MarkDirty();
+                    return;
+                }
+            }
+
+            // Push undo after validation, then perform drop
+            PushDropUndo();
+            dropHandler.Drop(dropInfo);
+            SharedModel.Instance.UpdateLastStateSnapshot();
+            SharedModel.Instance.MarkDirty();
         }
     }
 }

--- a/InfoPanel/Views/Components/Guide/GuideProperties.xaml
+++ b/InfoPanel/Views/Components/Guide/GuideProperties.xaml
@@ -1,0 +1,82 @@
+<UserControl
+    x:Class="InfoPanel.Views.Components.GuideProperties"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:InfoPanel.Views.Components"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:metro="http://metro.mahapps.com/winfx/xaml/controls"
+    xmlns:models="clr-namespace:InfoPanel.Models"
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    d:DataContext="{d:DesignInstance Type=models:GuideDisplayItem}"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+    <Grid Margin="10,10,10,10">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+
+        <StackPanel Grid.Column="0" Margin="0,0,10,0">
+            <TextBox x:Name="TextBoxName" Text="{Binding Name}" />
+            <TextBlock
+                Margin="5,0,0,0"
+                FontSize="12"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Text="Name" />
+
+            <StackPanel Margin="0,10,0,0">
+                <ui:NumberBox
+                    Margin="0,0,0,0"
+                    FontSize="14"
+                    MaxDecimalPlaces="0"
+                    Minimum="1"
+                    SmallChange="1"
+                    Text="{Binding Length}"
+                    Value="{Binding Length}" />
+                <TextBlock
+                    Margin="5,0,0,0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="Length" />
+            </StackPanel>
+
+            <StackPanel Margin="0,10,0,0">
+                <metro:ColorPicker
+                    Height="40"
+                    Margin="0,0,0,0"
+                    metro:TextBoxHelper.UseFloatingWatermark="True"
+                    metro:TextBoxHelper.Watermark="Guide color"
+                    Background="Transparent"
+                    SelectedColor="{Binding Color, Mode=TwoWay}" />
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Grid.Column="1" Margin="10,0,0,0">
+            <Slider
+                Margin="0,0,0,0"
+                Maximum="180"
+                Minimum="-180"
+                Value="{Binding Rotation}" />
+
+            <Grid Margin="5,0,5,0">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="auto" />
+                </Grid.ColumnDefinitions>
+                <TextBlock
+                    Grid.Column="0"
+                    Margin="0,0,0,0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="Rotation ° (0 = horizontal, 90 = vertical)" />
+                <TextBlock
+                    Grid.Column="1"
+                    Margin="0,0,0,0"
+                    FontSize="12"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Text="{Binding Rotation, Mode=OneWay}" />
+            </Grid>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/InfoPanel/Views/Components/Guide/GuideProperties.xaml.cs
+++ b/InfoPanel/Views/Components/Guide/GuideProperties.xaml.cs
@@ -1,0 +1,15 @@
+using System.Windows.Controls;
+
+namespace InfoPanel.Views.Components
+{
+    /// <summary>
+    /// Interaction logic for GuideProperties.xaml
+    /// </summary>
+    public partial class GuideProperties : UserControl
+    {
+        public GuideProperties()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/InfoPanel/Views/Components/Sensors/CommonActions.xaml
+++ b/InfoPanel/Views/Components/Sensors/CommonActions.xaml
@@ -52,5 +52,13 @@
             Content=""
             Icon="{ui:SymbolIcon Group20}"
             ToolTip="New Group" />
+
+        <ui:Button
+            x:Name="ButtonNewGuide"
+            Margin="10,0,0,0"
+            Appearance="Success"
+            Click="ButtonNewGuide_Click"
+            Icon="{ui:SymbolIcon SubGrid20}"
+            ToolTip="Add a guide line" />
     </StackPanel>
 </UserControl>

--- a/InfoPanel/Views/Components/Sensors/CommonActions.xaml.cs
+++ b/InfoPanel/Views/Components/Sensors/CommonActions.xaml.cs
@@ -93,5 +93,19 @@ namespace InfoPanel.Views.Components
                 SharedModel.Instance.PushDisplayItemTo(groupDisplayItem, selectedItem);
             }
         }
+
+        private void ButtonNewGuide_Click(object sender, RoutedEventArgs e)
+        {
+            if (SharedModel.Instance.SelectedProfile is Profile selectedProfile)
+            {
+                var item = new GuideDisplayItem("Guide", selectedProfile)
+                {
+                    X = selectedProfile.Width / 2,
+                    Y = selectedProfile.Height / 2,
+                    Length = System.Math.Min(selectedProfile.Width, selectedProfile.Height)
+                };
+                SharedModel.Instance.AddDisplayItem(item);
+            }
+        }
     }
 }

--- a/InfoPanel/Views/DisplayWindow.xaml.cs
+++ b/InfoPanel/Views/DisplayWindow.xaml.cs
@@ -7,6 +7,7 @@ using SkiaSharp.Views.Desktop;
 using SkiaSharp.Views.WPF;
 using System;
 using Serilog;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Timers;
@@ -48,6 +49,18 @@ namespace InfoPanel.Views.Common
 
         private bool dragStart = false;
         private System.Windows.Point startPosition = new System.Windows.Point();
+        private System.Windows.Point dragOrigin = new System.Windows.Point();
+        private AxisLock _axisLock = AxisLock.None;
+        private const double AxisLockThreshold = 4.0;
+
+        private enum AxisLock
+        {
+            None,
+            Horizontal,
+            Vertical
+        }
+
+        private const double GuideSnapThreshold = 5.0;
 
         public DisplayWindow(Profile profile)
         {
@@ -379,6 +392,41 @@ namespace InfoPanel.Views.Common
             return point;
         }
 
+        /// <summary>
+        /// Snaps a candidate drag position to nearby guide lines (any rotation) by projecting
+        /// onto each guide's perpendicular within threshold and summing the corrections.
+        /// For axis-aligned guides (0°/90°) this only affects the matching axis, so independent
+        /// horizontal+vertical snapping composes correctly; for arbitrary angles it's an approximation.
+        /// </summary>
+        private System.Windows.Point ApplyGuideSnap(System.Windows.Point point, DisplayItem draggedItem)
+        {
+            double dx = 0, dy = 0;
+
+            foreach (var guide in SharedModel.Instance.GetProfileDisplayItemsCopy(Profile).OfType<GuideDisplayItem>())
+            {
+                if (guide == draggedItem || guide.Hidden)
+                {
+                    continue;
+                }
+
+                var radians = guide.Rotation * Math.PI / 180.0;
+                var nx = -Math.Sin(radians);
+                var ny = Math.Cos(radians);
+
+                var vx = point.X - guide.X;
+                var vy = point.Y - guide.Y;
+                var dist = vx * nx + vy * ny;
+
+                if (Math.Abs(dist) <= GuideSnapThreshold)
+                {
+                    dx += -dist * nx;
+                    dy += -dist * ny;
+                }
+            }
+
+            return new System.Windows.Point(point.X + dx, point.Y + dy);
+        }
+
         private void OnTimerElapsed(object? sender, ElapsedEventArgs e)
         {
             if (_renderInvalidationPending) return;
@@ -610,6 +658,19 @@ namespace InfoPanel.Views.Common
 
         private void Window_KeyUp(object sender, System.Windows.Input.KeyEventArgs e)
         {
+            if (e.Key == Key.Delete)
+            {
+                if (SharedModel.Instance.SelectedItems.Count > 1)
+                {
+                    SharedModel.Instance.RemoveSelectedItems();
+                }
+                else if (SharedModel.Instance.SelectedItem is DisplayItem selectedItem)
+                {
+                    SharedModel.Instance.RemoveDisplayItem(selectedItem);
+                }
+                return;
+            }
+
             if (SharedModel.Instance.SelectedVisibleItems != null)
             {
                 foreach (var displayItem in SharedModel.Instance.SelectedVisibleItems)
@@ -635,7 +696,125 @@ namespace InfoPanel.Views.Common
 
         private void Window_MouseUp(object sender, MouseButtonEventArgs e)
         {
+            if (dragStart)
+            {
+                ApplyDragGroupTarget();
+            }
+
             dragStart = false;
+            _axisLock = AxisLock.None;
+            SharedModel.Instance.DragHoverGroup = null;
+        }
+
+        /// <summary>
+        /// Leaf (non-group) selected items eligible for canvas drag-to-group. Excludes items whose
+        /// containing group is itself selected, since that means the whole group is being moved as a
+        /// rigid unit rather than the user re-parenting individual items.
+        /// </summary>
+        private static List<DisplayItem> GetDraggableLeafItems()
+        {
+            var result = new List<DisplayItem>();
+            foreach (var item in SharedModel.Instance.SelectedVisibleItems)
+            {
+                if (item is GroupDisplayItem || !item.Selected || item.IsLocked) continue;
+                var parent = SharedModel.Instance.GetParent(item);
+                if (parent != null && parent.Selected) continue;
+                result.Add(item);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Recomputes which group (if any) the currently dragged item(s) are hovering over, so
+        /// PanelDraw can render a highlight around it. Only top-level, unlocked groups are
+        /// considered, and a group's own bounds exclude the items being dragged so dragging within
+        /// a group's own area doesn't spuriously self-match.
+        /// </summary>
+        private void UpdateDragHoverGroup()
+        {
+            var draggedItems = GetDraggableLeafItems();
+            if (draggedItems.Count == 0)
+            {
+                SharedModel.Instance.DragHoverGroup = null;
+                return;
+            }
+
+            SKRect? draggedBounds = null;
+            foreach (var item in draggedItems)
+            {
+                var bounds = item.EvaluateBounds();
+                draggedBounds = draggedBounds is SKRect existing ? SKRect.Union(existing, bounds) : bounds;
+            }
+
+            if (draggedBounds is not SKRect combined)
+            {
+                SharedModel.Instance.DragHoverGroup = null;
+                return;
+            }
+
+            GroupDisplayItem? match = null;
+            foreach (var group in SharedModel.Instance.GetProfileDisplayItemsCopy(Profile).OfType<GroupDisplayItem>())
+            {
+                if (group.Hidden || group.IsLocked) continue;
+
+                var groupBounds = SharedModel.Instance.GetGroupBounds(group, draggedItems);
+                if (groupBounds is SKRect gb && gb.IntersectsWith(combined))
+                {
+                    match = group;
+                }
+            }
+
+            SharedModel.Instance.DragHoverGroup = match;
+        }
+
+        /// <summary>
+        /// On mouse-up, re-parents dragged items based on where they were dropped: into the hovered
+        /// group if one was found, out to the root level if dragged clear of their own group's
+        /// bounds, or left untouched otherwise (including items in a locked group, which never move).
+        /// </summary>
+        private void ApplyDragGroupTarget()
+        {
+            var draggedItems = GetDraggableLeafItems();
+            if (draggedItems.Count == 0) return;
+
+            var hoverGroup = SharedModel.Instance.DragHoverGroup;
+            var moves = new List<(DisplayItem Item, GroupDisplayItem? TargetGroup)>();
+
+            foreach (var item in draggedItems)
+            {
+                var currentGroup = SharedModel.Instance.GetParent(item);
+
+                if (currentGroup != null && currentGroup.IsLocked)
+                {
+                    continue;
+                }
+
+                GroupDisplayItem? targetGroup;
+                if (hoverGroup != null)
+                {
+                    targetGroup = hoverGroup;
+                }
+                else if (currentGroup != null)
+                {
+                    var ownBounds = SharedModel.Instance.GetGroupBounds(currentGroup, draggedItems);
+                    var stillInside = ownBounds is SKRect ob && ob.IntersectsWith(item.EvaluateBounds());
+                    targetGroup = stillInside ? currentGroup : null;
+                }
+                else
+                {
+                    targetGroup = null;
+                }
+
+                if (targetGroup != currentGroup)
+                {
+                    moves.Add((item, targetGroup));
+                }
+            }
+
+            if (moves.Count > 0)
+            {
+                SharedModel.Instance.MoveItemsToGroup(moves);
+            }
         }
 
         private void SetWindowPositionRelativeToScreen()
@@ -756,6 +935,8 @@ namespace InfoPanel.Views.Common
                 else
                 {
                     startPosition = GetProfilePoint(e);
+                    dragOrigin = startPosition;
+                    _axisLock = AxisLock.None;
 
                     foreach (var item in SharedModel.Instance.SelectedVisibleItems)
                     {
@@ -861,6 +1042,33 @@ namespace InfoPanel.Views.Common
 
                 var currentPosition = GetProfilePoint(e);
 
+                if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift))
+                {
+                    if (_axisLock == AxisLock.None)
+                    {
+                        var dx = currentPosition.X - dragOrigin.X;
+                        var dy = currentPosition.Y - dragOrigin.Y;
+
+                        if (Math.Abs(dx) >= AxisLockThreshold || Math.Abs(dy) >= AxisLockThreshold)
+                        {
+                            _axisLock = Math.Abs(dx) >= Math.Abs(dy) ? AxisLock.Horizontal : AxisLock.Vertical;
+                        }
+                    }
+
+                    if (_axisLock == AxisLock.Horizontal)
+                    {
+                        currentPosition.Y = dragOrigin.Y;
+                    }
+                    else if (_axisLock == AxisLock.Vertical)
+                    {
+                        currentPosition.X = dragOrigin.X;
+                    }
+                }
+                else
+                {
+                    _axisLock = AxisLock.None;
+                }
+
                 foreach (var displayItem in SharedModel.Instance.SelectedVisibleItems)
                 {
                     if (displayItem.Selected && !displayItem.IsLocked)
@@ -871,12 +1079,18 @@ namespace InfoPanel.Views.Common
                         x = (int)(Math.Round((double)x / gridSize) * gridSize);
                         y = (int)(Math.Round((double)y / gridSize) * gridSize);
 
+                        var snapped = ApplyGuideSnap(new System.Windows.Point(x, y), displayItem);
+                        x = (int)Math.Round(snapped.X);
+                        y = (int)Math.Round(snapped.Y);
+
                         displayItem.X = x;
                         displayItem.Y = y;
                     }
                 }
 
                 startPosition = currentPosition;
+
+                UpdateDragHoverGroup();
             }
         }
 

--- a/InfoPanel/Views/Pages/DesignPage.xaml
+++ b/InfoPanel/Views/Pages/DesignPage.xaml
@@ -509,6 +509,9 @@
                                     <components:ShapeProperties ShapeDisplayItem="{Binding}" />
                                 </StackPanel>
                             </DataTemplate>
+                            <DataTemplate DataType="{x:Type models:GuideDisplayItem}">
+                                <components:GuideProperties />
+                            </DataTemplate>
                         </ContentControl.Resources>
                     </ContentControl>
 

--- a/InfoPanel/Views/Windows/MainWindow.xaml.cs
+++ b/InfoPanel/Views/Windows/MainWindow.xaml.cs
@@ -133,6 +133,18 @@ namespace InfoPanel.Views.Windows
                     SharedModel.Instance.Redo();
                 e.Handled = true;
             }
+            else if (e.Key == Key.Delete)
+            {
+                if (SharedModel.Instance.SelectedItems.Count > 1)
+                {
+                    SharedModel.Instance.RemoveSelectedItems();
+                }
+                else if (SharedModel.Instance.SelectedItem is DisplayItem selectedItem)
+                {
+                    SharedModel.Instance.RemoveDisplayItem(selectedItem);
+                }
+                e.Handled = true;
+            }
         }
 
         private void MainWindow_SizeChanged(object sender, SizeChangedEventArgs e)


### PR DESCRIPTION
## What this adds

**Multi-select duplicate** — selecting 2+ items and duplicating now clones all selected items together, offset by 10px so they're visible.

**Multi-select reorder** — Move Up/Down works on a multi-selection as a group, preserving relative order. Works across group boundaries independently.

**Multi-select delete** — Delete key and delete button now remove all selected items at once in a single undo step. Right-clicking a group offers "Delete Group and Children".

**Shift+drag axis lock** — holding Shift while dragging constrains movement to the dominant axis (horizontal or vertical), Figma/Photoshop style. Works for single and multi-selection.

**Drag-to-group** — items can be dragged into a group from the item list or from the canvas. Dragging out of a group back to root is also supported. Groups highlight in orange while a drag is hovering over them.

**Alignment guides** — guides are first-class display items (like text or image). Add via the green button row, position/rotate freely, snap other items to them within 5px, customize color per guide, toggle visibility, delete individually. Saved with profile.

## Files changed
- `SharedModel.cs` — multi-select duplicate, reorder, delete, drag-to-group logic
- `DisplayItems.xaml(.cs)` — UI for all multi-select operations and drag-to-group
- `DisplayWindow.xaml.cs` — Shift+drag axis lock, canvas drag-to-group, guide snap
- `GuideDisplayItem.cs` (new) — guide as a proper DisplayItem
- `GuideProperties.xaml(.cs)` (new) — guide property panel
- `PanelDraw.cs` — guide rendering
- `CommonActions.xaml(.cs)` — Add Guide button