### PR TITLE
Add Lian Li 8.8 inch USB panel support

### DIFF
--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -262,6 +262,8 @@
 	  <ProjectReference Include="..\InfoPanel.Plugins.Loader\InfoPanel.Plugins.Loader.csproj" />
 	  <ProjectReference Include="..\InfoPanel.Plugins.Ipc\InfoPanel.Plugins.Ipc.csproj" />
 	  <ProjectReference Include="..\InfoPanel.Plugins.Host\InfoPanel.Plugins.Host.csproj" />
+	  <!-- Include InfoPanel.Extras in the restore graph. BuildExtras below still copies it to the bundled plugins directory. -->
+	  <ProjectReference Include="..\InfoPanel.Extras\InfoPanel.Extras.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/InfoPanel/Services/TuringPanelTask.cs
+++ b/InfoPanel/Services/TuringPanelTask.cs
@@ -44,6 +44,7 @@ namespace InfoPanel.Services
                     case TuringPanelModel.REV_5INCH_USB:
                     case TuringPanelModel.REV_16INCH_USB:
                     case TuringPanelModel.REV_21INCH_USB:
+                    case TuringPanelModel.LIANLI_88INCH_USB:
                         deviceTask = new TuringPanelUsbDeviceTask(device);
                         break;
                     case TuringPanelModel.TURING_3_5:

--- a/InfoPanel/Services/TuringPanelUsbDeviceTask.cs
+++ b/InfoPanel/Services/TuringPanelUsbDeviceTask.cs
@@ -1,6 +1,8 @@
 using InfoPanel.Extensions;
 using InfoPanel.Models;
+using InfoPanel.TuringPanel;
 using InfoPanel.Utils;
+using InfoPanel.ViewModels;
 using LcdDriver.TuringSmartScreen;
 using LibUsbDotNet;
 using LibUsbDotNet.Main;
@@ -21,8 +23,23 @@ namespace InfoPanel.Services
         private readonly TuringPanelDevice _device;
         private readonly int _panelWidth;
         private readonly int _panelHeight;
-
         public TuringPanelDevice Device => _device;
+
+        private sealed class TuringUsbScreenDeviceAdapter : IUsbScreenDevice
+        {
+            private readonly ScreenDevice _inner;
+
+            public TuringUsbScreenDeviceAdapter(ScreenDevice inner)
+            {
+                _inner = inner;
+            }
+
+            public bool Sync() => _inner.Sync();
+            public bool StopMedia() => _inner.StopMedia();
+            public bool SetBrightness(byte value) => _inner.SetBrightness(value);
+            public bool DrawJpeg(byte[] imageBytes) => _inner.DrawJpeg(imageBytes);
+            public void Dispose() => _inner.Dispose();
+        }
 
         public TuringPanelUsbDeviceTask(TuringPanelDevice device)
         {
@@ -43,17 +60,29 @@ namespace InfoPanel.Services
 
             if (ConfigModel.Instance.GetProfile(profileGuid) is Profile profile)
             {
+                var isLianLiDevice = _device.ModelInfo.Model == TuringPanelModel.LIANLI_88INCH_USB;
                 var rotation = _device.Rotation;
+
+                // The Lian Li 8.8" panel framebuffer is natively portrait
+                // (480x1920). Landscape profiles must be rotated 90 degrees into the
+                // portrait frame, matching the Linux driver's render path.
+                if (isLianLiDevice && rotation == LCD_ROTATION.RotateNone)
+                {
+                    rotation = LCD_ROTATION.Rotate90FlipNone;
+                }
+
                 using var bitmap = PanelDrawTask.RenderSK(profile, false);
 
                 using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
 
                 using var pixmap = resizedBitmap.PeekPixels();
-                using var data = pixmap.Encode(SKEncodedImageFormat.Jpeg, _device.JpegQuality);
+                var imageFormat = SKEncodedImageFormat.Jpeg;
+                var jpegQuality = isLianLiDevice ? 95 : _device.JpegQuality;
+                using var data = pixmap.Encode(imageFormat, jpegQuality);
 
                 if (data == null || data.IsEmpty)
                 {
-                    Logger.Error("TuringPanelDevice {Device}: Failed to encode bitmap to JPEG", _device);
+                    Logger.Error("TuringPanelDevice {Device}: Failed to encode bitmap to {Format}", _device, imageFormat);
                     return null;
                 }
 
@@ -61,6 +90,56 @@ namespace InfoPanel.Services
             }
 
             return null;
+        }
+
+        private static byte[] EncodeSolidFrame(int width, int height, SKColor color, SKEncodedImageFormat format, int quality)
+        {
+            using var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul));
+            bitmap.Erase(color);
+
+            using var pixmap = bitmap.PeekPixels();
+            using var data = pixmap.Encode(format, quality);
+            return data?.ToArray() ?? Array.Empty<byte>();
+        }
+
+        private void PrepareLianLiImageLayers(LianLiUsbScreenDevice lianLiDevice)
+        {
+            try
+            {
+                // Match the vendor ApplyTemplate() prep sequence, but keep it isolated:
+                // SyncClock(true, onlySync: true), StopClock(), clear PNG layer, clear JPG layer.
+                var syncClockOk = lianLiDevice.SyncClockOnly();
+                Thread.Sleep(50);
+
+                var stopClockOk = lianLiDevice.StopClock();
+                Thread.Sleep(50);
+
+                var clearPng = EncodeSolidFrame(_panelWidth, _panelHeight, SKColors.Transparent, SKEncodedImageFormat.Png, 100);
+                var clearPngOk = clearPng.Length > 0 && lianLiDevice.DrawPngLayer(clearPng);
+                Thread.Sleep(50);
+
+                var clearJpeg = EncodeSolidFrame(_panelWidth, _panelHeight, SKColors.Black, SKEncodedImageFormat.Jpeg, 95);
+                var clearJpegOk = clearJpeg.Length > 0 && lianLiDevice.DrawJpegLayer(clearJpeg);
+                Thread.Sleep(50);
+
+                // Linux driver ends init with SetFrameRate(30) (cmd 15 / 0x0F).
+                var frameRateOk = lianLiDevice.SetFrameRate(30);
+
+                Logger.Information(
+                    "TuringPanelDevice {Device}: Lian Li prep sequence results: SyncClockOnly={SyncClockOk}, StopClock={StopClockOk}, ClearPng={ClearPngOk} ({ClearPngBytes} bytes), ClearJpeg={ClearJpegOk} ({ClearJpegBytes} bytes), SetFrameRate={FrameRateOk}",
+                    _device,
+                    syncClockOk,
+                    stopClockOk,
+                    clearPngOk,
+                    clearPng.Length,
+                    clearJpegOk,
+                    clearJpeg.Length,
+                    frameRateOk);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "TuringPanelDevice {Device}: Lian Li prep sequence failed", _device);
+            }
         }
 
         private async Task<UsbRegistry?> FindTargetDeviceAsync()
@@ -116,7 +195,10 @@ namespace InfoPanel.Services
                     return;
                 }
 
-                using var screenDevice = new ScreenDevice(usbDevice);
+                var isLianLiDevice = _device.ModelInfo.Model == TuringPanelModel.LIANLI_88INCH_USB;
+                using IUsbScreenDevice screenDevice = isLianLiDevice
+                    ? new LianLiUsbScreenDevice(usbDevice)
+                    : new TuringUsbScreenDeviceAdapter(new ScreenDevice(usbDevice));
 
                 Logger.Information("TuringPanelDevice {Device}: Initialized successfully", _device);
                 _device.UpdateRuntimeProperties(isRunning: true);
@@ -143,6 +225,12 @@ namespace InfoPanel.Services
                     // Stop any video playback to prevent flickering
                     screenDevice.StopMedia();
                     Thread.Sleep(200);
+
+                    if (screenDevice is LianLiUsbScreenDevice lianLiDevice)
+                    {
+                        PrepareLianLiImageLayers(lianLiDevice);
+                        Thread.Sleep(200);
+                    }
 
                     // Set brightness
                     var brightness = _device.Brightness;

--- a/InfoPanel/TuringPanel/LianLiUsbScreenDevice.cs
+++ b/InfoPanel/TuringPanel/LianLiUsbScreenDevice.cs
@@ -1,0 +1,319 @@
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Serilog;
+using System;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace InfoPanel.TuringPanel
+{
+    internal interface IUsbScreenDevice : IDisposable
+    {
+        bool Sync();
+        bool StopMedia();
+        bool SetBrightness(byte value);
+        bool DrawJpeg(byte[] imageBytes);
+    }
+
+    /// <summary>
+    /// Lian Li's LCD USB protocol is Turing-like, but its reference app writes the
+    /// encrypted command packet and image payload as one bulk transfer. The stock
+    /// Turing driver writes them as two transfers, which can make Lian Li panels
+    /// accept a frame briefly and then stop responding.
+    /// </summary>
+    public sealed class LianLiUsbScreenDevice : IUsbScreenDevice
+    {
+        private static readonly ILogger Logger = Log.ForContext<LianLiUsbScreenDevice>();
+        private static readonly byte[] KeyIv = "slv3tuzx"u8.ToArray();
+        private static readonly DateTime AppStartTime = DateTime.Today.AddDays(-1.0);
+
+        private const int CommandSize = 500;
+        private const int PacketSize = 512;
+        private const int TimeoutMs = 2000;
+        private const int ImageAckTimeoutMs = 200;
+        private const int MaxImagePayload = 512_000;
+        private const byte GetVersionCommand = 10;
+        private const byte SetBrightnessCommand = 14;
+        private const byte SetFrameRateCommand = 15;
+        private const byte SyncClockCommand = 51;
+        private const byte StopClockCommand = 52;
+        private const byte PushJpegCommand = 101;
+        private const byte PushPngCommand = 102;
+        private const byte QueryBlockCommand = 122;
+        private const byte StopMediaCommand = 123;
+
+        private readonly UsbDevice _usbDevice;
+        private readonly UsbEndpointReader _reader;
+        private readonly UsbEndpointWriter _writer;
+        private readonly DES _des;
+        private readonly byte[] _commandBuffer = new byte[CommandSize];
+        private readonly byte[] _readBuffer = new byte[PacketSize];
+        private bool _disposed;
+
+        public LianLiUsbScreenDevice(UsbDevice usbDevice)
+        {
+            _usbDevice = usbDevice ?? throw new ArgumentNullException(nameof(usbDevice));
+
+            if (_usbDevice is IUsbDevice wholeUsbDevice)
+            {
+                wholeUsbDevice.SetConfiguration(1);
+                wholeUsbDevice.ClaimInterface(0);
+            }
+
+            _reader = _usbDevice.OpenEndpointReader(ReadEndpointID.Ep01);
+            _writer = _usbDevice.OpenEndpointWriter(WriteEndpointID.Ep01);
+
+            _des = DES.Create();
+            _des.Mode = CipherMode.CBC;
+            _des.Padding = PaddingMode.PKCS7;
+            _des.Key = KeyIv;
+            _des.IV = KeyIv;
+        }
+
+        public bool Sync() => RequestResponse(GetVersionCommand);
+
+        public bool SetBrightness(byte value)
+        {
+            PrepareCommandHeader(SetBrightnessCommand);
+            _commandBuffer[8] = value;
+            return RequestResponsePrepared();
+        }
+
+        public bool StopMedia() => RequestResponse(StopMediaCommand);
+
+        public bool SyncClockOnly()
+        {
+            var now = DateTime.Now;
+
+            PrepareCommandHeader(SyncClockCommand);
+            _commandBuffer[8] = (byte)(now.Year >> 8);
+            _commandBuffer[9] = (byte)(now.Year & 0xFF);
+            _commandBuffer[10] = (byte)now.Month;
+            _commandBuffer[11] = (byte)now.Day;
+            _commandBuffer[12] = (byte)now.Hour;
+            _commandBuffer[13] = (byte)now.Minute;
+            _commandBuffer[14] = (byte)now.Second;
+            _commandBuffer[15] = 2;
+
+            return RequestResponsePrepared();
+        }
+
+        public bool StopClock()
+        {
+            PrepareCommandHeader(StopClockCommand);
+            _commandBuffer[8] = 0;
+            return RequestResponsePrepared();
+        }
+
+        public bool DrawPngLayer(byte[] imageBytes)
+        {
+            if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
+
+            return DrawImageLayer(PushPngCommand, imageBytes);
+        }
+
+        public bool DrawJpegLayer(byte[] imageBytes)
+        {
+            if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
+
+            return DrawImageLayer(PushJpegCommand, imageBytes);
+        }
+
+        public bool DrawJpeg(byte[] imageBytes)
+        {
+            if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
+
+            // Main frames must target the JPEG/background layer. The PNG path is
+            // used only for clearing the overlay during initialization.
+            return DrawJpegLayer(imageBytes);
+        }
+
+        /// <summary>Set the panel frame rate. The Linux driver initializes this panel to 30 FPS.</summary>
+        public bool SetFrameRate(byte fps)
+        {
+            PrepareCommandHeader(SetFrameRateCommand);
+            _commandBuffer[8] = fps;
+            return RequestResponsePrepared();
+        }
+
+        /// <summary>
+        /// Query the device frame buffer level (cmd 122 / 0x7A).
+        /// Returns null when no response could be read.
+        /// </summary>
+        public byte? QueryBlock()
+        {
+            PrepareCommandHeader(QueryBlockCommand);
+            if (!RequestResponsePrepared(null, out var hasResponse) || !hasResponse)
+            {
+                return null;
+            }
+
+            return _readBuffer[8];
+        }
+
+        /// <summary>
+        /// Poll QueryBlock every 50ms until the device buffer level drains to
+        /// <paramref name="threshold"/> or below. Mirrors the Linux driver's
+        /// wait_buffer() (max ~2s).
+        /// </summary>
+        private void WaitForBufferDrain(byte threshold)
+        {
+            for (var i = 0; i < 40; i++)
+            {
+                var level = QueryBlock();
+                if (level == null || level <= threshold)
+                {
+                    return;
+                }
+
+                System.Threading.Thread.Sleep(50);
+            }
+
+            Logger.Debug("LianLi buffer drain wait timed out after 2s");
+        }
+
+        private bool DrawImageLayer(byte commandId, byte[] imageBytes)
+        {
+            if (imageBytes.Length > MaxImagePayload)
+            {
+                Logger.Warning(
+                    "LianLi image payload {Length} exceeds device limit {Limit}, dropping frame",
+                    imageBytes.Length,
+                    MaxImagePayload);
+                return false;
+            }
+
+            PrepareCommandHeader(commandId);
+            BinaryPrimitives.WriteInt32BigEndian(_commandBuffer.AsSpan(8, 4), imageBytes.Length);
+            var ok = RequestResponsePrepared(imageBytes, out var hasResponse);
+
+            // Flow control: response byte [8] is the device buffer level. The
+            // Linux driver waits for it to drain below 2 whenever it exceeds 3.
+            if (ok && hasResponse && _readBuffer[8] > 3)
+            {
+                WaitForBufferDrain(2);
+            }
+
+            return ok;
+        }
+
+        private bool RequestResponse(byte commandId)
+        {
+            PrepareCommandHeader(commandId);
+            return RequestResponsePrepared();
+        }
+
+        private void PrepareCommandHeader(byte commandId)
+        {
+            Array.Clear(_commandBuffer, 0, _commandBuffer.Length);
+            _commandBuffer[0] = commandId;
+            _commandBuffer[2] = 26;
+            _commandBuffer[3] = 109;
+            var timestamp = unchecked((int)(DateTime.UtcNow - AppStartTime).TotalMilliseconds);
+            BinaryPrimitives.WriteInt32LittleEndian(_commandBuffer.AsSpan(4, 4), timestamp);
+        }
+
+        private byte[] EncryptCommandPacket()
+        {
+            var encryptedCommand = _des.EncryptCbc(_commandBuffer, KeyIv, PaddingMode.PKCS7);
+            var packet = new byte[PacketSize];
+            Buffer.BlockCopy(encryptedCommand, 0, packet, 0, Math.Min(encryptedCommand.Length, PacketSize - 2));
+            packet[510] = 161;
+            packet[511] = 26;
+            return packet;
+        }
+
+        private bool RequestResponsePrepared(byte[]? payload = null)
+        {
+            return RequestResponsePrepared(payload, out _);
+        }
+
+        private bool RequestResponsePrepared(byte[]? payload, out bool hasResponse)
+        {
+            hasResponse = false;
+            var commandPacket = EncryptCommandPacket();
+            byte[] writeBuffer;
+
+            if (payload == null || payload.Length == 0)
+            {
+                writeBuffer = commandPacket;
+            }
+            else
+            {
+                writeBuffer = new byte[PacketSize + payload.Length];
+                Buffer.BlockCopy(commandPacket, 0, writeBuffer, 0, PacketSize);
+                Buffer.BlockCopy(payload, 0, writeBuffer, PacketSize, payload.Length);
+            }
+
+            try
+            {
+                _reader.ReadFlush();
+
+                var errorCode = _writer.Write(writeBuffer, TimeoutMs, out var transferred);
+                if (errorCode != ErrorCode.None || transferred != writeBuffer.Length)
+                {
+                    Logger.Warning(
+                        "LianLi USB write failed: {ErrorCode}, transferred {Transferred}/{Expected}",
+                        errorCode,
+                        transferred,
+                        writeBuffer.Length);
+                    return false;
+                }
+
+                Array.Clear(_readBuffer, 0, _readBuffer.Length);
+                errorCode = _reader.Read(_readBuffer, payload == null ? TimeoutMs : ImageAckTimeoutMs, out transferred);
+                if (payload != null && errorCode == ErrorCode.IoTimedOut)
+                {
+                    // Lian Li's reference WinUsb.Read ignores the read result and returns
+                    // the zero-filled 512-byte buffer even when no response is available.
+                    // Image pushes commonly render successfully without a readable ACK.
+                    return true;
+                }
+
+                if (errorCode != ErrorCode.None || transferred != PacketSize)
+                {
+                    Logger.Warning(
+                        "LianLi USB read failed: {ErrorCode}, transferred {Transferred}/{Expected}",
+                        errorCode,
+                        transferred,
+                        PacketSize);
+                    return false;
+                }
+
+                hasResponse = true;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "LianLi USB request failed");
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            try
+            {
+                if (_usbDevice.IsOpen)
+                {
+                    _reader.Dispose();
+                    _writer.Dispose();
+
+                    if (_usbDevice is IUsbDevice wholeUsbDevice)
+                    {
+                        wholeUsbDevice.ReleaseInterface(0);
+                    }
+
+                    _usbDevice.Close();
+                }
+            }
+            finally
+            {
+                _des.Dispose();
+            }
+        }
+    }
+}

--- a/InfoPanel/TuringPanel/TuringPanelModel.cs
+++ b/InfoPanel/TuringPanel/TuringPanelModel.cs
@@ -22,5 +22,8 @@
         REV_16INCH_USB,
         REV_21INCH_USB,
 
+        // Lian Li USB LCDs using the Turing-compatible transport
+        LIANLI_88INCH_USB,
+
     }
 }

--- a/InfoPanel/TuringPanel/TuringPanelModelDatabase.cs
+++ b/InfoPanel/TuringPanel/TuringPanelModelDatabase.cs
@@ -23,6 +23,7 @@ namespace InfoPanel.TuringPanel
             [TuringPanelModel.REV_5INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_5INCH_USB, Name = "Turing Smart Screen 5\"", Width = 720, Height = 1280, VendorId = 0x1cbe, ProductId = 0x0050, IsUsbDevice = true },
             [TuringPanelModel.REV_16INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_16INCH_USB, Name = "Turing Smart Screen 1.6\"", Width = 400, Height = 400, VendorId = 0x1cbe, ProductId = 0x0016, IsUsbDevice = true },
             [TuringPanelModel.REV_21INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.REV_21INCH_USB, Name = "Turing Smart Screen 2.1\"", Width = 480, Height = 480, VendorId = 0x1cbe, ProductId = 0x0021, IsUsbDevice = true },
+            [TuringPanelModel.LIANLI_88INCH_USB] = new TuringPanelModelInfo { Model = TuringPanelModel.LIANLI_88INCH_USB, Name = "Lian Li Universal Screen 8.8\"", Width = 480, Height = 1920, VendorId = 0x1cbe, ProductId = 0xa088, IsUsbDevice = true },
         };
 
         public static bool TryGetModelInfo(int vendorId, int productId, bool isUsbDevice, out TuringPanelModelInfo modelInfo)


### PR DESCRIPTION

[infopanel-lianli-us88-pr-ready.patch](https://github.com/user-attachments/files/29799787/infopanel-lianli-us88-pr-ready.patch)
## Summary

Adds support for the Lian Li 8.8" USB display panel (`VID 0x1CBE`, `PID 0xA088`) using the existing Turing USB panel rendering path with a Lian Li-specific transport implementation.

## What changed

- Adds `LIANLI_88INCH_USB` to the Turing panel model database.
- Registers the Lian Li 8.8" panel as a `480x1920` portrait USB display.
- Routes Lian Li USB devices through a new `LianLiUsbScreenDevice` implementation.
- Sends rendered frames as JPEG using Lian Li command `101` / `PushJpg`.
- Rotates the existing landscape render buffer into the panel's native portrait framebuffer.
- Adds Lian Li frame-rate initialization via command `15` / `SetFrameRate`.
- Adds query-based device buffer flow control via command `122` / `QueryBlock`.
- Tolerates USB read timeouts where the device does not return a response.
- Adds `InfoPanel.Extras` to the normal restore graph so a fresh `dotnet build InfoPanel.csproj` restores all projects needed by the existing custom Extras build target.

## Notes

The Lian Li 8.8" device uses the same 512-byte DES-CBC packet structure as the existing USB LCD protocol family, but its image path is device-specific:

- JPEG/background command: `101`
- PNG/overlay command: `102` — not used for the main frame path
- Stop media command: `123`
- Query block command: `122`
- Frame-rate command: `15`
- Native panel dimensions: `480x1920`

## Verification

Verified from a brand-new clone of this repository on Windows:

```powershell
git clone https://github.com/habibrehmansg/infopanel.git C:\Users\User\git\infopanel-fresh-patch-test
cd C:\Users\User\git\infopanel-fresh-patch-test
git checkout 1.4.x
git apply --check C:\Users\User\git\infopanel-lianli-us88-pr-ready.patch
git apply C:\Users\User\git\infopanel-lianli-us88-pr-ready.patch
git diff --check
dotnet build .\InfoPanel\InfoPanel.csproj -c Debug -p:Platform=x64 -p:RuntimeIdentifier=win-x64
```

Result:

```text
Build succeeded.
81 Warning(s)
0 Error(s)
```

The warnings are pre-existing project warnings unrelated to this change.

Runtime behavior was also tested on a Lian Li 8.8" USB display and confirmed working.

NOTE: I Attached a patch file as well that anyone can use to grab a copy of the source and apply if this doesn't get approved for merge. 

Just download the attached patch file and then: 

## Clone the repo
`git clone https://github.com/habibrehmansg/infopanel.git`

## Apply the patch
`git apply ..\infopanel-lianli-us88-pr-ready.patch`

## Build the binaries (you do need to have the .Net 8.0 SDK Installed)
`dotnet build .\InfoPanel\InfoPanel.csproj -c Debug -p:Platform=x64 -p:RuntimeIdentifier=win-x64`

## Run the exe
`.\InfoPanel\bin\x64\Debug\net8.0-windows10.0.19041.0\win-x64\InfoPanel.exe`

<img width="1219" height="388" alt="image" src="https://github.com/user-attachments/assets/2e39ef93-1d67-4457-b640-f7294324d330" />

This is the panel: https://www.amazon.com/Lian-Li-8-8-Universal-Screen/dp/B0FKH3NK1H/?th=1
