### PR TITLE
Fix profile windows becoming undraggable under heavy render load

### DIFF
--- a/InfoPanel/Models/LockedImage.cs
+++ b/InfoPanel/Models/LockedImage.cs
@@ -659,6 +659,18 @@ namespace InfoPanel.Models
                         using var snapshot = _pluginImage.GetCurrentFrame();
                         if (snapshot != null)
                         {
+                            // Fast path: no resize needed (e.g. item at 100% scale). Hand the
+                            // frame straight through instead of allocating a full-size surface
+                            // and running a same-size cubic resample every frame — on large
+                            // plugin images (2650x720 spectrum) that resample alone kept the
+                            // display thread ~98% busy and starved WPF mouse input, which made
+                            // profile windows undraggable.
+                            if (snapshot.Width == targetWidth && snapshot.Height == targetHeight)
+                            {
+                                access(snapshot);
+                                return;
+                            }
+
                             var resizeInfo = new SKImageInfo(targetWidth, targetHeight);
                             using var surface = SKSurface.Create(resizeInfo);
                             if (surface != null)

--- a/InfoPanel/Views/DisplayWindow.xaml.cs
+++ b/InfoPanel/Views/DisplayWindow.xaml.cs
@@ -384,13 +384,19 @@ namespace InfoPanel.Views.Common
             if (_renderInvalidationPending) return;
             _renderInvalidationPending = true;
 
+            // Post the invalidation BELOW input priority. The DisplayWindowThread is both the
+            // render loop and the WPF input dispatcher for the profile window; if frames are
+            // expensive (large plugin images, video) and get queued at Render priority they
+            // outrank mouse events indefinitely and the window becomes undraggable/unclickable.
+            // At Background priority a slow frame simply drops (via _renderInvalidationPending)
+            // and pending input is serviced first.
             if (!OpenGL)
             {
                 _dispatcher.BeginInvoke(() =>
                 {
                     _renderInvalidationPending = false;
                     _sKElement?.InvalidateVisual();
-                }, DispatcherPriority.Render);
+                }, DispatcherPriority.Background);
             }
             else
             {
@@ -398,7 +404,7 @@ namespace InfoPanel.Views.Common
                 {
                     _renderInvalidationPending = false;
                     _skGlElement?.InvalidateVisual();
-                }, DispatcherPriority.Render);
+                }, DispatcherPriority.Background);
             }
         }
 


### PR DESCRIPTION
## Why?

Profile windows stop responding to click-and-drag (and any mouse input) whenever a frame is expensive to render. Reproduced with a 2650x720 plugin image (AudioSpectrum) shown at ≥ ~55% scale on a 60 fps target. A blank profile drags fine. Anyone with a large plugin image or heavy video background at a high frame rate can hit this.

Instrumenting the display thread showed it ~98% busy painting (~45 ms/frame) while `Window_MouseDown` / `MouseMove` never fired at all, even though the HWND was alive, painted, hit-testable, not layered-transparent, and answering `WM_NULL`. The input was arriving at the window but never being serviced.

## How?

Two changes, both small and self-contained:

- **Render invalidation posted at `DispatcherPriority.Render`** outranks `Input` on the same dispatcher. The `DisplayWindowThread` is both the render loop and the WPF input dispatcher for the profile window, so when a frame takes longer than the render-timer interval the render queue *always* has higher-priority work than pending mouse events, and input starves indefinitely. Posting at `DispatcherPriority.Background` lets a slow frame simply drop (the existing `_renderInvalidationPending` guard already coalesces) and pending input is serviced first. This is why the failure had a sharp cutoff at a specific item scale: it kicked in exactly when per-frame cost exceeded the interval.
- **Plugin-image draw path** allocated a full-size `SKSurface` and ran a Mitchell-cubic resample every frame even when source and target sizes were identical (item at 100% scale): a same-size resample doing real filtering work on a 7.6 MB image for nothing. Added a fast path that hands the frame straight through when no resize is needed.

Confirmed on the reproducing setup: dragging works at 100% scale and the spectrum still animates smoothly.

<sub>Generated with Claude Code</sub>
