### PR TITLE
Add Jonsbo display support (DS916 and DS339)

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -405,6 +405,7 @@ namespace InfoPanel
                 await TuringPanelTask.Instance.StopAsync(true);
                 await ThermalrightPanelTask.Instance.StopAsync(true);
                 await ThermaltakePanelTask.Instance.StopAsync(true);
+                await JonsboPanelTask.Instance.StopAsync(true);
             });
         }
 
@@ -426,6 +427,7 @@ namespace InfoPanel
                         await TuringPanelTask.Instance.StopAsync(true);
                         await ThermalrightPanelTask.Instance.StopAsync(true);
                         await ThermaltakePanelTask.Instance.StopAsync(true);
+                        await JonsboPanelTask.Instance.StopAsync(true);
                     });
                     break;
             }
@@ -453,6 +455,11 @@ namespace InfoPanel
                 await ThermaltakePanelTask.Instance.StartAsync();
             }
 
+            if (ConfigModel.Instance.Settings.JonsboPanelMultiDeviceMode)
+            {
+                await JonsboPanelTask.Instance.StartAsync();
+            }
+
             if (ConfigModel.Instance.Settings.WebServer)
             {
                 await WebServerTask.Instance.StartAsync();
@@ -466,6 +473,7 @@ namespace InfoPanel
             await TuringPanelTask.Instance.StopAsync();
             await ThermalrightPanelTask.Instance.StopAsync();
             await ThermaltakePanelTask.Instance.StopAsync();
+            await JonsboPanelTask.Instance.StopAsync();
         }
 
         private void App_Exit(object sender, ExitEventArgs e)

--- a/InfoPanel/JonsboPanel/JonsboMs9132Device.cs
+++ b/InfoPanel/JonsboPanel/JonsboMs9132Device.cs
@@ -1,0 +1,236 @@
+using HidSharp;
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Serilog;
+using System;
+using System.Linq;
+using System.Threading;
+
+namespace InfoPanel.JonsboPanel
+{
+    /// <summary>
+    /// MacroSilicon MS9132 USB display transport, used by the Jonsbo DS339 (376x960).
+    /// Protocol from the ms912x/ms9132 Linux drivers plus a USB capture of the OEM
+    /// JONSBO-AIO app driving a real DS339 (see JONSBO-AIO PROTOCOL.md):
+    ///
+    ///   * Control plane rides the HID interface (MI_00) as 8-byte feature reports:
+    ///       A6 [op] [6 bytes]  writes, B5 [addr_be16] reads (SET_REPORT then GET_REPORT).
+    ///     Mode-set sequence (captured verbatim from the OEM app):
+    ///       A6 07 01 02                    power on
+    ///       A6 05 00                       video off
+    ///       A6 03 03
+    ///       A6 01 [w_be16] [h_be16] 11 00  input info: resolution, color=0x11 (RGB888), byte_sel=0
+    ///       A6 02 [vic] 00 [w_be16] [h_be16]  output info: VIC index, out color 0
+    ///       A6 04 01
+    ///       A6 05 01                       video on
+    ///   * Frames go to bulk OUT EP 0x04 on the vendor interface (MI_03, "msusb video",
+    ///     needs the OEM's libusb driver or WinUSB):
+    ///       8-byte header: FF 00 | x/16 (u8) | y (be16) | width/16 (u8) | height|0x8000 (be16)
+    ///       + width*height*3 bytes BGR888 + 8-byte trailer FF C0 00 00 00 00 00 00,
+    ///     written in 64 KB chunks. Width byte rounds down (376/16 -> 23), as captured.
+    /// </summary>
+    public sealed class JonsboMs9132Device : IDisposable
+    {
+        private static readonly ILogger Logger = Log.ForContext<JonsboMs9132Device>();
+
+        public const int VENDOR_ID = 0x345F;
+        public const int PRODUCT_ID = 0x9132;
+
+        private const int ChunkSize = 65536;
+        private const int WriteTimeoutMs = 5000;
+
+        private HidStream? _hidStream;
+        private UsbDevice? _usbDevice;
+        private UsbEndpointWriter? _writer;
+        private bool _disposed;
+
+        public string SerialNumber { get; private set; } = string.Empty;
+
+        public static JonsboMs9132Device? Open()
+        {
+            var dev = new JonsboMs9132Device();
+            try
+            {
+                // Control plane: the HID interface, via the inbox HID driver.
+                var hidDevice = DeviceList.Local.GetHidDevices(VENDOR_ID, PRODUCT_ID).FirstOrDefault();
+                if (hidDevice == null)
+                {
+                    Logger.Warning("JonsboMs9132: HID interface not found (VID={Vid:X4} PID={Pid:X4})", VENDOR_ID, PRODUCT_ID);
+                    dev.Dispose();
+                    return null;
+                }
+
+                if (!hidDevice.TryOpen(out var hidStream))
+                {
+                    Logger.Warning("JonsboMs9132: Cannot open HID interface");
+                    dev.Dispose();
+                    return null;
+                }
+                dev._hidStream = hidStream;
+
+                try { dev.SerialNumber = hidDevice.GetSerialNumber(); } catch { }
+
+                // Frame pipe: the vendor "msusb video" interface via libusb/WinUSB.
+                var finder = new UsbDeviceFinder(VENDOR_ID, PRODUCT_ID);
+                dev._usbDevice = UsbDevice.OpenUsbDevice(finder);
+                if (dev._usbDevice == null)
+                {
+                    Logger.Warning("JonsboMs9132: Video interface not found — is the Jonsbo MSUSBDisplay driver installed on interface 3?");
+                    dev.Dispose();
+                    return null;
+                }
+
+                if (dev._usbDevice is IUsbDevice wholeDevice)
+                {
+                    wholeDevice.SetConfiguration(1);
+                    wholeDevice.ClaimInterface(3);
+                }
+
+                dev._writer = dev._usbDevice.OpenEndpointWriter(WriteEndpointID.Ep04);
+
+                Logger.Information("JonsboMs9132: Opened (serial {Serial})", dev.SerialNumber);
+                return dev;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "JonsboMs9132: Open failed");
+                dev.Dispose();
+                return null;
+            }
+        }
+
+        private void WriteControl(byte[] payload8)
+        {
+            if (_hidStream == null) throw new InvalidOperationException("HID not open");
+            // Feature report: [reportId=0] + 8 payload bytes.
+            var buffer = new byte[9];
+            Array.Copy(payload8, 0, buffer, 1, Math.Min(payload8.Length, 8));
+            _hidStream.SetFeature(buffer);
+        }
+
+        /// <summary>Reads a device register via B5 (SET_REPORT request, GET_REPORT reply).</summary>
+        public int ReadRegister(ushort address)
+        {
+            if (_hidStream == null) throw new InvalidOperationException("HID not open");
+            WriteControl([0xB5, (byte)(address >> 8), (byte)(address & 0xFF), 0, 0, 0, 0, 0]);
+            var buffer = new byte[9];
+            _hidStream.GetFeature(buffer);
+            // Reply layout mirrors the request: [reportId] B5 addr_hi addr_lo data0 ...
+            return buffer[4];
+        }
+
+        /// <summary>Panel connection status (register 0x32): 1 = connected.</summary>
+        public bool IsPanelConnected()
+        {
+            try { return ReadRegister(0x0032) == 1; }
+            catch { return false; }
+        }
+
+        /// <summary>
+        /// Applies the captured OEM mode-set sequence for the given native resolution and VIC.
+        /// </summary>
+        public void SetMode(int width, int height, byte vic)
+        {
+            byte wHi = (byte)(width >> 8), wLo = (byte)(width & 0xFF);
+            byte hHi = (byte)(height >> 8), hLo = (byte)(height & 0xFF);
+
+            WriteControl([0xA6, 0x07, 0x01, 0x02, 0, 0, 0, 0]);   // power on
+            WriteControl([0xA6, 0x05, 0x00, 0, 0, 0, 0, 0]);      // video off
+            WriteControl([0xA6, 0x03, 0x03, 0, 0, 0, 0, 0]);
+            WriteControl([0xA6, 0x01, wHi, wLo, hHi, hLo, 0x11, 0x00]); // in: RGB888
+            WriteControl([0xA6, 0x02, vic, 0x00, wHi, wLo, hHi, hLo]);  // out: VIC
+            WriteControl([0xA6, 0x04, 0x01, 0, 0, 0, 0, 0]);
+            WriteControl([0xA6, 0x05, 0x01, 0, 0, 0, 0, 0]);      // video on
+            Thread.Sleep(100);
+
+            Logger.Information("JonsboMs9132: Mode set {Width}x{Height} VIC {Vic}", width, height, vic);
+        }
+
+        public void PowerOff()
+        {
+            try { WriteControl([0xA6, 0x07, 0, 0, 0, 0, 0, 0]); }
+            catch (Exception ex) { Logger.Debug(ex, "JonsboMs9132: PowerOff failed"); }
+        }
+
+        /// <summary>
+        /// Sends one full frame. <paramref name="bgrPixels"/> must be width*height*3 bytes,
+        /// B,G,R order, top-down rows at the panel's native (portrait) resolution.
+        /// </summary>
+        public void SendFrame(byte[] bgrPixels, int width, int height)
+        {
+            if (_writer == null) throw new InvalidOperationException("USB not open");
+
+            int payloadLen = width * height * 3;
+            if (bgrPixels.Length < payloadLen)
+                throw new ArgumentException($"Pixel buffer too small: {bgrPixels.Length} < {payloadLen}");
+
+            int total = 8 + payloadLen + 8;
+            var buffer = System.Buffers.ArrayPool<byte>.Shared.Rent(total);
+            try
+            {
+                // Header: FF 00, x/16, y BE16, width/16 (rounded down, per OEM capture), height | 0x8000.
+                buffer[0] = 0xFF;
+                buffer[1] = 0x00;
+                buffer[2] = 0x00;                       // x/16
+                buffer[3] = 0x00;                       // y hi
+                buffer[4] = 0x00;                       // y lo
+                buffer[5] = (byte)(width / 16);
+                int flaggedHeight = height | 0x8000;
+                buffer[6] = (byte)(flaggedHeight >> 8);
+                buffer[7] = (byte)(flaggedHeight & 0xFF);
+
+                Buffer.BlockCopy(bgrPixels, 0, buffer, 8, payloadLen);
+
+                // Trailer: FF C0 00 00 00 00 00 00
+                int t = 8 + payloadLen;
+                buffer[t] = 0xFF;
+                buffer[t + 1] = 0xC0;
+                for (int i = 2; i < 8; i++) buffer[t + i] = 0;
+
+                // Write in 64 KB chunks, matching the OEM app's transfer pattern.
+                int offset = 0;
+                while (offset < total)
+                {
+                    int len = Math.Min(ChunkSize, total - offset);
+                    var ec = _writer.Write(buffer, offset, len, WriteTimeoutMs, out int written);
+                    if (ec != ErrorCode.None || written != len)
+                        throw new Exception($"USB bulk write failed: {ec} ({written}/{len})");
+                    offset += len;
+                }
+            }
+            finally
+            {
+                System.Buffers.ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            PowerOff();
+            try { _hidStream?.Dispose(); } catch { }
+            _hidStream = null;
+            try
+            {
+                if (_usbDevice != null)
+                {
+                    if (_usbDevice.IsOpen)
+                    {
+                        if (_usbDevice is IUsbDevice wholeDevice)
+                        {
+                            try { wholeDevice.ReleaseInterface(3); } catch { }
+                        }
+                        _usbDevice.Close();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "JonsboMs9132: Dispose error");
+            }
+            _usbDevice = null;
+            _writer = null;
+        }
+    }
+}

--- a/InfoPanel/JonsboPanel/JonsboPanelHelper.cs
+++ b/InfoPanel/JonsboPanel/JonsboPanelHelper.cs
@@ -1,0 +1,116 @@
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management;
+using System.Text.RegularExpressions;
+
+namespace InfoPanel.JonsboPanel
+{
+    public class JonsboPanelDiscoveryInfo
+    {
+        public string DeviceId { get; set; } = "";
+        public string DeviceLocation { get; set; } = ""; // COM port name (e.g. "COM5")
+        public int VendorId { get; set; }
+        public int ProductId { get; set; }
+        public JonsboPanelModel Model { get; set; }
+        public JonsboPanelModelInfo? ModelInfo { get; set; }
+    }
+
+    public static partial class JonsboPanelHelper
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(JonsboPanelHelper));
+
+        /// <summary>
+        /// Scans for Jonsbo panels: HLVMAX serial devices via Win32_SerialPort, and
+        /// MacroSilicon MS9132 USB displays (DS339) via their HID control interface.
+        /// </summary>
+        public static List<JonsboPanelDiscoveryInfo> ScanDevices()
+        {
+            var devices = new List<JonsboPanelDiscoveryInfo>();
+
+            try
+            {
+                using var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_SerialPort");
+                foreach (ManagementObject obj in searcher.Get().Cast<ManagementObject>())
+                {
+                    string? comPort = obj["DeviceID"]?.ToString();
+                    string? pnpDeviceId = obj["PNPDeviceID"]?.ToString();
+
+                    if (comPort == null || pnpDeviceId == null) continue;
+                    if (!TryParseVidPid(pnpDeviceId, out var vid, out var pid)) continue;
+
+                    var modelInfo = JonsboPanelModelDatabase.GetModelByVidPid(vid, pid);
+                    if (modelInfo == null) continue;
+
+                    Logger.Information("JonsboPanelHelper: Found {Name} on {Port} (PNP={Pnp})",
+                        modelInfo.Name, comPort, pnpDeviceId);
+
+                    devices.Add(new JonsboPanelDiscoveryInfo
+                    {
+                        DeviceId = pnpDeviceId,
+                        DeviceLocation = comPort,
+                        VendorId = vid,
+                        ProductId = pid,
+                        Model = modelInfo.Model,
+                        ModelInfo = modelInfo,
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "JonsboPanelHelper: Error scanning serial ports");
+            }
+
+            // MS9132-based panels (DS339): presence-detect via the HID control interface,
+            // which binds to the inbox HID driver regardless of the video-interface driver.
+            try
+            {
+                foreach (var hid in HidSharp.DeviceList.Local.GetHidDevices(
+                    JonsboPanelModelDatabase.MS9132_VENDOR_ID, JonsboPanelModelDatabase.MS9132_PRODUCT_ID))
+                {
+                    var modelInfo = JonsboPanelModelDatabase.Models[JonsboPanelModel.DS339];
+
+                    string serial = "";
+                    try { serial = hid.GetSerialNumber(); } catch { }
+
+                    string deviceId = $"USB\\VID_{JonsboPanelModelDatabase.MS9132_VENDOR_ID:X4}&PID_{JonsboPanelModelDatabase.MS9132_PRODUCT_ID:X4}\\{serial}";
+
+                    Logger.Information("JonsboPanelHelper: Found {Name} (MS9132, serial {Serial})",
+                        modelInfo.Name, serial);
+
+                    devices.Add(new JonsboPanelDiscoveryInfo
+                    {
+                        DeviceId = deviceId,
+                        DeviceLocation = string.IsNullOrEmpty(serial) ? "MS9132" : serial,
+                        VendorId = JonsboPanelModelDatabase.MS9132_VENDOR_ID,
+                        ProductId = JonsboPanelModelDatabase.MS9132_PRODUCT_ID,
+                        Model = modelInfo.Model,
+                        ModelInfo = modelInfo,
+                    });
+                    break; // one MS9132 device supported per scan for now
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "JonsboPanelHelper: Error scanning MS9132 devices");
+            }
+
+            Logger.Information("JonsboPanelHelper: Found {Count} Jonsbo panel device(s)", devices.Count);
+            return devices;
+        }
+
+        private static bool TryParseVidPid(string pnpDeviceId, out int vid, out int pid)
+        {
+            vid = 0; pid = 0;
+            var match = VidPidRegex().Match(pnpDeviceId);
+            if (!match.Success) return false;
+            vid = Convert.ToInt32(match.Groups[1].Value, 16);
+            pid = Convert.ToInt32(match.Groups[2].Value, 16);
+            return true;
+        }
+
+        [GeneratedRegex(@"VID_([0-9A-Fa-f]{4})&PID_([0-9A-Fa-f]{4})")]
+        private static partial Regex VidPidRegex();
+    }
+}

--- a/InfoPanel/JonsboPanel/JonsboPanelModel.cs
+++ b/InfoPanel/JonsboPanel/JonsboPanelModel.cs
@@ -1,0 +1,15 @@
+namespace InfoPanel.JonsboPanel
+{
+    public enum JonsboPanelModel
+    {
+        Unknown,
+        DS916,          // VID 0x33C3, PID 0xF101, 462x1920 native portrait ("VMAXB16" identity), CDC raw-JPEG
+        DS339,          // VID 0x345F, PID 0x9132 (MacroSilicon MS9132), 376x960 native portrait, RGB888 USB display
+    }
+
+    public enum JonsboTransportType
+    {
+        Serial,         // HLVMAX CDC ACM COM port, raw JPEG frames
+        Ms9132,         // MacroSilicon MS9132: HID control plane + bulk RGB888 frames
+    }
+}

--- a/InfoPanel/JonsboPanel/JonsboPanelModelDatabase.cs
+++ b/InfoPanel/JonsboPanel/JonsboPanelModelDatabase.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace InfoPanel.JonsboPanel
+{
+    /// <summary>
+    /// Jonsbo displays ("HLVMAX" / Artinchip family).
+    /// Reference platform: Jonsbo DS916 (9.16", 462x1920 native portrait).
+    /// Transport is USB CDC ACM (virtual COM port); the line coding is ignored by the
+    /// firmware — frames are plain bulk writes. Protocol reverse-engineered from the
+    /// OEM JONSBO-AIO app + USB capture (see JONSBO-PROTOCOL.md):
+    ///   handshake F0 A5 5A 0F -> 26-byte ASCII identity, then raw JPEG per frame.
+    /// </summary>
+    public static class JonsboPanelModelDatabase
+    {
+        public const int JONSBO_VENDOR_ID = 0x33C3;   // Artinchip Technology (shared with Hongtai/JL SKUs)
+        public const int JONSBO_PRODUCT_ID_DS916 = 0xF101;
+
+        public const int MS9132_VENDOR_ID = 0x345F;   // MacroSilicon
+        public const int MS9132_PRODUCT_ID = 0x9132;
+
+        public static readonly (int Vid, int Pid)[] SupportedDevices =
+        [
+            (JONSBO_VENDOR_ID, JONSBO_PRODUCT_ID_DS916),
+            (MS9132_VENDOR_ID, MS9132_PRODUCT_ID),
+        ];
+
+        public static readonly Dictionary<JonsboPanelModel, JonsboPanelModelInfo> Models = new()
+        {
+            [JonsboPanelModel.DS916] = new JonsboPanelModelInfo
+            {
+                Model = JonsboPanelModel.DS916,
+                Name = "Jonsbo DS916",
+                Width = 462,     // native portrait; identity string overrides at runtime
+                Height = 1920,
+                VendorId = JONSBO_VENDOR_ID,
+                ProductId = JONSBO_PRODUCT_ID_DS916,
+                TransportType = JonsboTransportType.Serial,
+                MaxJpegBytes = 256 * 1024,
+                DefaultFrameRate = 25,
+            },
+            // DS339: MacroSilicon MS9132 USB display bridge driving a 376x960 portrait panel.
+            // Mode-set uses the Jonsbo custom VIC 171 (from the OEM app's EDID timing table),
+            // frames are raw BGR888 (verified against a USB capture of the OEM app).
+            [JonsboPanelModel.DS339] = new JonsboPanelModelInfo
+            {
+                Model = JonsboPanelModel.DS339,
+                Name = "Jonsbo DS339",
+                Width = 376,     // native portrait
+                Height = 960,
+                VendorId = MS9132_VENDOR_ID,
+                ProductId = MS9132_PRODUCT_ID,
+                TransportType = JonsboTransportType.Ms9132,
+                Vic = 171,
+                DefaultFrameRate = 15,
+            },
+        };
+
+        public static JonsboPanelModelInfo? GetModelByVidPid(int vid, int pid)
+        {
+            return Models.Values.FirstOrDefault(m => m.VendorId == vid && m.ProductId == pid);
+        }
+    }
+}

--- a/InfoPanel/JonsboPanel/JonsboPanelModelInfo.cs
+++ b/InfoPanel/JonsboPanel/JonsboPanelModelInfo.cs
@@ -1,0 +1,26 @@
+namespace InfoPanel.JonsboPanel
+{
+    public class JonsboPanelModelInfo
+    {
+        public JonsboPanelModel Model { get; init; }
+        public string Name { get; init; } = "Unknown Model";
+
+        /// <summary>Native panel resolution (portrait for the DS916: 462x1920).
+        /// The handshake identity string overrides these at runtime.</summary>
+        public int Width { get; init; }
+        public int Height { get; init; }
+
+        public int VendorId { get; init; }
+        public int ProductId { get; init; }
+
+        public JonsboTransportType TransportType { get; init; } = JonsboTransportType.Serial;
+
+        /// <summary>CEA/custom VIC for MS9132 mode-set (171 = 376x960 on the DS339).</summary>
+        public byte Vic { get; init; }
+
+        /// <summary>Soft cap on JPEG payload size in bytes (OEM app streams ~120 KB frames). Serial transport only.</summary>
+        public int MaxJpegBytes { get; init; } = 256 * 1024;
+
+        public int DefaultFrameRate { get; init; } = 25;
+    }
+}

--- a/InfoPanel/JonsboPanel/JonsboSerialDevice.cs
+++ b/InfoPanel/JonsboPanel/JonsboSerialDevice.cs
@@ -1,0 +1,175 @@
+using Serilog;
+using System;
+using System.IO.Ports;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace InfoPanel.JonsboPanel
+{
+    /// <summary>
+    /// Serial communication for Jonsbo displays (DS916 family, "HLVMAX" firmware).
+    /// Protocol (reverse-engineered from the OEM JONSBO-AIO app + USB capture):
+    ///   * USB CDC ACM virtual COM port. Line coding is ignored by the firmware —
+    ///     the OEM app opens at 9600 baud and streams ~120 KB frames regardless.
+    ///   * Handshake: write F0 A5 5A 0F, device replies with a 26-byte ASCII identity:
+    ///       "VMAXB160462*1920S261301227"
+    ///        [7-char model][width]*[height][serial]
+    ///     Resolution is in the panel's NATIVE (portrait) orientation.
+    ///   * Frames: one raw JFIF JPEG per frame written straight to the port.
+    ///     No envelope, no size header, no checksum, no keep-alive, no terminator.
+    ///     JPEG dimensions must match the native portrait resolution.
+    /// </summary>
+    public sealed partial class JonsboSerialDevice : IDisposable
+    {
+        private static readonly ILogger Logger = Log.ForContext<JonsboSerialDevice>();
+
+        private static readonly byte[] HandshakeCommand = [0xF0, 0xA5, 0x5A, 0x0F];
+
+        private const int BaudRate = 9600; // nominal only — CDC bulk ignores it (matches OEM app)
+        private const int ReadTimeoutMs = 2000;
+        private const int WriteTimeoutMs = 5000;
+
+        private SerialPort? _port;
+        private bool _disposed;
+
+        public bool IsOpen => _port?.IsOpen == true;
+        public string PortName { get; private set; } = string.Empty;
+
+        public class DeviceIdentity
+        {
+            public string Model { get; set; } = "";   // 7-char prefix, e.g. "VMAXB16"
+            public string Serial { get; set; } = "";  // e.g. "S261301227"
+            public int Width { get; set; }            // native portrait width  (462 on DS916)
+            public int Height { get; set; }           // native portrait height (1920 on DS916)
+            public string Raw { get; set; } = "";
+        }
+
+        /// <summary>Opens the COM port. The baud rate is irrelevant to the firmware.</summary>
+        public static JonsboSerialDevice? Open(string comPort)
+        {
+            var dev = new JonsboSerialDevice();
+            try
+            {
+                dev._port = new SerialPort(comPort, BaudRate)
+                {
+                    ReadTimeout = ReadTimeoutMs,
+                    WriteTimeout = WriteTimeoutMs,
+                    DtrEnable = true,
+                    RtsEnable = true,
+                    Handshake = Handshake.None,
+                };
+                dev._port.Open();
+                dev.PortName = comPort;
+                dev._port.DiscardInBuffer();
+
+                Logger.Information("JonsboSerialDevice: Opened {Port}", comPort);
+                return dev;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "JonsboSerialDevice: Failed to open {Port}", comPort);
+                dev.Dispose();
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sends the F0 A5 5A 0F handshake and parses the ASCII identity reply.
+        /// The OEM app retries after 1 s on silence; callers should do the same.
+        /// </summary>
+        public DeviceIdentity? GetIdentity()
+        {
+            if (_port == null || !_port.IsOpen) throw new InvalidOperationException("Port not open");
+
+            _port.DiscardInBuffer();
+            _port.Write(HandshakeCommand, 0, HandshakeCommand.Length);
+
+            // Reply observed as a single 26-byte burst ~4 ms after the command.
+            // Read until the port goes quiet (or a sane cap) to tolerate length variations.
+            var buffer = new byte[64];
+            int total = 0;
+            try
+            {
+                int b = _port.ReadByte(); // blocks up to ReadTimeout for the first byte
+                if (b < 0) return null;
+                buffer[total++] = (byte)b;
+
+                var deadline = DateTime.UtcNow.AddMilliseconds(300);
+                while (total < buffer.Length && DateTime.UtcNow < deadline)
+                {
+                    if (_port.BytesToRead > 0)
+                    {
+                        int n = _port.Read(buffer, total, Math.Min(_port.BytesToRead, buffer.Length - total));
+                        if (n > 0) total += n;
+                    }
+                    else
+                    {
+                        System.Threading.Thread.Sleep(10);
+                    }
+                }
+            }
+            catch (TimeoutException)
+            {
+                Logger.Debug("JonsboSerialDevice: No identity reply from {Port}", PortName);
+                return null;
+            }
+
+            string raw = Encoding.ASCII.GetString(buffer, 0, total).Trim('\0', '\r', '\n', ' ');
+            Logger.Information("JonsboSerialDevice: Identity reply ({Len} bytes): {Raw}", total, raw);
+
+            // "VMAXB16" + "0462*1920" + "S261301227"
+            var match = IdentityRegex().Match(raw);
+            if (!match.Success)
+            {
+                Logger.Warning("JonsboSerialDevice: Unrecognized identity format: {Raw}", raw);
+                return null;
+            }
+
+            return new DeviceIdentity
+            {
+                Model = match.Groups[1].Value,
+                Width = int.Parse(match.Groups[2].Value),
+                Height = int.Parse(match.Groups[3].Value),
+                Serial = match.Groups[4].Value,
+                Raw = raw,
+            };
+        }
+
+        /// <summary>
+        /// Sends one frame: the raw JPEG bytes, nothing else. The JPEG must be encoded at
+        /// the panel's native (portrait) resolution.
+        /// </summary>
+        public void SendJpegFrame(byte[] jpeg)
+        {
+            if (_port == null || !_port.IsOpen) throw new InvalidOperationException("Port not open");
+            _port.Write(jpeg, 0, jpeg.Length);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            try
+            {
+                if (_port != null)
+                {
+                    // No close/stop command is known for this firmware; the panel falls back
+                    // to its boot animation when frames stop arriving.
+                    if (_port.IsOpen)
+                    {
+                        try { _port.Close(); } catch { }
+                    }
+                    _port.Dispose();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "JonsboSerialDevice: Dispose error");
+            }
+            _port = null;
+        }
+
+        [GeneratedRegex(@"^(.{7})(\d{3,4})\*(\d{3,4})(\S*)")]
+        private static partial Regex IdentityRegex();
+    }
+}

--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -502,6 +502,17 @@ namespace InfoPanel
                     await ThermaltakePanelTask.Instance.StopAsync();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.JonsboPanelMultiDeviceMode))
+            {
+                if (Settings.JonsboPanelMultiDeviceMode)
+                {
+                    await JonsboPanelTask.Instance.StartAsync();
+                }
+                else
+                {
+                    await JonsboPanelTask.Instance.StopAsync();
+                }
+            }
 
             await SaveSettingsAsync();
         }
@@ -711,6 +722,15 @@ namespace InfoPanel
                             foreach (var device in settings.ThermaltakePanelDevices)
                             {
                                 Settings.ThermaltakePanelDevices.Add(device);
+                            }
+
+                            // Load Jonsbo panel settings
+                            Settings.JonsboPanelMultiDeviceMode = settings.JonsboPanelMultiDeviceMode;
+
+                            Settings.JonsboPanelDevices.Clear();
+                            foreach (var device in settings.JonsboPanelDevices)
+                            {
+                                Settings.JonsboPanelDevices.Add(device);
                             }
 
                             // Load hotkey bindings

--- a/InfoPanel/Models/JonsboPanelDevice.cs
+++ b/InfoPanel/Models/JonsboPanelDevice.cs
@@ -1,0 +1,133 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using InfoPanel.JonsboPanel;
+using InfoPanel.ViewModels;
+using Serilog;
+using System;
+using System.Windows.Threading;
+
+namespace InfoPanel.Models
+{
+    public partial class JonsboPanelDevice : ObservableObject
+    {
+        private static readonly ILogger Logger = Log.ForContext<JonsboPanelDevice>();
+
+        [ObservableProperty]
+        private string _deviceId = string.Empty;
+
+        [ObservableProperty]
+        private string _deviceLocation = string.Empty; // COM port e.g. "COM5"
+
+        [ObservableProperty]
+        private JonsboPanelModel _model = JonsboPanelModel.DS916;
+
+        partial void OnModelChanged(JonsboPanelModel value)
+        {
+            OnPropertyChanged(nameof(ModelInfo));
+            OnPropertyChanged(nameof(DisplayWidth));
+            OnPropertyChanged(nameof(DisplayHeight));
+        }
+
+        [ObservableProperty]
+        private bool _enabled = false;
+
+        [ObservableProperty]
+        private Guid _profileGuid = Guid.Empty;
+
+        // The DS916 panel is natively portrait (462x1920); default to 90° so a
+        // landscape 1920x462 profile fills it out of the box.
+        [ObservableProperty]
+        private LCD_ROTATION _rotation = LCD_ROTATION.Rotate90FlipNone;
+
+        [ObservableProperty]
+        private int _brightness = 100;
+
+        [ObservableProperty]
+        private int _targetFrameRate = 15;
+
+        [ObservableProperty]
+        private int _jpegQuality = 80;
+
+        // Runtime properties (not persisted)
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private string _id = Guid.NewGuid().ToString();
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private JonsboPanelDeviceRuntimeProperties _runtimeProperties;
+
+        public JonsboPanelDevice()
+        {
+            _runtimeProperties = new();
+        }
+
+        public JonsboPanelModelInfo? ModelInfo =>
+            JonsboPanelModelDatabase.Models.TryGetValue(Model, out var info) ? info : null;
+
+        public int DisplayWidth => ModelInfo?.Width ?? 0;
+        public int DisplayHeight => ModelInfo?.Height ?? 0;
+
+        public bool IsMatching(string deviceId, string deviceLocation, JonsboPanelModel model)
+        {
+            if (DeviceId.Equals(deviceId) && DeviceLocation.Equals(deviceLocation) && Model.Equals(model))
+                return true;
+            // Fallback: match by PNP device id alone (COM ports can change)
+            if (DeviceId.Equals(deviceId) && Model.Equals(model))
+                return true;
+            return false;
+        }
+
+        private DateTime _lastUpdate = DateTime.MinValue;
+        private readonly TimeSpan _throttleInterval = TimeSpan.FromSeconds(1);
+
+        public void UpdateRuntimeProperties(bool? isRunning = null, int? frameRate = null, long? frameTime = null, string? errorMessage = null)
+        {
+            var now = DateTime.UtcNow;
+
+            if (isRunning != null || errorMessage != null)
+            {
+                _lastUpdate = now;
+                DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+                return;
+            }
+
+            if (now - _lastUpdate < _throttleInterval) return;
+            _lastUpdate = now;
+            DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+        }
+
+        private void DispatchUpdate(bool? isRunning, int? frameRate, long? frameTime, string? errorMessage)
+        {
+            if (System.Windows.Application.Current?.Dispatcher is Dispatcher dispatcher)
+            {
+                dispatcher.BeginInvoke(() =>
+                {
+                    if (isRunning != null) RuntimeProperties.IsRunning = isRunning.Value;
+                    if (frameRate != null) RuntimeProperties.FrameRate = frameRate.Value;
+                    if (frameTime != null) RuntimeProperties.FrameTime = frameTime.Value;
+                    if (errorMessage != null) RuntimeProperties.ErrorMessage = errorMessage;
+                });
+            }
+        }
+
+        public override string ToString() => DeviceLocation;
+
+        public partial class JonsboPanelDeviceRuntimeProperties : ObservableObject
+        {
+            [ObservableProperty]
+            private bool _isRunning = false;
+
+            [ObservableProperty]
+            private string _name = "Jonsbo Panel";
+
+            [ObservableProperty]
+            private int _frameRate = 0;
+
+            [ObservableProperty]
+            private long _frameTime = 0;
+
+            [ObservableProperty]
+            private string _errorMessage = string.Empty;
+        }
+    }
+}

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -93,6 +93,16 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _thermaltakePanelMultiDeviceMode = false;
 
+        private readonly ObservableCollection<JonsboPanelDevice> _jonsboPanelDevices = [];
+
+        public ObservableCollection<JonsboPanelDevice> JonsboPanelDevices
+        {
+            get { return _jonsboPanelDevices; }
+        }
+
+        [ObservableProperty]
+        private bool _jonsboPanelMultiDeviceMode = false;
+
         private readonly ObservableCollection<HotkeyBinding> _hotkeyBindings = [];
 
         public ObservableCollection<HotkeyBinding> HotkeyBindings
@@ -140,6 +150,7 @@ namespace InfoPanel.Models
             TuringPanelDevices.CollectionChanged += TuringPanelDevices_CollectionChanged;
             ThermalrightPanelDevices.CollectionChanged += ThermalrightPanelDevices_CollectionChanged;
             ThermaltakePanelDevices.CollectionChanged += ThermaltakePanelDevices_CollectionChanged;
+            JonsboPanelDevices.CollectionChanged += JonsboPanelDevices_CollectionChanged;
         }
 
         private void BeadaPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -232,6 +243,27 @@ namespace InfoPanel.Models
         {
             if (e.PropertyName != nameof(ThermaltakePanelDevice.RuntimeProperties))
                 OnPropertyChanged(nameof(ThermaltakePanelDevices));
+        }
+
+        private void JonsboPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (JonsboPanelDevice device in e.OldItems)
+                    device.PropertyChanged -= JonsboDevice_PropertyChanged;
+            }
+            if (e.NewItems != null)
+            {
+                foreach (JonsboPanelDevice device in e.NewItems)
+                    device.PropertyChanged += JonsboDevice_PropertyChanged;
+            }
+            OnPropertyChanged(nameof(JonsboPanelDevices));
+        }
+
+        private void JonsboDevice_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(JonsboPanelDevice.RuntimeProperties))
+                OnPropertyChanged(nameof(JonsboPanelDevices));
         }
 
     }

--- a/InfoPanel/Services/JonsboPanelDeviceTask.cs
+++ b/InfoPanel/Services/JonsboPanelDeviceTask.cs
@@ -1,0 +1,431 @@
+using InfoPanel.Drawing;
+using InfoPanel.Extensions;
+using InfoPanel.JonsboPanel;
+using InfoPanel.Models;
+using InfoPanel.Utils;
+using Serilog;
+using SkiaSharp;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class JonsboPanelDeviceTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<JonsboPanelDeviceTask>();
+
+        private readonly JonsboPanelDevice _device;
+        private int _panelWidth;   // native portrait width  (462 on DS916)
+        private int _panelHeight;  // native portrait height (1920 on DS916)
+
+        public JonsboPanelDeviceTask(JonsboPanelDevice device)
+        {
+            _device = device;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            var modelInfo = _device.ModelInfo;
+            if (modelInfo == null)
+            {
+                _device.UpdateRuntimeProperties(errorMessage: "Unknown model");
+                return;
+            }
+
+            _panelWidth = modelInfo.Width;
+            _panelHeight = modelInfo.Height;
+
+            _device.UpdateRuntimeProperties(isRunning: false, errorMessage: string.Empty);
+            _device.RuntimeProperties.Name = $"{modelInfo.Name} ({_panelWidth}x{_panelHeight})";
+
+            if (modelInfo.TransportType == JonsboTransportType.Ms9132)
+            {
+                await DoMs9132WorkAsync(modelInfo, token);
+                return;
+            }
+
+            int retryCount = 0;
+            while (!token.IsCancellationRequested)
+            {
+                JonsboSerialDevice? serial = null;
+                try
+                {
+                    Logger.Information("JonsboDevice {Device}: Opening (attempt {Retry})", _device, retryCount + 1);
+                    serial = JonsboSerialDevice.Open(_device.DeviceLocation);
+
+                    if (serial == null)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: $"Cannot open {_device.DeviceLocation}");
+                        await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    // Handshake: F0 A5 5A 0F -> ASCII identity with model, native resolution, serial.
+                    // The OEM app retries after 1 s of silence; do the same once before giving up.
+                    var identity = serial.GetIdentity();
+                    if (identity == null)
+                    {
+                        await Task.Delay(1000, token);
+                        identity = serial.GetIdentity();
+                    }
+
+                    if (identity == null)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: "No identity reply");
+                        serial.Dispose();
+                        await Task.Delay(2000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    Logger.Information("JonsboDevice {Device}: model={Model} serial={Serial} native {W}x{H}",
+                        _device, identity.Model, identity.Serial, identity.Width, identity.Height);
+
+                    // Trust the device-reported native resolution.
+                    if (identity.Width > 0 && identity.Height > 0)
+                    {
+                        _panelWidth = identity.Width;
+                        _panelHeight = identity.Height;
+                    }
+
+                    _device.RuntimeProperties.Name = $"{modelInfo.Name} {identity.Model} ({_panelWidth}x{_panelHeight})";
+
+                    retryCount = 0;
+                    await RunRenderSendLoop(serial, token);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "JonsboDevice {Device}: Error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+                    retryCount++;
+                }
+                finally
+                {
+                    serial?.Dispose();
+                    _device.UpdateRuntimeProperties(isRunning: false);
+                }
+
+                if (!token.IsCancellationRequested)
+                    await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+            }
+        }
+
+        private async Task RunRenderSendLoop(JonsboSerialDevice serial, CancellationToken token)
+        {
+            FpsCounter fpsCounter = new(60);
+            byte[]? latestFrame = null;
+            byte[]? lastSentFrame = null;
+            AutoResetEvent frameAvailable = new(false);
+
+            var renderCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+            var renderToken = renderCts.Token;
+
+            _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
+
+            // Render thread: produce JPEG frames at the target frame rate.
+            var renderTask = Task.Run(async () =>
+            {
+                Thread.CurrentThread.Name ??= $"Jonsbo-Render-{_device.DeviceLocation}";
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    while (!renderToken.IsCancellationRequested)
+                    {
+                        stopwatch.Restart();
+
+                        var frame = GenerateJpegBuffer();
+                        Interlocked.Exchange(ref latestFrame, frame);
+                        frameAvailable.Set();
+
+                        var targetFrameTime = 1000 / Math.Max(1, _device.TargetFrameRate);
+                        var elapsedMs = (int)stopwatch.ElapsedMilliseconds;
+                        var remaining = targetFrameTime - elapsedMs;
+                        if (remaining > 0) await Task.Delay(remaining, renderToken);
+                    }
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "JonsboDevice {Device}: Render error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: e.Message);
+                    renderCts.Cancel();
+                }
+            }, renderToken);
+
+            // Send thread: drain frames to the serial port. The firmware has no keep-alive
+            // command; the OEM app simply resends the current image every ~500 ms when the
+            // content is static, so we resend the last frame if nothing new shows up.
+            var sendTask = Task.Run(() =>
+            {
+                Thread.CurrentThread.Name ??= $"Jonsbo-Send-{_device.DeviceLocation}";
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    while (!token.IsCancellationRequested)
+                    {
+                        byte[]? jpegData;
+                        if (frameAvailable.WaitOne(1000))
+                        {
+                            jpegData = Interlocked.Exchange(ref latestFrame, null);
+                        }
+                        else
+                        {
+                            // No new frame in 1 s — resend the previous one so the panel
+                            // doesn't fall back to its boot animation.
+                            jpegData = lastSentFrame;
+                        }
+
+                        if (jpegData != null)
+                        {
+                            stopwatch.Restart();
+                            serial.SendJpegFrame(jpegData);
+                            lastSentFrame = jpegData;
+
+                            fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                            _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+                        }
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Error(e, "JonsboDevice {Device}: Send error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: e.Message);
+                }
+                finally
+                {
+                    renderCts.Cancel();
+                }
+            }, token);
+
+            await Task.WhenAll(renderTask, sendTask);
+
+            frameAvailable.Dispose();
+            renderCts.Dispose();
+        }
+
+        private byte[] GenerateJpegBuffer()
+        {
+            var modelInfo = _device.ModelInfo;
+            int maxBytes = modelInfo?.MaxJpegBytes ?? 256 * 1024;
+
+            if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
+            {
+                var rotation = _device.Rotation;
+
+                using var bitmap = PanelDrawTask.RenderSK(profile, false,
+                    colorType: SKColorType.Rgba8888,
+                    alphaType: SKAlphaType.Opaque);
+
+                // The JPEG must be in the panel's native portrait orientation; the rotation
+                // setting maps the (usually landscape) profile onto it.
+                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
+
+                SKBitmap encodeBitmap = resizedBitmap;
+                SKBitmap? dimmed = null;
+                try
+                {
+                    if (_device.Brightness < 100)
+                    {
+                        // No hardware backlight command is known for this firmware —
+                        // brightness is applied in-pixel.
+                        dimmed = ApplyBrightness(resizedBitmap);
+                        encodeBitmap = dimmed;
+                    }
+
+                    int quality = _device.JpegQuality;
+                    using var image = SKImage.FromBitmap(encodeBitmap);
+
+                    // Drop quality until the JPEG fits the soft payload cap.
+                    for (int attempt = 0; attempt < 5; attempt++)
+                    {
+                        using var data = image.Encode(SKEncodedImageFormat.Jpeg, quality);
+                        if (data.Size <= maxBytes || quality <= 30)
+                            return data.ToArray();
+                        quality = Math.Max(30, quality - 15);
+                    }
+                    using var fallback = image.Encode(SKEncodedImageFormat.Jpeg, 30);
+                    return fallback.ToArray();
+                }
+                finally
+                {
+                    dimmed?.Dispose();
+                }
+            }
+
+            return GenerateBlackJpeg();
+        }
+
+        private SKBitmap ApplyBrightness(SKBitmap source)
+        {
+            float scale = Math.Clamp(_device.Brightness, 0, 100) / 100f;
+            var result = new SKBitmap(source.Width, source.Height, source.ColorType, source.AlphaType);
+            using var canvas = new SKCanvas(result);
+            using var paint = new SKPaint();
+            paint.ColorFilter = SKColorFilter.CreateColorMatrix(
+            [
+                scale, 0,     0,     0, 0,
+                0,     scale, 0,     0, 0,
+                0,     0,     scale, 0, 0,
+                0,     0,     0,     1, 0
+            ]);
+            canvas.DrawBitmap(source, 0, 0, paint);
+            return result;
+        }
+
+        private byte[]? _cachedBlackJpeg;
+
+        private byte[] GenerateBlackJpeg()
+        {
+            if (_cachedBlackJpeg != null) return _cachedBlackJpeg;
+            using var bitmap = new SKBitmap(_panelWidth, _panelHeight, SKColorType.Rgba8888, SKAlphaType.Opaque);
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(SKColors.Black);
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Jpeg, 50);
+            _cachedBlackJpeg = data.ToArray();
+            return _cachedBlackJpeg;
+        }
+
+        // ==================== MS9132 transport (DS339) ====================
+
+        private async Task DoMs9132WorkAsync(JonsboPanelModelInfo modelInfo, CancellationToken token)
+        {
+            int retryCount = 0;
+            while (!token.IsCancellationRequested)
+            {
+                JonsboMs9132Device? ms = null;
+                try
+                {
+                    Logger.Information("JonsboDevice {Device}: Opening MS9132 (attempt {Retry})", _device, retryCount + 1);
+                    ms = JonsboMs9132Device.Open();
+
+                    if (ms == null)
+                    {
+                        _device.UpdateRuntimeProperties(errorMessage: "Cannot open MS9132 (video interface driver missing?)");
+                        await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+                        retryCount++;
+                        continue;
+                    }
+
+                    if (!ms.IsPanelConnected())
+                    {
+                        Logger.Warning("JonsboDevice {Device}: MS9132 reports no panel connected (reg 0x32)", _device);
+                        // Continue anyway — some firmware revisions may not report status.
+                    }
+
+                    ms.SetMode(_panelWidth, _panelHeight, modelInfo.Vic);
+                    _device.RuntimeProperties.Name = $"{modelInfo.Name} ({_panelWidth}x{_panelHeight})";
+                    _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
+
+                    retryCount = 0;
+                    await RunMs9132RenderSendLoop(ms, token);
+                }
+                catch (OperationCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "JonsboDevice {Device}: MS9132 error", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+                    retryCount++;
+                }
+                finally
+                {
+                    ms?.Dispose();
+                    _device.UpdateRuntimeProperties(isRunning: false);
+                }
+
+                if (!token.IsCancellationRequested)
+                    await Task.Delay(retryCount < 3 ? 1000 : 5000, token);
+            }
+        }
+
+        private async Task RunMs9132RenderSendLoop(JonsboMs9132Device ms, CancellationToken token)
+        {
+            FpsCounter fpsCounter = new(60);
+            var stopwatch = new Stopwatch();
+            byte[]? bgrBuffer = null;
+
+            while (!token.IsCancellationRequested)
+            {
+                stopwatch.Restart();
+
+                GenerateBgrFrame(ref bgrBuffer);
+                ms.SendFrame(bgrBuffer!, _panelWidth, _panelHeight);
+
+                fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+
+                var targetFrameTime = 1000 / Math.Max(1, _device.TargetFrameRate);
+                var remaining = targetFrameTime - (int)stopwatch.ElapsedMilliseconds;
+                if (remaining > 0) await Task.Delay(remaining, token);
+            }
+        }
+
+        /// <summary>
+        /// Renders the profile and converts to BGR888 at the panel's native portrait
+        /// resolution, reusing <paramref name="bgrBuffer"/> across frames.
+        /// </summary>
+        private void GenerateBgrFrame(ref byte[]? bgrBuffer)
+        {
+            int pixelCount = _panelWidth * _panelHeight;
+            bgrBuffer ??= new byte[pixelCount * 3];
+
+            SKBitmap? rendered = null;
+            try
+            {
+                if (ConfigModel.Instance.GetProfile(_device.ProfileGuid) is Profile profile)
+                {
+                    using var bitmap = PanelDrawTask.RenderSK(profile, false,
+                        colorType: SKColorType.Rgba8888,
+                        alphaType: SKAlphaType.Opaque);
+                    rendered = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, _device.Rotation);
+                }
+                else
+                {
+                    rendered = new SKBitmap(_panelWidth, _panelHeight, SKColorType.Rgba8888, SKAlphaType.Opaque);
+                    rendered.Erase(SKColors.Black);
+                }
+
+                float scale = Math.Clamp(_device.Brightness, 0, 100) / 100f;
+                bool dim = scale < 1f;
+
+                unsafe
+                {
+                    byte* src = (byte*)rendered.GetPixels().ToPointer();
+                    int srcRowBytes = rendered.RowBytes;
+                    fixed (byte* dstBase = bgrBuffer)
+                    {
+                        byte* dst = dstBase;
+                        for (int y = 0; y < _panelHeight; y++)
+                        {
+                            byte* row = src + y * srcRowBytes;
+                            for (int x = 0; x < _panelWidth; x++)
+                            {
+                                byte r = row[x * 4];      // Rgba8888: R,G,B,A
+                                byte g = row[x * 4 + 1];
+                                byte b = row[x * 4 + 2];
+                                if (dim)
+                                {
+                                    r = (byte)(r * scale);
+                                    g = (byte)(g * scale);
+                                    b = (byte)(b * scale);
+                                }
+                                // Wire format is BGR888 (DRM_FORMAT_RGB888 memory order)
+                                *dst++ = b;
+                                *dst++ = g;
+                                *dst++ = r;
+                            }
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                rendered?.Dispose();
+            }
+        }
+    }
+}

--- a/InfoPanel/Services/JonsboPanelTask.cs
+++ b/InfoPanel/Services/JonsboPanelTask.cs
@@ -1,0 +1,123 @@
+using InfoPanel.Models;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class JonsboPanelTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<JonsboPanelTask>();
+        private static readonly Lazy<JonsboPanelTask> _instance = new(() => new JonsboPanelTask());
+
+        private readonly ConcurrentDictionary<string, JonsboPanelDeviceTask> _deviceTasks = new();
+
+        public static JonsboPanelTask Instance => _instance.Value;
+
+        private JonsboPanelTask() { }
+
+        public override async Task StopAsync(bool shutdown = false)
+        {
+            await base.StopAsync(shutdown);
+            await StopAllDevices();
+        }
+
+        public async Task StartDevice(JonsboPanelDevice device)
+        {
+            if (_deviceTasks.TryGetValue(device.Id, out var task))
+            {
+                await task.StopAsync();
+                _deviceTasks.TryRemove(device.Id, out _);
+            }
+
+            var deviceTask = new JonsboPanelDeviceTask(device);
+            if (_deviceTasks.TryAdd(device.Id, deviceTask))
+            {
+                await deviceTask.StartAsync(CancellationToken);
+                Logger.Information("Started Jonsbo panel device {Device}", device);
+            }
+        }
+
+        public async Task StopDevice(string deviceId)
+        {
+            if (_deviceTasks.TryRemove(deviceId, out var deviceTask))
+            {
+                await deviceTask.StopAsync();
+                Logger.Information("Stopped Jonsbo panel device {DeviceId}", deviceId);
+            }
+        }
+
+        public async Task StopAllDevices()
+        {
+            var tasks = new List<Task>();
+            foreach (var kvp in _deviceTasks.ToList())
+            {
+                if (_deviceTasks.TryRemove(kvp.Key, out var deviceTask))
+                    tasks.Add(Task.Run(async () => await deviceTask.StopAsync()));
+            }
+            await Task.WhenAll(tasks);
+            Logger.Information("Stopped all Jonsbo panel devices");
+        }
+
+        public bool IsDeviceRunning(string deviceId)
+        {
+            return _deviceTasks.TryGetValue(deviceId, out var task) && task.IsRunning;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            await Task.Delay(300, token);
+
+            try
+            {
+                var settings = ConfigModel.Instance.Settings;
+                if (settings.JonsboPanelMultiDeviceMode)
+                    await RunMultiDeviceMode(token);
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception e)
+            {
+                Logger.Error(e, "JonsboPanel: Error in DoWorkAsync");
+            }
+        }
+
+        private async Task RunMultiDeviceMode(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var settings = ConfigModel.Instance.Settings;
+                    if (!settings.JonsboPanelMultiDeviceMode) break;
+
+                    var enabledConfigs = settings.JonsboPanelDevices.Where(d => d.Enabled).ToList();
+
+                    foreach (var config in enabledConfigs)
+                    {
+                        if (!IsDeviceRunning(config.Id))
+                            await StartDevice(config);
+                    }
+
+                    var runningDeviceIds = _deviceTasks.Keys.ToList();
+                    foreach (var deviceId in runningDeviceIds)
+                    {
+                        if (!enabledConfigs.Any(c => c.Id == deviceId))
+                            await StopDevice(deviceId);
+                    }
+
+                    await Task.Delay(1000, token);
+                }
+                catch (TaskCanceledException) { break; }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "JonsboPanel: Error in RunMultiDeviceMode");
+                    await Task.Delay(1000, token);
+                }
+            }
+        }
+    }
+}

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -1206,6 +1206,299 @@
         </ui:CardExpander>
         <!--  end ThermaltakePanel Multi-Device settings  -->
 
+        <!--  JonsboPanel Multi-Device settings (Jonsbo displays)  -->
+        <ui:CardExpander
+            Margin="0,10,0,0"
+            IsExpanded="True">
+            <ui:CardExpander.Icon>
+                <ui:SymbolIcon Symbol="Whiteboard24" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock
+                            FontSize="13"
+                            FontWeight="Medium"
+                            Text="Jonsbo" />
+                        <TextBlock
+                            Margin="0,5,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                            Text="Jonsbo DS916, DS339, and other Jonsbo displays." />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,10,0" Orientation="Horizontal">
+                            <ui:ToggleSwitch
+                                Grid.Column="1"
+                                Margin="0,0,10,0"
+                                IsChecked="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.JonsboPanelMultiDeviceMode}" />
+                        </StackPanel>
+                    </StackPanel>
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <ui:Button
+                        Grid.Column="1"
+                        Margin="0,0,0,0"
+                        HorizontalAlignment="Right"
+                        Appearance="Primary"
+                        Click="ButtonDiscoverJonsboPanelDevices_Click"
+                        Content="Discover Devices"
+                        Icon="{ui:SymbolIcon Search20}"
+                        Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.JonsboPanelMultiDeviceMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+
+                <!--  JonsboPanel Device List  -->
+                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.JonsboPanelDevices}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ui:CardControl Margin="0,0,0,10">
+                                <ui:CardControl.Header>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock FontSize="13" FontWeight="Medium">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0}">
+                                                        <Binding Path="RuntimeProperties.Name" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                                TextWrapping="Wrap">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                                        <Binding Path="DeviceId" />
+                                                        <Binding Path="DeviceLocation" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorTertiaryBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}Dimensions: {0}x{1}">
+                                                        <Binding Path="DisplayWidth" />
+                                                        <Binding Path="DisplayHeight" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <!--  Panel status when enabled  -->
+                                            <StackPanel Visibility="{Binding Enabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Orientation="Horizontal"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="Panel is running:" />
+                                                    <TextBlock
+                                                        Margin="10,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="{Binding RuntimeProperties.FrameRate, StringFormat='{}{0} FPS'}" />
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="LawnGreen"
+                                                        Text="{Binding RuntimeProperties.FrameTime, StringFormat=' @ {0}ms'}" />
+                                                </StackPanel>
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="Orange"
+                                                        Text="Display is not running. Check the COM port and connection." />
+                                                    <TextBlock
+                                                        FontSize="12"
+                                                        Foreground="Orange"
+                                                        Text="{Binding RuntimeProperties.ErrorMessage}"
+                                                        Visibility="{Binding RuntimeProperties.ErrorMessage, Converter={StaticResource StringToVisibilityConverter}}" />
+                                                </StackPanel>
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                </ui:CardControl.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <StackPanel Margin="10,0,0,0" VerticalAlignment="Top">
+                                        <ui:Button
+                                            Width="160"
+                                            Appearance="Secondary"
+                                            Click="ButtonAdvancedPopup_Click"
+                                            Content="Advanced"
+                                            Icon="{ui:SymbolIcon Settings20}" />
+                                        <Popup
+                                            AllowsTransparency="True"
+                                            Placement="Bottom"
+                                            StaysOpen="False">
+                                            <Border
+                                                Padding="15"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8">
+                                                <StackPanel Width="250">
+                                                    <!--  Brightness  -->
+                                                    <StackPanel>
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="0"
+                                                            TickFrequency="1"
+                                                            Value="{Binding Brightness}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Brightness" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding Brightness}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  Target FPS  -->
+                                                    <StackPanel Margin="0,10,0,0">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="60"
+                                                            Minimum="1"
+                                                            TickFrequency="1"
+                                                            Value="{Binding TargetFrameRate}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Target FPS" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding TargetFrameRate}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  JPEG Quality  -->
+                                                    <StackPanel Margin="0,10,0,0">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="50"
+                                                            TickFrequency="5"
+                                                            Value="{Binding JpegQuality}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="JPEG Quality" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding JpegQuality}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </StackPanel>
+                                    <StackPanel Margin="10,0,0,0">
+                                        <!--  Profile selection  -->
+                                        <ComboBox
+                                            Width="250"
+                                            Margin="0,0,0,0"
+                                            DisplayMemberPath="Name"
+                                            ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Profiles}"
+                                            SelectedValue="{Binding ProfileGuid}"
+                                            SelectedValuePath="Guid" />
+                                        <!--  Rotation  -->
+                                        <ComboBox
+                                            Margin="0,10,0,0"
+                                            ItemsSource="{Binding Path=ViewModel.RotationValues, RelativeSource={RelativeSource AncestorType=pages:UsbPanelsPage}}"
+                                            SelectedItem="{Binding Rotation}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Converter={StaticResource EnumToDescriptionConverter}}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <Grid Margin="20,0,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <!--  Enable toggle  -->
+                                        <ui:ToggleSwitch
+                                            Margin="0,0,0,0"
+                                            VerticalAlignment="Center"
+                                            IsChecked="{Binding Enabled}" />
+                                        <!--  Remove button  -->
+                                        <ui:Button
+                                            Grid.Row="1"
+                                            Width="32"
+                                            Height="32"
+                                            Margin="0,10,0,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Bottom"
+                                            Appearance="Danger"
+                                            BorderThickness="0"
+                                            Click="ButtonRemoveJonsboPanelDevice_Click"
+                                            Icon="{ui:SymbolIcon Delete20}"
+                                            Tag="{Binding}"
+                                            ToolTip="Remove Device" />
+                                    </Grid>
+                                </StackPanel>
+                            </ui:CardControl>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ui:CardExpander>
+        <!--  end JonsboPanel Multi-Device settings  -->
+
         <!--  Global Hotkeys  -->
         <ui:CardExpander Margin="0,20,0,0" IsExpanded="False">
             <ui:CardExpander.Icon>

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -4,6 +4,7 @@ using InfoPanel.Services;
 using InfoPanel.TuringPanel;
 using InfoPanel.ThermalrightPanel;
 using InfoPanel.ThermaltakePanel;
+using InfoPanel.JonsboPanel;
 using InfoPanel.ViewModels;
 using InfoPanel.Views.Windows;
 using LibUsbDotNet;
@@ -635,6 +636,91 @@ public partial class UsbPanelsPage : Page
                     }
 
                     settings.ThermaltakePanelDevices.Remove(deviceConfig);
+                }
+            });
+        }
+    }
+
+
+    // === Jonsbo Panel (DS916 / HLVMAX family) ===
+
+    private async void ButtonDiscoverJonsboPanelDevices_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button)
+        {
+            button.IsEnabled = false;
+            await UpdateJonsboPanelDeviceList();
+            button.IsEnabled = true;
+        }
+    }
+
+    private Task UpdateJonsboPanelDeviceList()
+    {
+        var discoveredDevices = JonsboPanelHelper.ScanDevices();
+
+        Logger.Information("JonsboPanel Discovery: Found {Count} devices", discoveredDevices.Count);
+
+        foreach (var discoveredDevice in discoveredDevices)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var device = settings.JonsboPanelDevices.FirstOrDefault(d =>
+                    d.IsMatching(discoveredDevice.DeviceId, discoveredDevice.DeviceLocation, discoveredDevice.Model));
+
+                if (device == null)
+                {
+                    var newDevice = new JonsboPanelDevice()
+                    {
+                        DeviceId = discoveredDevice.DeviceId,
+                        DeviceLocation = discoveredDevice.DeviceLocation,
+                        Model = discoveredDevice.Model,
+                        ProfileGuid = ConfigModel.Instance.Profiles.FirstOrDefault()?.Guid ?? Guid.Empty,
+                        TargetFrameRate = discoveredDevice.ModelInfo?.DefaultFrameRate ?? 25,
+                    };
+
+                    if (discoveredDevice.ModelInfo != null)
+                    {
+                        newDevice.RuntimeProperties.Name = discoveredDevice.ModelInfo.Name;
+                    }
+
+                    settings.JonsboPanelDevices.Add(newDevice);
+                    Logger.Information("JonsboPanel Discovery: Added new device '{DeviceId}' on {Port}",
+                        discoveredDevice.DeviceId, discoveredDevice.DeviceLocation);
+                }
+                else
+                {
+                    // COM port may have changed; refresh location.
+                    device.DeviceLocation = discoveredDevice.DeviceLocation;
+
+                    if (device.ModelInfo != null)
+                    {
+                        device.RuntimeProperties.Name = device.ModelInfo.Name;
+                    }
+
+                    Logger.Information("JonsboPanel Discovery: Device '{DeviceId}' already exists", discoveredDevice.DeviceId);
+                }
+            });
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void ButtonRemoveJonsboPanelDevice_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is JonsboPanelDevice runtimeDevice)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var deviceConfig = settings.JonsboPanelDevices.FirstOrDefault(c => c.Id == runtimeDevice.Id);
+
+                if (deviceConfig != null)
+                {
+                    if (JonsboPanelTask.Instance.IsDeviceRunning(deviceConfig.Id))
+                    {
+                        _ = JonsboPanelTask.Instance.StopDevice(deviceConfig.Id);
+                    }
+
+                    settings.JonsboPanelDevices.Remove(deviceConfig);
                 }
             });
         }


### PR DESCRIPTION
## Why?

Jonsbo ships two different USB displays, the DS916 (9.16", 1920x462) and the DS339 (960x376), with no third-party support anywhere. Their protocols were reverse-engineered from the decompiled OEM JONSBO-AIO app plus USB captures of it driving real hardware, and both are now confirmed working in InfoPanel on real panels.

## How?

A new **Jonsbo** panel category for their displays, with two transports behind one UI section, following the existing multi-device panel-task pattern.

### Supported panels

| Model | Resolution (native) | VID:PID | Transport | Frame format |
|-------|--------------------|---------|-----------|--------------|
| **Jonsbo DS916** | 462x1920 portrait | `33C3:F101` (Artinchip, "HLVMAX") | CDC ACM serial | raw JFIF JPEG |
| **Jonsbo DS339** | 376x960 portrait | `345F:9132` (MacroSilicon MS9132) | HID control + USB bulk | BGR888 raw frames |

### DS916 (HLVMAX serial)

- Handshake: write `F0 A5 5A 0F`, device replies with a 26-byte ASCII identity `VMAXB16` + `0462*1920` + serial. The device-reported resolution wins over the model database, so future HLVMAX SKUs work without code changes.
- Frames: one **raw JPEG** per frame: no envelope, no checksum, no keep-alive; the firmware ignores line coding entirely. The send loop resends the last frame after 1 s of static content (matching the OEM cadence) so the panel never falls back to its boot animation.

### DS339 (MacroSilicon MS9132 USB display)

- Control plane rides the **HID interface as 8-byte feature reports** (`A6` writes / `B5` reads) through the inbox HID driver, verified against the ms912x/ms9132 Linux drivers and replayed verbatim from the OEM capture: power on, input info (RGB888), output info with Jonsbo's custom **VIC 171** timing, video on.
- Frames go to bulk EP `0x04` on the vendor "msusb video" interface (bound to the OEM's libusb driver or WinUSB): 8-byte header (`FF 00`, x/16, y, width/16, height | `0x8000`) + BGR888 payload + `FF C0` trailer, in 64 KB chunks.
- Panel-connected status is read from register `0x32`; no hardware brightness op exists, so brightness is applied in-pixel.

### Integration

- `InfoPanel/JonsboPanel/` protocol layer (model database, WMI + HID discovery, serial and MS9132 device classes)
- `JonsboPanelTask` singleton + per-device `JonsboPanelDeviceTask` (render/send loops per transport)
- Settings/ConfigModel persistence and App lifecycle wiring identical to the other panel families
- New "Jonsbo" CardExpander on the USB Panels page: Discover, profile picker, rotation (defaults to 90° so landscape 1920x462 / 960x376 profiles fill the portrait panels out of the box), and an advanced popup with Brightness / Target FPS / JPEG quality

Confirmed working on real DS916 and DS339 hardware.

<sub>Generated with Claude Code</sub>

