### PR TITLE
Add Lian Li LCD panel support

### DIFF
--- a/InfoPanel/App.xaml.cs
+++ b/InfoPanel/App.xaml.cs
@@ -403,6 +403,7 @@ namespace InfoPanel
             {
                 await BeadaPanelTask.Instance.StopAsync(true);
                 await TuringPanelTask.Instance.StopAsync(true);
+                await LianLiPanelTask.Instance.StopAsync(true);
                 await ThermalrightPanelTask.Instance.StopAsync(true);
                 await ThermaltakePanelTask.Instance.StopAsync(true);
             });
@@ -424,6 +425,7 @@ namespace InfoPanel
                     {
                         await BeadaPanelTask.Instance.StopAsync(true);
                         await TuringPanelTask.Instance.StopAsync(true);
+                        await LianLiPanelTask.Instance.StopAsync(true);
                         await ThermalrightPanelTask.Instance.StopAsync(true);
                         await ThermaltakePanelTask.Instance.StopAsync(true);
                     });
@@ -441,6 +443,11 @@ namespace InfoPanel
             if (ConfigModel.Instance.Settings.TuringPanelMultiDeviceMode)
             {
                 await TuringPanelTask.Instance.StartAsync();
+            }
+
+            if (ConfigModel.Instance.Settings.LianLiPanelMultiDeviceMode)
+            {
+                await LianLiPanelTask.Instance.StartAsync();
             }
 
             if (ConfigModel.Instance.Settings.ThermalrightPanelMultiDeviceMode)
@@ -464,6 +471,7 @@ namespace InfoPanel
         {
             await BeadaPanelTask.Instance.StopAsync();
             await TuringPanelTask.Instance.StopAsync();
+            await LianLiPanelTask.Instance.StopAsync();
             await ThermalrightPanelTask.Instance.StopAsync();
             await ThermaltakePanelTask.Instance.StopAsync();
         }

--- a/InfoPanel/InfoPanel.csproj
+++ b/InfoPanel/InfoPanel.csproj
@@ -262,6 +262,8 @@
 	  <ProjectReference Include="..\InfoPanel.Plugins.Loader\InfoPanel.Plugins.Loader.csproj" />
 	  <ProjectReference Include="..\InfoPanel.Plugins.Ipc\InfoPanel.Plugins.Ipc.csproj" />
 	  <ProjectReference Include="..\InfoPanel.Plugins.Host\InfoPanel.Plugins.Host.csproj" />
+	  <!-- Include InfoPanel.Extras in the restore graph. BuildExtras below still copies it to the bundled plugins directory. -->
+	  <ProjectReference Include="..\InfoPanel.Extras\InfoPanel.Extras.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/InfoPanel/LianLiPanel/LianLiPanelHelper.cs
+++ b/InfoPanel/LianLiPanel/LianLiPanelHelper.cs
@@ -1,0 +1,59 @@
+using InfoPanel.Models;
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace InfoPanel.LianLiPanel
+{
+    public static class LianLiPanelHelper
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(LianLiPanelHelper));
+
+        public static Task<List<LianLiPanelDevice>> GetUsbDevices()
+        {
+            try
+            {
+                List<LianLiPanelDevice> devices = [];
+
+                foreach (UsbRegistry deviceReg in UsbDevice.AllDevices)
+                {
+                    var modelInfo = LianLiPanelModelDatabase.GetModelByVidPid(deviceReg.Vid, deviceReg.Pid);
+                    if (modelInfo == null)
+                    {
+                        continue;
+                    }
+
+                    if (deviceReg.DeviceProperties["DeviceID"] is not string deviceId ||
+                        deviceReg.DeviceProperties["LocationInformation"] is not string deviceLocation)
+                    {
+                        Logger.Warning(
+                            "LianLiPanel Discovery: Skipping device with missing properties - DeviceID: '{DeviceId}', LocationInformation: '{DeviceLocation}'",
+                            deviceReg.DeviceProperties["DeviceID"],
+                            deviceReg.DeviceProperties["LocationInformation"]);
+                        continue;
+                    }
+
+                    Logger.Information("Found Lian Li panel device: {Name} at {Location} (ID: {DeviceId})",
+                        modelInfo.Name, deviceLocation, deviceId);
+
+                    devices.Add(new LianLiPanelDevice
+                    {
+                        DeviceId = deviceId,
+                        DeviceLocation = deviceLocation,
+                        Model = modelInfo.Model,
+                    });
+                }
+
+                return Task.FromResult(devices);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "LianLiPanelHelper: Error getting USB devices");
+                return Task.FromResult(new List<LianLiPanelDevice>());
+            }
+        }
+    }
+}

--- a/InfoPanel/LianLiPanel/LianLiPanelModel.cs
+++ b/InfoPanel/LianLiPanel/LianLiPanelModel.cs
@@ -1,0 +1,10 @@
+namespace InfoPanel.LianLiPanel
+{
+    public enum LianLiPanelModel
+    {
+        UniversalScreen88Inch,
+        UniversalScreen92Inch,
+        HydroShiftIIOledCurve,
+        HydroShiftIILcd,
+    }
+}

--- a/InfoPanel/LianLiPanel/LianLiPanelModelDatabase.cs
+++ b/InfoPanel/LianLiPanel/LianLiPanelModelDatabase.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace InfoPanel.LianLiPanel
+{
+    public static partial class LianLiPanelModelDatabase
+    {
+        public const int LianLiVendorId = 0x1cbe;
+
+        public static readonly Dictionary<LianLiPanelModel, LianLiPanelModelInfo> Models = new()
+        {
+            [LianLiPanelModel.UniversalScreen88Inch] = new LianLiPanelModelInfo
+            {
+                Model = LianLiPanelModel.UniversalScreen88Inch,
+                Name = "Lian Li Universal Screen 8.8\"",
+                Width = 480,
+                Height = 1920,
+                VendorId = LianLiVendorId,
+                ProductId = 0xa088,
+            },
+            [LianLiPanelModel.UniversalScreen92Inch] = new LianLiPanelModelInfo
+            {
+                Model = LianLiPanelModel.UniversalScreen92Inch,
+                Name = "Lian Li Universal Screen 9.2\"",
+                Width = 464,
+                Height = 1920,
+                VendorId = LianLiVendorId,
+                ProductId = 0xa092,
+            },
+            [LianLiPanelModel.HydroShiftIIOledCurve] = new LianLiPanelModelInfo
+            {
+                Model = LianLiPanelModel.HydroShiftIIOledCurve,
+                Name = "Lian Li HydroShift II OLED Curve",
+                Width = 2288,
+                Height = 1080,
+                VendorId = LianLiVendorId,
+                ProductId = 0xa068,
+            },
+            [LianLiPanelModel.HydroShiftIILcd] = new LianLiPanelModelInfo
+            {
+                Model = LianLiPanelModel.HydroShiftIILcd,
+                Name = "Lian Li HydroShift II LCD",
+                Width = 480,
+                Height = 480,
+                VendorId = LianLiVendorId,
+                ProductId = 0xa034,
+            },
+        };
+
+        public static LianLiPanelModelInfo? GetModelByVidPid(int vendorId, int productId)
+        {
+            return Models.Values.FirstOrDefault(m => m.VendorId == vendorId && m.ProductId == productId);
+        }
+
+        public static LianLiPanelModelInfo? GetModelByDeviceId(string? deviceId)
+        {
+            if (string.IsNullOrWhiteSpace(deviceId))
+            {
+                return null;
+            }
+
+            var match = VidPidRegex().Match(deviceId);
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            var vendorId = int.Parse(match.Groups[1].Value, System.Globalization.NumberStyles.HexNumber);
+            var productId = int.Parse(match.Groups[2].Value, System.Globalization.NumberStyles.HexNumber);
+            return GetModelByVidPid(vendorId, productId);
+        }
+
+        public static bool IsLianLiDeviceId(string? deviceId)
+        {
+            return GetModelByDeviceId(deviceId) != null;
+        }
+
+        [GeneratedRegex(@"VID_([0-9A-Fa-f]{4})&PID_([0-9A-Fa-f]{4})")]
+        private static partial Regex VidPidRegex();
+    }
+}

--- a/InfoPanel/LianLiPanel/LianLiPanelModelInfo.cs
+++ b/InfoPanel/LianLiPanel/LianLiPanelModelInfo.cs
@@ -1,0 +1,14 @@
+namespace InfoPanel.LianLiPanel
+{
+    public class LianLiPanelModelInfo
+    {
+        public LianLiPanelModel Model { get; init; }
+        public string Name { get; init; } = "Unknown Model";
+        public int Width { get; init; }
+        public int Height { get; init; }
+        public int VendorId { get; init; }
+        public int ProductId { get; init; }
+        public bool IsUsbDevice { get; init; } = true;
+        public bool RequiresPortraitRotationOffset { get; init; }
+    }
+}

--- a/InfoPanel/LianLiPanel/LianLiUsbScreenDevice.cs
+++ b/InfoPanel/LianLiPanel/LianLiUsbScreenDevice.cs
@@ -1,0 +1,328 @@
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Serilog;
+using System;
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace InfoPanel.LianLiPanel
+{
+    internal interface ILianLiUsbScreenDevice : IDisposable
+    {
+        bool Sync();
+        bool StopMedia();
+        bool SetBrightness(byte value);
+        bool DrawJpeg(byte[] imageBytes);
+    }
+
+    /// <summary>
+    /// Lian Li's LCD USB protocol expects the encrypted command packet and image
+    /// payload as one bulk transfer. Sending them separately can make these panels
+    /// accept a frame briefly and then stop responding.
+    /// </summary>
+    public sealed class LianLiUsbScreenDevice : ILianLiUsbScreenDevice
+    {
+        private static readonly ILogger Logger = Log.ForContext<LianLiUsbScreenDevice>();
+        private static readonly byte[] KeyIv = "slv3tuzx"u8.ToArray();
+        private static readonly DateTime AppStartTime = DateTime.Today.AddDays(-1.0);
+
+        private const int CommandSize = 500;
+        private const int PacketSize = 512;
+        private const int TimeoutMs = 2000;
+        private const int ImageAckTimeoutMs = 200;
+        private const int MaxImagePayload = 512_000;
+        private const byte GetVersionCommand = 10;
+        private const byte SetBrightnessCommand = 14;
+        private const byte SetFrameRateCommand = 15;
+        private const byte SyncClockCommand = 51;
+        private const byte StopClockCommand = 52;
+        private const byte PushJpegCommand = 101;
+        private const byte PushPngCommand = 102;
+        private const byte QueryBlockCommand = 122;
+        private const byte StopMediaCommand = 123;
+
+        private readonly UsbDevice _usbDevice;
+        private readonly UsbEndpointReader _reader;
+        private readonly UsbEndpointWriter _writer;
+        private readonly DES _des;
+        private readonly byte[] _commandBuffer = new byte[CommandSize];
+        private readonly byte[] _readBuffer = new byte[PacketSize];
+        private bool _disposed;
+
+        public LianLiUsbScreenDevice(UsbDevice usbDevice)
+        {
+            _usbDevice = usbDevice ?? throw new ArgumentNullException(nameof(usbDevice));
+
+            if (_usbDevice is IUsbDevice wholeUsbDevice)
+            {
+                wholeUsbDevice.SetConfiguration(1);
+                wholeUsbDevice.ClaimInterface(0);
+            }
+
+            _reader = _usbDevice.OpenEndpointReader(ReadEndpointID.Ep01);
+            _writer = _usbDevice.OpenEndpointWriter(WriteEndpointID.Ep01);
+
+            _des = DES.Create();
+            _des.Mode = CipherMode.CBC;
+            _des.Padding = PaddingMode.PKCS7;
+            _des.Key = KeyIv;
+            _des.IV = KeyIv;
+        }
+
+        public bool Sync() => RequestResponse(GetVersionCommand);
+
+        public bool SetBrightness(byte value)
+        {
+            PrepareCommandHeader(SetBrightnessCommand);
+            _commandBuffer[8] = value;
+            return RequestResponsePrepared();
+        }
+
+        public bool StopMedia() => RequestResponse(StopMediaCommand);
+
+        public bool SyncClockOnly()
+        {
+            var now = DateTime.Now;
+
+            PrepareCommandHeader(SyncClockCommand);
+            _commandBuffer[8] = (byte)(now.Year >> 8);
+            _commandBuffer[9] = (byte)(now.Year & 0xFF);
+            _commandBuffer[10] = (byte)now.Month;
+            _commandBuffer[11] = (byte)now.Day;
+            _commandBuffer[12] = (byte)now.Hour;
+            _commandBuffer[13] = (byte)now.Minute;
+            _commandBuffer[14] = (byte)now.Second;
+            _commandBuffer[15] = 2;
+
+            return RequestResponsePrepared();
+        }
+
+        public bool StopClock()
+        {
+            PrepareCommandHeader(StopClockCommand);
+            _commandBuffer[8] = 0;
+            return RequestResponsePrepared();
+        }
+
+        public bool DrawPngLayer(byte[] imageBytes)
+        {
+            if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
+
+            return DrawImageLayer(PushPngCommand, imageBytes);
+        }
+
+        public bool DrawJpegLayer(byte[] imageBytes)
+        {
+            if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
+
+            return DrawImageLayer(PushJpegCommand, imageBytes);
+        }
+
+        public bool DrawJpeg(byte[] imageBytes)
+        {
+            if (imageBytes == null) throw new ArgumentNullException(nameof(imageBytes));
+
+            // Main frames must target the JPEG/background layer. The PNG path is
+            // used only for clearing the overlay during initialization.
+            return DrawJpegLayer(imageBytes);
+        }
+
+        /// <summary>Set the panel frame rate. The Linux driver initializes this panel to 30 FPS.</summary>
+        public bool SetFrameRate(byte fps)
+        {
+            PrepareCommandHeader(SetFrameRateCommand);
+            _commandBuffer[8] = fps;
+            return RequestResponsePrepared();
+        }
+
+        /// <summary>
+        /// Query the device frame buffer level (cmd 122 / 0x7A).
+        /// Returns null when no response could be read.
+        /// </summary>
+        public byte? QueryBlock()
+        {
+            PrepareCommandHeader(QueryBlockCommand);
+            if (!RequestResponsePrepared(null, out var hasResponse) || !hasResponse)
+            {
+                return null;
+            }
+
+            return _readBuffer[8];
+        }
+
+        /// <summary>
+        /// Poll QueryBlock every 2ms until the device buffer level drains to
+        /// <paramref name="threshold"/> or below. Mirrors the Linux driver's
+        /// wait_buffer() (max ~2s).
+        /// </summary>
+        private void WaitForBufferDrain(byte threshold)
+        {
+            for (var i = 0; i < 1000; i++)
+            {
+                var level = QueryBlock();
+                if (level == null || level <= threshold)
+                {
+                    return;
+                }
+
+                System.Threading.Thread.Sleep(2);
+            }
+
+            Logger.Debug("LianLi buffer drain wait timed out after 2s");
+        }
+
+        private bool DrawImageLayer(byte commandId, byte[] imageBytes)
+        {
+            if (imageBytes.Length > MaxImagePayload)
+            {
+                Logger.Warning(
+                    "LianLi image payload {Length} exceeds device limit {Limit}, dropping frame",
+                    imageBytes.Length,
+                    MaxImagePayload);
+                return false;
+            }
+
+            PrepareCommandHeader(commandId);
+            BinaryPrimitives.WriteInt32BigEndian(_commandBuffer.AsSpan(8, 4), imageBytes.Length);
+            var ok = RequestResponsePrepared(imageBytes, out var hasResponse);
+
+            // Flow control: response byte [8] is the device buffer level. The
+            // Linux driver waits for it to drain below 2 whenever it exceeds 3.
+            if (ok && hasResponse && _readBuffer[8] > 3)
+            {
+                WaitForBufferDrain(2);
+            }
+
+            return ok;
+        }
+
+        private bool RequestResponse(byte commandId)
+        {
+            PrepareCommandHeader(commandId);
+            return RequestResponsePrepared();
+        }
+
+        private void PrepareCommandHeader(byte commandId)
+        {
+            Array.Clear(_commandBuffer, 0, _commandBuffer.Length);
+            _commandBuffer[0] = commandId;
+            _commandBuffer[2] = 26;
+            _commandBuffer[3] = 109;
+            var timestamp = unchecked((int)(DateTime.UtcNow - AppStartTime).TotalMilliseconds);
+            BinaryPrimitives.WriteInt32LittleEndian(_commandBuffer.AsSpan(4, 4), timestamp);
+        }
+
+        private byte[] EncryptCommandPacket()
+        {
+            var encryptedCommand = _des.EncryptCbc(_commandBuffer, KeyIv, PaddingMode.PKCS7);
+            var packet = new byte[PacketSize];
+            Buffer.BlockCopy(encryptedCommand, 0, packet, 0, Math.Min(encryptedCommand.Length, PacketSize - 2));
+            packet[510] = 161;
+            packet[511] = 26;
+            return packet;
+        }
+
+        private bool RequestResponsePrepared(byte[]? payload = null)
+        {
+            return RequestResponsePrepared(payload, out _);
+        }
+
+        private bool RequestResponsePrepared(byte[]? payload, out bool hasResponse)
+        {
+            hasResponse = false;
+            var commandPacket = EncryptCommandPacket();
+            byte[] writeBuffer;
+
+            if (payload == null || payload.Length == 0)
+            {
+                writeBuffer = commandPacket;
+            }
+            else
+            {
+                writeBuffer = new byte[PacketSize + payload.Length];
+                Buffer.BlockCopy(commandPacket, 0, writeBuffer, 0, PacketSize);
+                Buffer.BlockCopy(payload, 0, writeBuffer, PacketSize, payload.Length);
+            }
+
+            try
+            {
+                _reader.ReadFlush();
+
+                var errorCode = _writer.Write(writeBuffer, TimeoutMs, out var transferred);
+                if (errorCode != ErrorCode.None || transferred != writeBuffer.Length)
+                {
+                    Logger.Warning(
+                        "LianLi USB write failed: {ErrorCode}, transferred {Transferred}/{Expected}",
+                        errorCode,
+                        transferred,
+                        writeBuffer.Length);
+                    return false;
+                }
+
+                Array.Clear(_readBuffer, 0, _readBuffer.Length);
+                errorCode = _reader.Read(_readBuffer, payload == null ? TimeoutMs : ImageAckTimeoutMs, out transferred);
+                if (payload != null && errorCode == ErrorCode.IoTimedOut)
+                {
+                    // Lian Li's reference WinUsb.Read ignores the read result and returns
+                    // the zero-filled 512-byte buffer even when no response is available.
+                    // Image pushes commonly render successfully without a readable ACK.
+                    return true;
+                }
+
+                if (errorCode != ErrorCode.None || transferred != PacketSize)
+                {
+                    Logger.Warning(
+                        "LianLi USB read failed: {ErrorCode}, transferred {Transferred}/{Expected}",
+                        errorCode,
+                        transferred,
+                        PacketSize);
+                    return false;
+                }
+
+                hasResponse = true;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "LianLi USB request failed");
+                return false;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+
+            try
+            {
+                _reader?.Dispose();
+                _writer?.Dispose();
+
+                if (_usbDevice != null)
+                {
+                    if (_usbDevice.IsOpen)
+                    {
+                        if (_usbDevice is IUsbDevice wholeUsbDevice)
+                        {
+                            wholeUsbDevice.ReleaseInterface(0);
+                            wholeUsbDevice.ResetDevice();
+                        }
+
+                        _usbDevice.Close();
+                    }
+                }
+
+                UsbDevice.Exit();
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "Error during LianLi device disposal");
+            }
+            finally
+            {
+                _des.Dispose();
+            }
+        }
+    }
+}

--- a/InfoPanel/Models/ConfigModel.cs
+++ b/InfoPanel/Models/ConfigModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using InfoPanel.Models;
 using InfoPanel.Monitors;
 using InfoPanel.Services;
+using InfoPanel.LianLiPanel;
 using InfoPanel.TuringPanel;
 using Microsoft.Win32;
 using Microsoft.Win32.TaskScheduler;
@@ -442,6 +443,17 @@ namespace InfoPanel
                     await TuringPanelTask.Instance.StopAsync();
                 }
             }
+            else if (e.PropertyName == nameof(Settings.LianLiPanelMultiDeviceMode))
+            {
+                if (Settings.LianLiPanelMultiDeviceMode)
+                {
+                    await LianLiPanelTask.Instance.StartAsync();
+                }
+                else
+                {
+                    await LianLiPanelTask.Instance.StopAsync();
+                }
+            }
             else if (e.PropertyName == nameof(Settings.WebServer))
             {
                 if (Settings.WebServer)
@@ -690,9 +702,38 @@ namespace InfoPanel
                             Settings.TuringPanelMultiDeviceMode = settings.TuringPanelMultiDeviceMode;
 
                             Settings.TuringPanelDevices.Clear();
+                            Settings.LianLiPanelDevices.Clear();
                             foreach (var device in settings.TuringPanelDevices)
                             {
+                                var lianLiModelInfo = LianLiPanelModelDatabase.GetModelByDeviceId(device.DeviceId);
+                                if (lianLiModelInfo != null)
+                                {
+                                    Settings.LianLiPanelDevices.Add(new LianLiPanelDevice
+                                    {
+                                        DeviceId = device.DeviceId,
+                                        DeviceLocation = device.DeviceLocation,
+                                        Model = lianLiModelInfo.Model,
+                                        Enabled = device.Enabled,
+                                        ProfileGuid = device.ProfileGuid,
+                                        Rotation = device.Rotation,
+                                        Brightness = device.Brightness,
+                                        TargetFrameRate = device.TargetFrameRate,
+                                        JpegQuality = device.JpegQuality,
+                                    });
+                                    continue;
+                                }
+
                                 Settings.TuringPanelDevices.Add(device);
+                            }
+
+                            Settings.LianLiPanelMultiDeviceMode = settings.LianLiPanelMultiDeviceMode;
+
+                            foreach (var device in settings.LianLiPanelDevices)
+                            {
+                                if (!Settings.LianLiPanelDevices.Any(d => d.IsMatching(device.DeviceId)))
+                                {
+                                    Settings.LianLiPanelDevices.Add(device);
+                                }
                             }
 
                             // Load Thermalright panel settings

--- a/InfoPanel/Models/HotkeyBinding.cs
+++ b/InfoPanel/Models/HotkeyBinding.cs
@@ -16,7 +16,7 @@ namespace InfoPanel.Models
         private Key _key = Key.None;
 
         /// <summary>
-        /// Device type: "Beada", "Turing", or "Thermalright"
+        /// Device type: "Beada", "Turing", "LianLi", or "Thermalright"
         /// </summary>
         [ObservableProperty]
         private string _deviceType = string.Empty;
@@ -86,6 +86,10 @@ namespace InfoPanel.Models
                         })
                         .FirstOrDefault() ?? DeviceId,
                     "Turing" => ConfigModel.Instance.Settings.TuringPanelDevices
+                        .Where(d => d.DeviceId == DeviceId)
+                        .Select(d => d.Name ?? d.DeviceId)
+                        .FirstOrDefault() ?? DeviceId,
+                    "LianLi" => ConfigModel.Instance.Settings.LianLiPanelDevices
                         .Where(d => d.DeviceId == DeviceId)
                         .Select(d => d.Name ?? d.DeviceId)
                         .FirstOrDefault() ?? DeviceId,

--- a/InfoPanel/Models/LianLiPanelDevice.cs
+++ b/InfoPanel/Models/LianLiPanelDevice.cs
@@ -1,0 +1,138 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using InfoPanel.LianLiPanel;
+using InfoPanel.ViewModels;
+using Serilog;
+using System;
+using System.Windows.Threading;
+
+namespace InfoPanel.Models
+{
+    public partial class LianLiPanelDevice : ObservableObject
+    {
+        private static readonly ILogger Logger = Log.ForContext<LianLiPanelDevice>();
+
+        [ObservableProperty]
+        private string _deviceId = string.Empty;
+
+        [ObservableProperty]
+        private string _deviceLocation = string.Empty;
+
+        [ObservableProperty]
+        private LianLiPanelModel _model = LianLiPanelModel.UniversalScreen88Inch;
+
+        partial void OnModelChanged(LianLiPanelModel value)
+        {
+            OnPropertyChanged(nameof(Name));
+            OnPropertyChanged(nameof(ModelInfo));
+            OnPropertyChanged(nameof(DisplayWidth));
+            OnPropertyChanged(nameof(DisplayHeight));
+        }
+
+        public string Name => ModelInfo?.Name ?? "Unknown Lian Li Panel";
+
+        public LianLiPanelModelInfo? ModelInfo =>
+            LianLiPanelModelDatabase.Models.TryGetValue(Model, out var info) ? info : null;
+
+        public int DisplayWidth => ModelInfo?.Width ?? 0;
+        public int DisplayHeight => ModelInfo?.Height ?? 0;
+
+        [ObservableProperty]
+        private bool _enabled = false;
+
+        [ObservableProperty]
+        private Guid _profileGuid = Guid.Empty;
+
+        [ObservableProperty]
+        private LCD_ROTATION _rotation = LCD_ROTATION.RotateNone;
+
+        [ObservableProperty]
+        private int _brightness = 100;
+
+        [ObservableProperty]
+        private int _targetFrameRate = 30;
+
+        [ObservableProperty]
+        private int _jpegQuality = 90;
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private string _id = Guid.NewGuid().ToString();
+
+        [ObservableProperty]
+        [property: System.Xml.Serialization.XmlIgnore]
+        private LianLiPanelDeviceRuntimeProperties _runtimeProperties;
+
+        public LianLiPanelDevice()
+        {
+            _runtimeProperties = new();
+        }
+
+        public bool IsMatching(string deviceId)
+        {
+            var matched = !string.IsNullOrEmpty(deviceId) &&
+                DeviceId.Equals(deviceId, StringComparison.OrdinalIgnoreCase);
+
+            Logger.Debug("Lian Li panel device match result: {Matched}, DeviceId: {DeviceId}",
+                matched, DeviceId);
+
+            return matched;
+        }
+
+        private DateTime _lastUpdate = DateTime.MinValue;
+        private readonly TimeSpan _throttleInterval = TimeSpan.FromSeconds(1);
+
+        public void UpdateRuntimeProperties(bool? isRunning = null, int? frameRate = null, long? frameTime = null, string? errorMessage = null)
+        {
+            var now = DateTime.UtcNow;
+
+            if (isRunning != null || errorMessage != null)
+            {
+                _lastUpdate = now;
+                DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+                return;
+            }
+
+            if (now - _lastUpdate < _throttleInterval)
+            {
+                return;
+            }
+
+            _lastUpdate = now;
+            DispatchUpdate(isRunning, frameRate, frameTime, errorMessage);
+        }
+
+        private void DispatchUpdate(bool? isRunning, int? frameRate, long? frameTime, string? errorMessage)
+        {
+            if (System.Windows.Application.Current?.Dispatcher is Dispatcher dispatcher)
+            {
+                dispatcher.BeginInvoke(() =>
+                {
+                    if (isRunning != null) RuntimeProperties.IsRunning = isRunning.Value;
+                    if (frameRate != null) RuntimeProperties.FrameRate = frameRate.Value;
+                    if (frameTime != null) RuntimeProperties.FrameTime = frameTime.Value;
+                    if (errorMessage != null) RuntimeProperties.ErrorMessage = errorMessage;
+                });
+            }
+        }
+
+        public override string ToString()
+        {
+            return $"LianLiPanel {DeviceId}";
+        }
+
+        public partial class LianLiPanelDeviceRuntimeProperties : ObservableObject
+        {
+            [ObservableProperty]
+            private bool _isRunning = false;
+
+            [ObservableProperty]
+            private int _frameRate = 0;
+
+            [ObservableProperty]
+            private long _frameTime = 0;
+
+            [ObservableProperty]
+            private string _errorMessage = string.Empty;
+        }
+    }
+}

--- a/InfoPanel/Models/Settings.cs
+++ b/InfoPanel/Models/Settings.cs
@@ -73,6 +73,13 @@ namespace InfoPanel.Models
         [ObservableProperty]
         private bool _turingPanelMultiDeviceMode = false;
 
+        private readonly ObservableCollection<LianLiPanelDevice> _lianLiPanelDevices = [];
+
+        public ObservableCollection<LianLiPanelDevice> LianLiPanelDevices => _lianLiPanelDevices;
+
+        [ObservableProperty]
+        private bool _lianLiPanelMultiDeviceMode = false;
+
         private readonly ObservableCollection<ThermalrightPanelDevice> _thermalrightPanelDevices = [];
 
         public ObservableCollection<ThermalrightPanelDevice> ThermalrightPanelDevices
@@ -138,6 +145,7 @@ namespace InfoPanel.Models
         {
             BeadaPanelDevices.CollectionChanged += BeadaPanelDevices_CollectionChanged;
             TuringPanelDevices.CollectionChanged += TuringPanelDevices_CollectionChanged;
+            LianLiPanelDevices.CollectionChanged += LianLiPanelDevices_CollectionChanged;
             ThermalrightPanelDevices.CollectionChanged += ThermalrightPanelDevices_CollectionChanged;
             ThermaltakePanelDevices.CollectionChanged += ThermaltakePanelDevices_CollectionChanged;
         }
@@ -182,6 +190,27 @@ namespace InfoPanel.Models
         {
             if (e.PropertyName != nameof(TuringPanelDevice.RuntimeProperties))
                 OnPropertyChanged(nameof(TuringPanelDevices));
+        }
+
+        private void LianLiPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+            {
+                foreach (LianLiPanelDevice device in e.OldItems)
+                    device.PropertyChanged -= LianLiDevice_PropertyChanged;
+            }
+            if (e.NewItems != null)
+            {
+                foreach (LianLiPanelDevice device in e.NewItems)
+                    device.PropertyChanged += LianLiDevice_PropertyChanged;
+            }
+            OnPropertyChanged(nameof(LianLiPanelDevices));
+        }
+
+        private void LianLiDevice_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName != nameof(LianLiPanelDevice.RuntimeProperties))
+                OnPropertyChanged(nameof(LianLiPanelDevices));
         }
 
         private void ThermalrightPanelDevices_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)

--- a/InfoPanel/Services/GlobalHotkeyService.cs
+++ b/InfoPanel/Services/GlobalHotkeyService.cs
@@ -213,6 +213,18 @@ namespace InfoPanel.Services
                     }
                     break;
 
+                case "LianLi":
+                    foreach (var device in ConfigModel.Instance.Settings.LianLiPanelDevices)
+                    {
+                        if (device.DeviceId == binding.DeviceId)
+                        {
+                            device.ProfileGuid = binding.ProfileGuid;
+                            Logger.Information("Switched Lian Li device {Device} to profile {Profile}", device.DeviceId, profile.Name);
+                            return;
+                        }
+                    }
+                    break;
+
                 case "Thermalright":
                     foreach (var device in ConfigModel.Instance.Settings.ThermalrightPanelDevices)
                     {

--- a/InfoPanel/Services/LianLiPanelDeviceTask.cs
+++ b/InfoPanel/Services/LianLiPanelDeviceTask.cs
@@ -1,0 +1,356 @@
+using InfoPanel.Extensions;
+using InfoPanel.LianLiPanel;
+using InfoPanel.Models;
+using InfoPanel.Utils;
+using InfoPanel.ViewModels;
+using LibUsbDotNet;
+using LibUsbDotNet.Main;
+using Serilog;
+using SkiaSharp;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class LianLiPanelDeviceTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<LianLiPanelDeviceTask>();
+        private readonly LianLiPanelDevice _device;
+        private readonly int _panelWidth;
+        private readonly int _panelHeight;
+        private LCD_ROTATION? _lastLoggedRotation;
+
+        public LianLiPanelDeviceTask(LianLiPanelDevice device)
+        {
+            _device = device ?? throw new ArgumentNullException(nameof(device));
+
+            if (device.ModelInfo == null)
+            {
+                throw new ArgumentException("Device model info cannot be null", nameof(device));
+            }
+
+            _panelWidth = device.ModelInfo.Width;
+            _panelHeight = device.ModelInfo.Height;
+        }
+
+        public byte[]? GenerateLcdBuffer()
+        {
+            var profileGuid = _device.ProfileGuid;
+
+            if (ConfigModel.Instance.GetProfile(profileGuid) is Profile profile)
+            {
+                var rotation = GetDeviceRotation();
+
+                if (_lastLoggedRotation != rotation)
+                {
+                    _lastLoggedRotation = rotation;
+                    Logger.Information("LianLiPanelDevice {Device}: Rotation changed. UI setting={UISetting}, mapped rotation={MappedRotation}",
+                        _device.Id, _device.Rotation, rotation);
+                }
+
+                using var bitmap = PanelDrawTask.RenderSK(profile, false);
+                using var resizedBitmap = SKBitmapExtensions.EnsureBitmapSize(bitmap, _panelWidth, _panelHeight, rotation);
+                using var pixmap = resizedBitmap.PeekPixels();
+                using var data = pixmap.Encode(SKEncodedImageFormat.Jpeg, _device.JpegQuality);
+
+                if (data == null || data.IsEmpty)
+                {
+                    Logger.Error("LianLiPanelDevice {Device}: Failed to encode bitmap to JPEG", _device);
+                    return null;
+                }
+
+                return data.ToArray();
+            }
+
+            return null;
+        }
+
+        private LCD_ROTATION GetDeviceRotation()
+        {
+            if (_device.ModelInfo?.RequiresPortraitRotationOffset != true)
+            {
+                return _device.Rotation;
+            }
+
+            return _device.Rotation switch
+            {
+                LCD_ROTATION.RotateNone => LCD_ROTATION.Rotate90FlipNone,
+                LCD_ROTATION.Rotate90FlipNone => LCD_ROTATION.Rotate180FlipNone,
+                LCD_ROTATION.Rotate180FlipNone => LCD_ROTATION.Rotate270FlipNone,
+                LCD_ROTATION.Rotate270FlipNone => LCD_ROTATION.RotateNone,
+                _ => _device.Rotation
+            };
+        }
+
+        private static byte[] EncodeSolidFrame(int width, int height, SKColor color, SKEncodedImageFormat format, int quality)
+        {
+            using var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul));
+            bitmap.Erase(color);
+
+            using var pixmap = bitmap.PeekPixels();
+            using var data = pixmap.Encode(format, quality);
+            return data?.ToArray() ?? Array.Empty<byte>();
+        }
+
+        private void PrepareImageLayers(LianLiUsbScreenDevice screenDevice)
+        {
+            try
+            {
+                var syncClockOk = screenDevice.SyncClockOnly();
+                Thread.Sleep(50);
+
+                var stopClockOk = screenDevice.StopClock();
+                Thread.Sleep(50);
+
+                var clearPng = EncodeSolidFrame(_panelWidth, _panelHeight, SKColors.Transparent, SKEncodedImageFormat.Png, 100);
+                var clearPngOk = clearPng.Length > 0 && screenDevice.DrawPngLayer(clearPng);
+                Thread.Sleep(50);
+
+                var clearJpeg = EncodeSolidFrame(_panelWidth, _panelHeight, SKColors.Black, SKEncodedImageFormat.Jpeg, 95);
+                var clearJpegOk = clearJpeg.Length > 0 && screenDevice.DrawJpegLayer(clearJpeg);
+                Thread.Sleep(50);
+
+                var frameRateOk = screenDevice.SetFrameRate((byte)_device.TargetFrameRate);
+
+                Logger.Information(
+                    "LianLiPanelDevice {Device}: Prep sequence results: SyncClockOnly={SyncClockOk}, StopClock={StopClockOk}, ClearPng={ClearPngOk} ({ClearPngBytes} bytes), ClearJpeg={ClearJpegOk} ({ClearJpegBytes} bytes), SetFrameRate={FrameRateOk}",
+                    _device,
+                    syncClockOk,
+                    stopClockOk,
+                    clearPngOk,
+                    clearPng.Length,
+                    clearJpegOk,
+                    clearJpeg.Length,
+                    frameRateOk);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "LianLiPanelDevice {Device}: Prep sequence failed", _device);
+            }
+        }
+
+        private Task<UsbRegistry?> FindTargetDeviceAsync()
+        {
+            if (_device.ModelInfo == null)
+            {
+                Logger.Error("LianLiPanelDevice {Device}: ModelInfo is null", _device);
+                return Task.FromResult<UsbRegistry?>(null);
+            }
+
+            foreach (UsbRegistry deviceReg in UsbDevice.AllDevices)
+            {
+                if (deviceReg.Vid == _device.ModelInfo.VendorId && deviceReg.Pid == _device.ModelInfo.ProductId)
+                {
+                    var deviceId = deviceReg.DeviceProperties["DeviceID"] as string;
+
+                    if (string.IsNullOrEmpty(deviceId))
+                    {
+                        Logger.Debug("LianLiPanelDevice {Device}: Unable to get DeviceId for device {DevicePath}", _device, deviceReg.DevicePath);
+                        continue;
+                    }
+
+                    if (_device.IsMatching(deviceId))
+                    {
+                        Logger.Information("LianLiPanelDevice {Device}: Found matching device with DeviceId {DeviceId}", _device, deviceId);
+                        return Task.FromResult<UsbRegistry?>(deviceReg);
+                    }
+                }
+            }
+
+            return Task.FromResult<UsbRegistry?>(null);
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            await Task.Delay(300, token);
+
+            try
+            {
+                var usbRegistry = await FindTargetDeviceAsync();
+
+                if (usbRegistry == null)
+                {
+                    Logger.Warning("LianLiPanelDevice {Device}: USB device not found.", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: "Device not found");
+                    return;
+                }
+
+                if (!usbRegistry.Open(out var usbDevice))
+                {
+                    Logger.Error("LianLiPanelDevice {Device}: Failed to open USB device", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: "Failed to open USB device");
+                    return;
+                }
+
+                using var screenDevice = new LianLiUsbScreenDevice(usbDevice);
+
+                Logger.Information("LianLiPanelDevice {Device}: Initialized successfully", _device);
+                _device.UpdateRuntimeProperties(isRunning: true, errorMessage: string.Empty);
+
+                try
+                {
+                    if (!screenDevice.Sync())
+                    {
+                        Logger.Warning("LianLiPanelDevice {Device}: Sync failed (1st attempt), device not ready", _device);
+                        _device.UpdateRuntimeProperties(errorMessage: "Device not ready (sync failed)");
+                        return;
+                    }
+                    Thread.Sleep(200);
+
+                    if (!screenDevice.Sync())
+                    {
+                        Logger.Warning("LianLiPanelDevice {Device}: Sync failed (2nd attempt), device not ready", _device);
+                        _device.UpdateRuntimeProperties(errorMessage: "Device not ready (sync failed)");
+                        return;
+                    }
+                    Thread.Sleep(200);
+
+                    screenDevice.StopMedia();
+                    Thread.Sleep(200);
+
+                    PrepareImageLayers(screenDevice);
+                    Thread.Sleep(200);
+
+                    var brightness = _device.Brightness;
+                    screenDevice.SetBrightness((byte)brightness);
+
+                    if (!screenDevice.Sync())
+                    {
+                        Logger.Warning("LianLiPanelDevice {Device}: Sync failed after brightness set, device not ready", _device);
+                        _device.UpdateRuntimeProperties(errorMessage: "Device not ready (sync failed)");
+                        return;
+                    }
+                    Thread.Sleep(200);
+
+                    FpsCounter fpsCounter = new(60);
+                    byte[]? latestFrame = null;
+                    AutoResetEvent frameAvailable = new(false);
+
+                    var renderCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                    var renderToken = renderCts.Token;
+
+                    var renderTask = Task.Run(async () =>
+                    {
+                        Thread.CurrentThread.Name ??= $"LianLiPanel-Render-{_device.DeviceId}";
+                        var stopwatch = new Stopwatch();
+
+                        while (!renderToken.IsCancellationRequested)
+                        {
+                            stopwatch.Restart();
+                            var frame = GenerateLcdBuffer();
+
+                            if (frame != null)
+                            {
+                                Interlocked.Exchange(ref latestFrame, frame);
+                                frameAvailable.Set();
+                            }
+
+                            var targetFrameTime = 1000 / Math.Max(1, _device.TargetFrameRate);
+                            var desiredFrameTime = Math.Max((int)fpsCounter.FrameTime, targetFrameTime);
+                            var elapsedMs = (int)stopwatch.ElapsedMilliseconds;
+                            var adaptiveFrameTime = desiredFrameTime - elapsedMs;
+
+                            if (adaptiveFrameTime > 0)
+                            {
+                                await Task.Delay(adaptiveFrameTime, renderToken);
+                            }
+                        }
+                    }, renderToken);
+
+                    var sendTask = Task.Run(() =>
+                    {
+                        Thread.CurrentThread.Name ??= $"LianLiPanel-Send-{_device.DeviceId}";
+                        try
+                        {
+                            var stopwatch = new Stopwatch();
+
+                            while (!token.IsCancellationRequested)
+                            {
+                                if (brightness != _device.Brightness)
+                                {
+                                    brightness = _device.Brightness;
+                                    screenDevice.SetBrightness((byte)brightness);
+                                    if (!screenDevice.Sync())
+                                    {
+                                        Logger.Warning("LianLiPanelDevice {Device}: Sync failed during brightness update", _device);
+                                        _device.UpdateRuntimeProperties(errorMessage: "Sync failed");
+                                        break;
+                                    }
+                                    Thread.Sleep(200);
+                                }
+
+                                if (frameAvailable.WaitOne(100))
+                                {
+                                    var frame = Interlocked.Exchange(ref latestFrame, null);
+                                    if (frame != null)
+                                    {
+                                        stopwatch.Restart();
+                                        if (!screenDevice.DrawJpeg(frame))
+                                        {
+                                            Logger.Warning("LianLiPanelDevice {Device}: DrawJpeg failed", _device);
+                                            _device.UpdateRuntimeProperties(errorMessage: "Draw failed");
+                                            break;
+                                        }
+
+                                        fpsCounter.Update(stopwatch.ElapsedMilliseconds);
+                                        _device.UpdateRuntimeProperties(frameRate: fpsCounter.FramesPerSecond, frameTime: fpsCounter.FrameTime);
+                                    }
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.Error(ex, "LianLiPanelDevice {Device}: Error in send task", _device);
+                        }
+                        finally
+                        {
+                            renderCts.Cancel();
+                        }
+                    }, token);
+
+                    await Task.WhenAll(renderTask, sendTask);
+                }
+                catch (TaskCanceledException)
+                {
+                    Logger.Debug("LianLiPanelDevice {Device}: Task cancelled", _device);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "LianLiPanelDevice {Device}: Exception during work", _device);
+                    _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+                }
+                finally
+                {
+                    try
+                    {
+                        screenDevice.StopMedia();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "LianLiPanelDevice {Device}: Exception when stopping media", _device);
+                    }
+
+                    try
+                    {
+                        screenDevice.SetBrightness(0);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "LianLiPanelDevice {Device}: Exception when setting brightness to 0", _device);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning(ex, "LianLiPanelDevice {Device}: Init error", _device);
+                _device.UpdateRuntimeProperties(errorMessage: ex.Message);
+            }
+            finally
+            {
+                _device.UpdateRuntimeProperties(isRunning: false);
+            }
+        }
+    }
+}

--- a/InfoPanel/Services/LianLiPanelTask.cs
+++ b/InfoPanel/Services/LianLiPanelTask.cs
@@ -1,0 +1,138 @@
+using InfoPanel.Models;
+using Serilog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace InfoPanel.Services
+{
+    public sealed class LianLiPanelTask : BackgroundTask
+    {
+        private static readonly ILogger Logger = Log.ForContext<LianLiPanelTask>();
+        private static readonly Lazy<LianLiPanelTask> _instance = new(() => new LianLiPanelTask());
+
+        private readonly ConcurrentDictionary<string, LianLiPanelDeviceTask> _deviceTasks = new();
+
+        public static LianLiPanelTask Instance => _instance.Value;
+
+        private LianLiPanelTask() { }
+
+        public override async Task StopAsync(bool shutdown = false)
+        {
+            await base.StopAsync(shutdown);
+            await StopAllDevices();
+        }
+
+        public async Task StartDevice(LianLiPanelDevice device)
+        {
+            if (_deviceTasks.TryGetValue(device.Id, out var task))
+            {
+                await task.StopAsync();
+                _deviceTasks.TryRemove(device.Id, out _);
+            }
+
+            var deviceTask = new LianLiPanelDeviceTask(device);
+            if (_deviceTasks.TryAdd(device.Id, deviceTask))
+            {
+                await deviceTask.StartAsync(CancellationToken);
+                Logger.Information("Started Lian Li panel device {Device}", device);
+            }
+        }
+
+        public async Task StopDevice(string deviceId)
+        {
+            if (_deviceTasks.TryRemove(deviceId, out var deviceTask))
+            {
+                await deviceTask.StopAsync();
+                Logger.Information("Stopped Lian Li panel device {DeviceId}", deviceId);
+            }
+        }
+
+        public async Task StopAllDevices()
+        {
+            var tasks = new List<Task>();
+            foreach (var kvp in _deviceTasks.ToList())
+            {
+                if (_deviceTasks.TryRemove(kvp.Key, out var deviceTask))
+                {
+                    tasks.Add(Task.Run(async () => await deviceTask.StopAsync()));
+                }
+            }
+
+            await Task.WhenAll(tasks);
+            Logger.Information("Stopped all Lian Li panel devices");
+        }
+
+        public bool IsDeviceRunning(string deviceId)
+        {
+            return _deviceTasks.TryGetValue(deviceId, out var task) && task.IsRunning;
+        }
+
+        protected override async Task DoWorkAsync(CancellationToken token)
+        {
+            await Task.Delay(300, token);
+
+            try
+            {
+                var settings = ConfigModel.Instance.Settings;
+                if (settings.LianLiPanelMultiDeviceMode)
+                {
+                    await RunMultiDeviceMode(token);
+                }
+            }
+            catch (TaskCanceledException) { }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "LianLiPanel: Error in DoWorkAsync");
+            }
+        }
+
+        private async Task RunMultiDeviceMode(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                try
+                {
+                    var settings = ConfigModel.Instance.Settings;
+                    if (!settings.LianLiPanelMultiDeviceMode)
+                    {
+                        break;
+                    }
+
+                    var enabledConfigs = settings.LianLiPanelDevices.Where(d => d.Enabled).ToList();
+
+                    foreach (var config in enabledConfigs)
+                    {
+                        if (!IsDeviceRunning(config.Id))
+                        {
+                            await StartDevice(config);
+                        }
+                    }
+
+                    var runningDeviceIds = _deviceTasks.Keys.ToList();
+                    foreach (var deviceId in runningDeviceIds)
+                    {
+                        if (!enabledConfigs.Any(c => c.Id == deviceId))
+                        {
+                            await StopDevice(deviceId);
+                        }
+                    }
+
+                    await Task.Delay(1000, token);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "LianLiPanel: Error in RunMultiDeviceMode");
+                    await Task.Delay(1000, token);
+                }
+            }
+        }
+    }
+}

--- a/InfoPanel/ViewModels/UsbPanelsViewModel.cs
+++ b/InfoPanel/ViewModels/UsbPanelsViewModel.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using InfoPanel.LianLiPanel;
 using InfoPanel.Models;
 using InfoPanel.ThermalrightPanel;
 using System;
@@ -6,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Data;
 using Wpf.Ui.Abstractions.Controls;
 
 namespace InfoPanel.ViewModels;
@@ -26,11 +28,21 @@ public partial class UsbPanelsViewModel : ObservableObject, INavigationAware
 {
     public ObservableCollection<LCD_ROTATION> RotationValues { get; set; }
     public ObservableCollection<ThermalrightDisplayMask> DisplayMaskValues { get; set; }
+    private readonly CollectionViewSource _turingCvs = new();
 
     public UsbPanelsViewModel()
     {
         RotationValues = new ObservableCollection<LCD_ROTATION>(Enum.GetValues(typeof(LCD_ROTATION)).Cast<LCD_ROTATION>());
         DisplayMaskValues = new ObservableCollection<ThermalrightDisplayMask>(Enum.GetValues(typeof(ThermalrightDisplayMask)).Cast<ThermalrightDisplayMask>());
+
+        _turingCvs.Source = ConfigModel.Instance.Settings.TuringPanelDevices;
+        _turingCvs.Filter += (_, e) =>
+        {
+            e.Accepted = e.Item is TuringPanelDevice device &&
+                !LianLiPanelModelDatabase.IsLianLiDeviceId(device.DeviceId);
+        };
+
+        ConfigModel.Instance.Settings.TuringPanelDevices.CollectionChanged += (_, _) => _turingCvs.View?.Refresh();
     }
 
     public ObservableCollection<BeadaPanelDevice> RuntimeBeadaPanelDevices
@@ -38,9 +50,11 @@ public partial class UsbPanelsViewModel : ObservableObject, INavigationAware
         get { return ConfigModel.Instance.Settings.BeadaPanelDevices; }
     }
 
-    public ObservableCollection<TuringPanelDevice> RuntimeTuringPanelDevices
+    public ICollectionView RuntimeTuringPanelDevices => _turingCvs.View;
+
+    public ObservableCollection<LianLiPanelDevice> RuntimeLianLiPanelDevices
     {
-        get { return ConfigModel.Instance.Settings.TuringPanelDevices; }
+        get { return ConfigModel.Instance.Settings.LianLiPanelDevices; }
     }
 
     public Task OnNavigatedFromAsync()

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml
@@ -315,7 +315,7 @@
                 </Grid>
 
                 <!--  TuringPanel Device List  -->
-                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.TuringPanelDevices}">
+                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding ViewModel.RuntimeTuringPanelDevices}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
                             <ui:CardControl Margin="0,0,0,10">
@@ -352,7 +352,7 @@
                                                 FontSize="12"
                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}">
                                                 <TextBlock.Text>
-                                                    <MultiBinding StringFormat="{}Dimensions: {0}×{1}">
+                                                    <MultiBinding StringFormat="{}Dimensions: {0}x{1}">
                                                         <Binding Path="ModelInfo.Width" />
                                                         <Binding Path="ModelInfo.Height" />
                                                     </MultiBinding>
@@ -457,7 +457,7 @@
                                                                 Visibility="{Binding ModelInfo.IsUsbDevice, Converter={StaticResource BooleanToVisibilityConverter}}">
                                                         <Slider
                                                             IsSnapToTickEnabled="True"
-                                                            Maximum="30"
+                                                            Maximum="60"
                                                             Minimum="1"
                                                             TickFrequency="1"
                                                             Value="{Binding TargetFrameRate}" />
@@ -564,6 +564,299 @@
             <!--  end TuringPanel Device Management  -->
         </ui:CardExpander>
         <!--  end TuringPanel Multi-Device settings  -->
+
+        <!--  start LianLiPanel Multi-Device settings  -->
+        <ui:CardExpander Margin="0,10,0,0" IsExpanded="True">
+            <ui:CardExpander.Icon>
+                <ui:SymbolIcon Symbol="Whiteboard24" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                        <TextBlock
+                            FontSize="13"
+                            FontWeight="Medium"
+                            Text="Lian Li Displays" />
+                        <TextBlock
+                            Margin="0,5,0,0"
+                            FontSize="12"
+                            Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                            Text="Configure and run multiple Lian Li devices simultaneously." />
+                    </StackPanel>
+
+                    <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                        <StackPanel Margin="0,0,10,0" Orientation="Horizontal">
+                            <ui:ToggleSwitch
+                                Grid.Column="1"
+                                Margin="0,0,10,0"
+                                IsChecked="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LianLiPanelMultiDeviceMode}" />
+                        </StackPanel>
+                    </StackPanel>
+
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <ui:Button
+                        Grid.Column="1"
+                        Margin="0,0,0,0"
+                        HorizontalAlignment="Right"
+                        Appearance="Primary"
+                        Click="ButtonDiscoverLianLiDevices_Click"
+                        Content="Discover Devices"
+                        Icon="{ui:SymbolIcon Search20}"
+                        Visibility="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Settings.LianLiPanelMultiDeviceMode, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                </Grid>
+
+                <!--  Lian Li Panel Device List  -->
+                <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding ViewModel.RuntimeLianLiPanelDevices}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <ui:CardControl Margin="0,0,0,10">
+                                <ui:CardControl.Header>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Grid.Column="0" VerticalAlignment="Center">
+                                            <TextBlock FontSize="13" FontWeight="Medium">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0}">
+                                                        <Binding Path="Name" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                                                TextWrapping="Wrap">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}{0} - {1}">
+                                                        <Binding Path="DeviceId" />
+                                                        <Binding Path="DeviceLocation" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <TextBlock
+                                                Margin="0,0,0,0"
+                                                FontSize="12"
+                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}">
+                                                <TextBlock.Text>
+                                                    <MultiBinding StringFormat="{}Dimensions: {0}x{1}">
+                                                        <Binding Path="ModelInfo.Width" />
+                                                        <Binding Path="ModelInfo.Height" />
+                                                    </MultiBinding>
+                                                </TextBlock.Text>
+                                            </TextBlock>
+
+                                            <!--  Panel status when enabled  -->
+                                            <StackPanel Visibility="{Binding Enabled, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <!--  Show when running  -->
+                                                <StackPanel
+                                                    Margin="0,5,0,0"
+                                                    Orientation="Horizontal"
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="SeaGreen"
+                                                        Text="Panel is running:" />
+                                                    <TextBlock
+                                                        Margin="10,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="SeaGreen"
+                                                        Text="{Binding RuntimeProperties.FrameRate, StringFormat='{}{0} FPS'}" />
+                                                    <TextBlock
+                                                        Margin="0,0,0,0"
+                                                        FontSize="12"
+                                                        Foreground="SeaGreen"
+                                                        Text="{Binding RuntimeProperties.FrameTime, StringFormat=' @ {0}ms'}" />
+                                                </StackPanel>
+
+                                                <!--  Show when not running  -->
+                                                <TextBlock
+                                                    Margin="0,5,0,0"
+                                                    FontSize="12"
+                                                    Foreground="Orange"
+                                                    Text="Display is not running. Check your USB connection and try again."
+                                                    Visibility="{Binding RuntimeProperties.IsRunning, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                    </Grid>
+                                </ui:CardControl.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <!--  Left buttons column  -->
+                                    <StackPanel Margin="10,0,0,0" VerticalAlignment="Top">
+                                        <!--  Advanced settings popup  -->
+                                        <ui:Button
+                                            Width="160"
+                                            Margin="0,0,0,10"
+                                            Appearance="Secondary"
+                                            Content="Advanced"
+                                            Icon="{ui:SymbolIcon Settings20}"
+                                            Click="ButtonAdvancedPopup_Click" />
+                                        <Popup
+                                            AllowsTransparency="True"
+                                            Placement="Bottom"
+                                            StaysOpen="False">
+                                            <Border
+                                                Padding="15"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource ControlElevationBorderBrush}"
+                                                BorderThickness="1"
+                                                CornerRadius="8">
+                                                <StackPanel Width="250">
+                                                    <!--  Brightness  -->
+                                                    <StackPanel>
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="0"
+                                                            TickFrequency="1"
+                                                            Value="{Binding Brightness}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Brightness" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding Brightness}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  Target FPS (USB devices only)  -->
+                                                    <StackPanel Margin="0,10,0,0"
+                                                                Visibility="{Binding ModelInfo.IsUsbDevice, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="60"
+                                                            Minimum="1"
+                                                            TickFrequency="1"
+                                                            Value="{Binding TargetFrameRate}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="Target FPS" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding TargetFrameRate}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                    <!--  JPEG Quality (USB devices only)  -->
+                                                    <StackPanel Margin="0,10,0,0"
+                                                                Visibility="{Binding ModelInfo.IsUsbDevice, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                        <Slider
+                                                            IsSnapToTickEnabled="True"
+                                                            Maximum="100"
+                                                            Minimum="50"
+                                                            TickFrequency="5"
+                                                            Value="{Binding JpegQuality}" />
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*" />
+                                                                <ColumnDefinition Width="Auto" />
+                                                            </Grid.ColumnDefinitions>
+                                                            <TextBlock
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="JPEG Quality" />
+                                                            <TextBlock
+                                                                Grid.Column="1"
+                                                                Margin="5,0,0,0"
+                                                                FontSize="12"
+                                                                Foreground="{DynamicResource TextFillColorDisabledBrush}"
+                                                                Text="{Binding JpegQuality}" />
+                                                        </Grid>
+                                                    </StackPanel>
+                                                </StackPanel>
+                                            </Border>
+                                        </Popup>
+                                    </StackPanel>
+                                    <StackPanel Margin="10,0,0,0">
+                                        <!--  Profile selection  -->
+                                        <ComboBox
+                                            Width="250"
+                                            Margin="0,0,0,0"
+                                            DisplayMemberPath="Name"
+                                            ItemsSource="{Binding Source={x:Static local:ConfigModel.Instance}, Path=Profiles}"
+                                            SelectedValue="{Binding ProfileGuid}"
+                                            SelectedValuePath="Guid" />
+                                        <!--  Rotation  -->
+                                        <ComboBox
+                                            Margin="0,10,0,0"
+                                            ItemsSource="{Binding Path=ViewModel.RotationValues, RelativeSource={RelativeSource AncestorType=pages:UsbPanelsPage}}"
+                                            SelectedItem="{Binding Rotation}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Converter={StaticResource EnumToDescriptionConverter}}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <Grid Margin="20,0,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <!--  Enable toggle  -->
+                                        <ui:ToggleSwitch
+                                            Margin="0,0,0,0"
+                                            VerticalAlignment="Center"
+                                            IsChecked="{Binding Enabled}" />
+                                        <!--  Remove button  -->
+                                        <ui:Button
+                                            Grid.Row="1"
+                                            Width="32"
+                                            Height="32"
+                                            Margin="0,10,0,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Bottom"
+                                            Appearance="Danger"
+                                            Click="ButtonRemoveLianLiPanelDevice_Click"
+                                            Icon="{ui:SymbolIcon Delete20}"
+                                            Tag="{Binding}"
+                                            ToolTip="Remove Device" />
+                                    </Grid>
+                                </StackPanel>
+                            </ui:CardControl>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+                <!--  end Lian Li Panel Device Management  -->
+            </ui:CardExpander>
+            <!--  end Lian Li Panel Multi-Device settings  -->
 
         <!--  start ThermalrightPanel Multi-Device settings  -->
         <ui:CardExpander

--- a/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
+++ b/InfoPanel/Views/Pages/UsbPanelsPage.xaml.cs
@@ -1,4 +1,5 @@
 using InfoPanel.BeadaPanel;
+using InfoPanel.LianLiPanel;
 using InfoPanel.Models;
 using InfoPanel.Services;
 using InfoPanel.TuringPanel;
@@ -47,6 +48,7 @@ public partial class UsbPanelsPage : Page
         // Refresh device combo when device lists change
         ConfigModel.Instance.Settings.BeadaPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
         ConfigModel.Instance.Settings.TuringPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
+        ConfigModel.Instance.Settings.LianLiPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
         ConfigModel.Instance.Settings.ThermalrightPanelDevices.CollectionChanged += (_, _) => PopulateDeviceCombo();
     }
 
@@ -194,6 +196,63 @@ public partial class UsbPanelsPage : Page
         }
     }
 
+    private async void ButtonDiscoverLianLiDevices_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button)
+        {
+            button.IsEnabled = false;
+            await UpdateLianLiPanelDeviceList();
+            button.IsEnabled = true;
+        }
+    }
+
+    private async Task UpdateLianLiPanelDeviceList()
+    {
+        var discoveredDevices = await LianLiPanelHelper.GetUsbDevices();
+
+        foreach (var discoveredDevice in discoveredDevices)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var device = settings.LianLiPanelDevices.FirstOrDefault(d => d.IsMatching(discoveredDevice.DeviceId));
+
+                if (device == null)
+                {
+                    discoveredDevice.ProfileGuid = ConfigModel.Instance.Profiles.FirstOrDefault()?.Guid ?? Guid.Empty;
+                    settings.LianLiPanelDevices.Add(discoveredDevice);
+                    Logger.Information("LianLiPanel Discovery: Added new device with DeviceId '{DeviceId}'", discoveredDevice.DeviceId);
+                }
+                else
+                {
+                    device.DeviceLocation = discoveredDevice.DeviceLocation;
+                    device.Model = discoveredDevice.Model;
+                    Logger.Information("LianLiPanel Discovery: Device with DeviceId '{DeviceId}' already exists", discoveredDevice.DeviceId);
+                }
+            });
+        }
+    }
+
+    private void ButtonRemoveLianLiPanelDevice_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is Button button && button.Tag is LianLiPanelDevice runtimeDevice)
+        {
+            ConfigModel.Instance.AccessSettings(settings =>
+            {
+                var deviceConfig = settings.LianLiPanelDevices.FirstOrDefault(c => c.Id == runtimeDevice.Id);
+
+                if (deviceConfig != null)
+                {
+                    if (LianLiPanelTask.Instance.IsDeviceRunning(deviceConfig.Id))
+                    {
+                        _ = LianLiPanelTask.Instance.StopDevice(deviceConfig.Id);
+                    }
+
+                    settings.LianLiPanelDevices.Remove(deviceConfig);
+                }
+            });
+        }
+    }
+
     private void ButtonRemoveTuringPanelDevice_Click(object sender, RoutedEventArgs e)
     {
         if (sender is Button button && button.Tag is TuringPanelDevice runtimeDevice)
@@ -245,6 +304,12 @@ public partial class UsbPanelsPage : Page
         {
             var name = d.Name ?? d.DeviceId;
             items.Add(Tuple.Create($"Turing|{d.DeviceId}|", name));
+        }
+
+        foreach (var d in ConfigModel.Instance.Settings.LianLiPanelDevices)
+        {
+            var name = d.Name ?? d.DeviceId;
+            items.Add(Tuple.Create($"LianLi|{d.DeviceId}|", name));
         }
 
         foreach (var d in ConfigModel.Instance.Settings.ThermalrightPanelDevices)


### PR DESCRIPTION
﻿## Summary

Follow-up to #150. Adds Lian Li USB LCD panel support as a separate device family instead of extending the existing Turzx/Turing model list.

## What changed

- Adds dedicated Lian Li model definitions, discovery, settings storage, task runner, and USB transport.
- Adds a separate "Lian Li Displays" section to the USB Panels page.
- Keeps Lian Li devices out of Turzx/Turing, including migration/filtering for previously saved Lian Li VID/PID entries that appeared as "Unknown Model".
- Adds support for Lian Li Universal Screen 8.8", Universal Screen 9.2", HydroShift II OLED Curve, and HydroShift II LCD.
- Uses the UI-selected rotation directly for all Lian Li models, with no model-specific rotation offset.

## Notes

The Lian Li USB transport sends the encrypted command packet and image payload as one bulk transfer, matching the device-specific behavior required by these panels.

## Verification

Tested on Windows against the current `1.4.x` branch:

```powershell
git apply --check C:\Users\Ozgur\Desktop\infopanel-lianli-allchanges.patch
git apply C:\Users\Ozgur\Desktop\infopanel-lianli-allchanges.patch
dotnet build InfoPanel.sln
```

Result:

```text
Build succeeded.
0 errors.
```

Runtime tested locally with:

- Lian Li Universal Screen 8.8"
- Lian Li HydroShift II LCD

Both devices are discovered under the Lian Li section and no longer appear under Turzx/Turing.
