### PR TITLE
Add configurable refresh interval for URL image sources

### DIFF
--- a/InfoPanel/Models/ImageDisplayItem.cs
+++ b/InfoPanel/Models/ImageDisplayItem.cs
@@ -146,6 +146,18 @@ namespace InfoPanel.Models
             }
         }
 
+        // Re-download interval for URL sources, in seconds. 0 = never (default).
+        // Lets webcams, rendered dashboards and other changing sources stay current.
+        private int _refreshInterval = 0;
+        public int RefreshInterval
+        {
+            get { return _refreshInterval; }
+            set
+            {
+                SetProperty(ref _refreshInterval, Math.Max(0, value));
+            }
+        }
+
         private bool _persistentCache = false;
         [System.Xml.Serialization.XmlIgnore]
         public bool PersistentCache

--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -124,6 +124,9 @@ namespace InfoPanel.Models
 
         public bool Loaded { get; private set; } = false;
 
+        /// <summary>When this image was created/downloaded. Used for the URL refresh interval.</summary>
+        public readonly DateTime LoadedAtUtc = DateTime.UtcNow;
+
         /// <summary>
         /// Creates a LockedImage backed by a plugin image proxy (shared memory).
         /// </summary>

--- a/InfoPanel/Utils/Cache.cs
+++ b/InfoPanel/Utils/Cache.cs
@@ -100,6 +100,19 @@ namespace InfoPanel
             // Check cache first
             if (ImageCache.TryGetValue(path, out LockedImage? cachedImage))
             {
+                // URL sources with a refresh interval get re-downloaded in the background;
+                // the current image keeps rendering until the replacement is ready.
+                if (cachedImage != null
+                    && imageDisplayItem?.RefreshInterval > 0
+                    && imageDisplayItem.Type != ImageDisplayItem.ImageType.RTSP
+                    && cachedImage.Type != LockedImage.ImageType.FFMPEG
+                    && path.IsUrl()
+                    && (DateTime.UtcNow - cachedImage.LoadedAtUtc).TotalSeconds >= imageDisplayItem.RefreshInterval
+                    && IsRefreshAttemptDue(path, imageDisplayItem.RefreshInterval))
+                {
+                    _ = Task.Run(() => RefreshImageSafe(path, imageDisplayItem));
+                }
+
                 return cachedImage;
             }
 
@@ -171,6 +184,69 @@ namespace InfoPanel
             ImageCache.Set(path, cachedImage, cacheOptions);
 
             Logger.Debug("Image '{Path}' loaded successfully (Persistent: {Persistent})", path, imageDisplayItem?.PersistentCache ?? false);
+        }
+
+        // Tracks the last refresh ATTEMPT per URL so a failing/slow source is retried at the
+        // configured interval instead of on every rendered frame.
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _lastRefreshAttempt = new();
+
+        private static bool IsRefreshAttemptDue(string path, int intervalSeconds)
+        {
+            if (_lastRefreshAttempt.TryGetValue(path, out var last)
+                && (DateTime.UtcNow - last).TotalSeconds < intervalSeconds)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        private static void RefreshImageSafe(string path, ImageDisplayItem imageDisplayItem)
+        {
+            // Skip silently if a load/refresh for this path is already in flight.
+            using var semLock = _locks.LockOrNull(path, 0);
+            if (semLock == null)
+            {
+                return;
+            }
+
+            _lastRefreshAttempt[path] = DateTime.UtcNow;
+
+            try
+            {
+                var refreshedImage = new LockedImage(path, imageDisplayItem);
+
+                var cacheOptions = new MemoryCacheEntryOptions
+                {
+                    PostEvictionCallbacks = {
+                        new PostEvictionCallbackRegistration
+                        {
+                            EvictionCallback = (key, value, reason, state) =>
+                            {
+                                Logger.Debug("Cache entry '{Key}' evicted due to {Reason}", key, reason);
+                                if (value is LockedImage lockedImage)
+                                {
+                                    lockedImage.Dispose();
+                                }
+                            }
+                        }
+                    }
+                };
+
+                if (imageDisplayItem.PersistentCache != true)
+                {
+                    cacheOptions.SlidingExpiration = TimeSpan.FromSeconds(10);
+                }
+
+                // Replacing the entry evicts (and disposes) the previous image.
+                ImageCache.Set(path, refreshedImage, cacheOptions);
+
+                Logger.Debug("Image '{Path}' refreshed (interval {Interval}s)", path, imageDisplayItem.RefreshInterval);
+            }
+            catch (Exception e)
+            {
+                // Keep serving the old image; next attempt after the interval elapses again.
+                Logger.Debug(e, "Failed to refresh image '{Path}', keeping cached copy", path);
+            }
         }
 
         public static void TouchImage(ImageDisplayItem imageDisplayItem)

--- a/InfoPanel/Views/Components/Image/ImageProperties.xaml
+++ b/InfoPanel/Views/Components/Image/ImageProperties.xaml
@@ -118,6 +118,25 @@
                                                         FontSize="12"
                                                         Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                                         Text="HTTP/HTTPS URL (tab to apply)" />
+                                                    <TextBlock
+                                                        Margin="5,10,0,0"
+                                                        FontSize="12"
+                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                        Text="Refresh every (s), 0 = never" />
+                                                    <ui:NumberBox
+                                                        Margin="0,3,0,0"
+                                                        FontSize="14"
+                                                        MaxDecimalPlaces="0"
+                                                        Minimum="0"
+                                                        SmallChange="1"
+                                                        Text="{Binding RefreshInterval}"
+                                                        Value="{Binding RefreshInterval}" />
+                                                    <TextBlock
+                                                        Margin="5,3,0,0"
+                                                        FontSize="12"
+                                                        Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                        TextWrapping="Wrap"
+                                                        Text="Re-downloads the image periodically for webcams, rendered dashboards and other changing sources." />
                                                 </StackPanel>
                                             </Grid>
                                         </DataTemplate>


### PR DESCRIPTION
## Why?

URL-sourced images are downloaded once into the image cache and never updated, so webcams, rendered dashboards, and other changing sources go permanently stale on the panel.

## How?

A per-item **"Refresh every (s), 0 = never"** setting in the image properties panel, shown only for URL sources.

- `ImageDisplayItem.RefreshInterval`: persisted per item, clamped to >= 0, default `0` keeps the existing download-once behavior.
- `LockedImage` records its creation time; on a cache hit for a URL source older than the interval, a **background re-download** starts while the current image keeps rendering. The cache entry is swapped only when the replacement is fully loaded, so there is no flicker or blank frame during refresh.
- Failed downloads keep serving the cached copy and retry only after a full interval (per-URL attempt tracking, so a dead webcam URL is not hammered on every rendered frame).
- RTSP/video sources are excluded; they already have their own live pipeline.
- Works with "Enable caching" on: the persistent cache entry is replaced in place at each interval.

<sub>Generated with Claude Code</sub>
