### PR TITLE
Fix Trofeo Vision 6.86" freeze at high brightness: cap JPEG frame size on HID panels

### DIFF
--- a/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
+++ b/InfoPanel/Services/ThermalrightPanelDeviceTask.cs
@@ -1721,6 +1721,18 @@ namespace InfoPanel.Services
                 var height = _panelHeight;
                 var pixelFormat = _detectedModel?.PixelFormat ?? ThermalrightPixelFormat.Jpeg;
 
+                // Cap JPEG frame size like TRCC does. TRCC never sends a JPEG >= 450,000 bytes
+                // (FormCZTV.ImageToJpg drops the frame and reduces quality by 5); the panel
+                // firmware's receive buffer is sized accordingly. Without this cap, a bright,
+                // high-entropy theme at quality 95 can exceed the buffer and wedge the panel
+                // (issue #139: Trofeo Vision 6.86" shows a frame then goes black until replug,
+                // and dimming to brightness 50 "fixes" it only because darker frames compress
+                // smaller). GenerateFrameBuffer's adaptive-quality loop enforces the cap.
+                if (pixelFormat == ThermalrightPixelFormat.Jpeg)
+                {
+                    _maxJpegSize = 400_000;
+                }
+
                 try
                 {
                     if (useBulk && bulkWriter != null)


### PR DESCRIPTION
## Why?

Fixes #139. On the Trofeo Vision 6.86" (and other HID JPEG panels), the panel can freeze and require a hard power cycle when Brightness is set to 100. The reporter found that lowering brightness avoided it, and PR #160 works around the symptom by dipping the LCD Brightness slider.

The actual root cause is frame size, not brightness. The HID Trofeo path had no cap on encoded JPEG size. Bright, high-entropy frames at quality 95 can exceed the firmware's receive buffer, and once an oversized frame is sent the panel wedges. Brightness only appears related because darker frames compress smaller.

TRCC never sends a JPEG of 450,000 bytes or more: its ImageToJpg drops the frame and reduces quality until it fits. InfoPanel already had this mechanism (`_maxJpegSize` with automatic quality step-down) for other panels, but it was never armed on the HID path, so it defaulted to no limit.

## How?

In `ThermalrightPanelDeviceTask.DoWorkHidAsync`, after model detection, set `_maxJpegSize = 400_000` for JPEG pixel format panels (slightly below TRCC's 450,000 threshold for safety margin). The existing oversize handling then kicks in: frames that exceed the cap are re-encoded at reduced quality instead of being sent to the panel.

This addresses the same symptom as PR #160 but at the root, without overriding the user's persisted brightness setting.

Verified on a Trofeo Vision 6.86" at Brightness 100 with high-entropy content (the unit never exhibited the wedge, so confirmation from the original reporter is still being requested in #139).

<sub>Generated with Claude Code</sub>
