### PR TITLE
Add display assignment dropdown to Profiles page with EDID friendly names

### DIFF
--- a/InfoPanel/Utils/DisplayNameHelper.cs
+++ b/InfoPanel/Utils/DisplayNameHelper.cs
@@ -1,0 +1,147 @@
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace InfoPanel.Utils
+{
+    /// <summary>
+    /// Maps GDI display device names (\.\DISPLAY1 ...) to the monitor's friendly name from its
+    /// EDID (e.g. "LG ULTRAWIDE"), the same name Windows Settings shows. GDI numbering does NOT
+    /// match the "Display 1 / 2" numbers in Windows Settings, so the friendly name is what users
+    /// actually recognise.
+    /// </summary>
+    public static class DisplayNameHelper
+    {
+        private static readonly ILogger Logger = Log.ForContext(typeof(DisplayNameHelper));
+
+        private const uint QDC_ONLY_ACTIVE_PATHS = 0x00000002;
+        private const uint DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME = 1;
+        private const uint DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME = 2;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LUID { public uint LowPart; public int HighPart; }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DISPLAYCONFIG_PATH_SOURCE_INFO
+        {
+            public LUID adapterId; public uint id; public uint modeInfoIdx; public uint statusFlags;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DISPLAYCONFIG_PATH_TARGET_INFO
+        {
+            public LUID adapterId; public uint id; public uint modeInfoIdx;
+            public uint outputTechnology; public uint rotation; public uint scaling;
+            public uint refreshRateNumerator; public uint refreshRateDenominator;
+            public uint scanLineOrdering; public bool targetAvailable; public uint statusFlags;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DISPLAYCONFIG_PATH_INFO
+        {
+            public DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
+            public DISPLAYCONFIG_PATH_TARGET_INFO targetInfo;
+            public uint flags;
+        }
+
+        // DISPLAYCONFIG_MODE_INFO is a 64-byte union; we only need its size for the buffer.
+        [StructLayout(LayoutKind.Sequential, Size = 64)]
+        private struct DISPLAYCONFIG_MODE_INFO { }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DISPLAYCONFIG_DEVICE_INFO_HEADER
+        {
+            public uint type; public uint size; public LUID adapterId; public uint id;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct DISPLAYCONFIG_SOURCE_DEVICE_NAME
+        {
+            public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)] public string viewGdiDeviceName;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct DISPLAYCONFIG_TARGET_DEVICE_NAME
+        {
+            public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+            public uint flags;
+            public uint outputTechnology;
+            public ushort edidManufactureId;
+            public ushort edidProductCodeId;
+            public uint connectorInstance;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)] public string monitorFriendlyDeviceName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string monitorDevicePath;
+        }
+
+        [DllImport("user32.dll")]
+        private static extern int GetDisplayConfigBufferSizes(uint flags, out uint numPathArrayElements, out uint numModeInfoArrayElements);
+
+        [DllImport("user32.dll")]
+        private static extern int QueryDisplayConfig(uint flags, ref uint numPathArrayElements, [Out] DISPLAYCONFIG_PATH_INFO[] pathArray,
+            ref uint numModeInfoArrayElements, [Out] DISPLAYCONFIG_MODE_INFO[] modeInfoArray, IntPtr currentTopologyId);
+
+        [DllImport("user32.dll")]
+        private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_SOURCE_DEVICE_NAME deviceName);
+
+        [DllImport("user32.dll")]
+        private static extern int DisplayConfigGetDeviceInfo(ref DISPLAYCONFIG_TARGET_DEVICE_NAME deviceName);
+
+        /// <summary>
+        /// Returns a map of GDI device name (e.g. "\.\DISPLAY2") to monitor friendly name
+        /// (e.g. "LG ULTRAWIDE"). Empty on any failure; never throws.
+        /// </summary>
+        public static Dictionary<string, string> GetFriendlyNames()
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, out uint pathCount, out uint modeCount) != 0)
+                    return result;
+
+                var paths = new DISPLAYCONFIG_PATH_INFO[pathCount];
+                var modes = new DISPLAYCONFIG_MODE_INFO[modeCount];
+                if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, ref pathCount, paths, ref modeCount, modes, IntPtr.Zero) != 0)
+                    return result;
+
+                for (int i = 0; i < pathCount; i++)
+                {
+                    var src = new DISPLAYCONFIG_SOURCE_DEVICE_NAME
+                    {
+                        header = new DISPLAYCONFIG_DEVICE_INFO_HEADER
+                        {
+                            type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME,
+                            size = (uint)Marshal.SizeOf<DISPLAYCONFIG_SOURCE_DEVICE_NAME>(),
+                            adapterId = paths[i].sourceInfo.adapterId,
+                            id = paths[i].sourceInfo.id,
+                        }
+                    };
+                    if (DisplayConfigGetDeviceInfo(ref src) != 0) continue;
+
+                    var tgt = new DISPLAYCONFIG_TARGET_DEVICE_NAME
+                    {
+                        header = new DISPLAYCONFIG_DEVICE_INFO_HEADER
+                        {
+                            type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME,
+                            size = (uint)Marshal.SizeOf<DISPLAYCONFIG_TARGET_DEVICE_NAME>(),
+                            adapterId = paths[i].targetInfo.adapterId,
+                            id = paths[i].targetInfo.id,
+                        }
+                    };
+                    if (DisplayConfigGetDeviceInfo(ref tgt) != 0) continue;
+
+                    var gdi = src.viewGdiDeviceName?.Trim();
+                    var friendly = tgt.monitorFriendlyDeviceName?.Trim();
+                    if (!string.IsNullOrEmpty(gdi) && !string.IsNullOrEmpty(friendly) && !result.ContainsKey(gdi))
+                        result[gdi] = friendly;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug(ex, "DisplayNameHelper: failed to query display config");
+            }
+            return result;
+        }
+    }
+}

--- a/InfoPanel/ViewModels/ProfilesViewModel.cs
+++ b/InfoPanel/ViewModels/ProfilesViewModel.cs
@@ -1,5 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using InfoPanel.Models;
+using InfoPanel.Utils;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -8,6 +9,42 @@ using Wpf.Ui.Abstractions.Controls;
 
 namespace InfoPanel.ViewModels
 {
+    /// <summary>
+    /// One connected monitor, for the "assign profile to display" dropdown.
+    /// </summary>
+    public class DisplayOption
+    {
+        public string DeviceName { get; init; } = "";
+        public int X { get; init; }
+        public int Y { get; init; }
+        public int Width { get; init; }
+        public int Height { get; init; }
+        public bool IsPrimary { get; init; }
+
+        /// <summary>Monitor name from EDID (what Windows Settings shows), e.g. "LG ULTRAWIDE". May be empty.</summary>
+        public string FriendlyName { get; init; } = "";
+
+        /// <summary>
+        /// e.g. "LG ULTRAWIDE  3440x1440 @ 0,0  (primary)  [DISPLAY2]". Leads with the friendly
+        /// name because the GDI "DISPLAYn" number does not match the Display 1/2 numbering in
+        /// Windows Settings.
+        /// </summary>
+        public string Label
+        {
+            get
+            {
+                var gdi = DeviceName[(DeviceName.LastIndexOf(System.IO.Path.DirectorySeparatorChar) + 1)..]; // strip the \.\ prefix
+                var head = string.IsNullOrEmpty(FriendlyName) ? gdi : FriendlyName;
+                var tail = string.IsNullOrEmpty(FriendlyName) ? "" : $"  [{gdi}]";
+                return $"{head}  {Width}x{Height} @ {X},{Y}{(IsPrimary ? "  (primary)" : "")}{tail}";
+            }
+        }
+
+        public TargetWindow ToTargetWindow() => new(X, Y, Width, Height, DeviceName);
+
+        public override string ToString() => Label;
+    }
+
     public class ProfilesViewModel: ObservableObject, INavigationAware
     {
         private Profile? _profile;
@@ -21,8 +58,49 @@ namespace InfoPanel.ViewModels
             }
         }
 
+        public ObservableCollection<DisplayOption> Displays { get; } = [];
+
         public ProfilesViewModel()
         {
+            RefreshDisplays();
+        }
+
+        /// <summary>Re-enumerates connected monitors (called on navigation so hot-plugged screens appear).</summary>
+        public void RefreshDisplays()
+        {
+            var friendly = DisplayNameHelper.GetFriendlyNames();
+            var monitors = ScreenHelper.GetAllMonitors()
+                .OrderByDescending(m => m.IsPrimary)
+                .ThenBy(m => m.DeviceName)
+                .Select(m => new DisplayOption
+                {
+                    DeviceName = m.DeviceName ?? "",
+                    FriendlyName = (m.DeviceName != null && friendly.TryGetValue(m.DeviceName, out var fn)) ? fn : "",
+                    X = (int)m.Bounds.Left,
+                    Y = (int)m.Bounds.Top,
+                    Width = (int)m.Bounds.Width,
+                    Height = (int)m.Bounds.Height,
+                    IsPrimary = m.IsPrimary,
+                })
+                .ToList();
+
+            Displays.Clear();
+            foreach (var m in monitors) Displays.Add(m);
+        }
+
+        /// <summary>
+        /// Finds the dropdown entry matching a profile's current TargetWindow by device name
+        /// (falls back to geometry if the name is missing), or null if that display is not connected.
+        /// </summary>
+        public DisplayOption? FindDisplayFor(TargetWindow? target)
+        {
+            if (target == null) return null;
+            if (!string.IsNullOrEmpty(target.DeviceName))
+            {
+                var byName = Displays.FirstOrDefault(d => string.Equals(d.DeviceName, target.DeviceName, StringComparison.OrdinalIgnoreCase));
+                if (byName != null) return byName;
+            }
+            return Displays.FirstOrDefault(d => d.X == target.X && d.Y == target.Y && d.Width == target.Width && d.Height == target.Height);
         }
 
         public Task OnNavigatedFromAsync()
@@ -32,6 +110,7 @@ namespace InfoPanel.ViewModels
 
         public Task OnNavigatedToAsync()
         {
+            RefreshDisplays();
             return Task.CompletedTask;
         }
     }

--- a/InfoPanel/Views/Pages/ProfilesPage.xaml
+++ b/InfoPanel/Views/Pages/ProfilesPage.xaml
@@ -242,17 +242,25 @@
                                                         </Grid.ColumnDefinitions>
 
                                                         <StackPanel>
-                                                            <TextBlock
-                                                                Margin="10,5,10,0"
+                                                            <!--  Display assignment: pick which monitor this profile's window lives on.
+                                                                  Selecting an entry sets Profile.TargetWindow and resets the window to that
+                                                                  display's top-left; a running panel moves immediately.  -->
+                                                            <ComboBox
+                                                                MinWidth="220"
+                                                                MaxWidth="340"
                                                                 HorizontalAlignment="Left"
-                                                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                                Text="{Binding TargetWindow.DeviceName, Mode=OneWay}"
-                                                                TextTrimming="CharacterEllipsis" />
+                                                                DisplayMemberPath="Label"
+                                                                ItemsSource="{Binding ViewModel.Displays, RelativeSource={RelativeSource AncestorType=Page}}"
+                                                                DataContextChanged="ComboBoxDisplay_DataContextChanged"
+                                                                Loaded="ComboBoxDisplay_Loaded"
+                                                                SelectionChanged="ComboBoxDisplay_SelectionChanged"
+                                                                Tag="{Binding}"
+                                                                ToolTip="Display this panel is assigned to" />
                                                             <TextBlock
                                                                 Margin="5,0,0,0"
                                                                 FontSize="12"
                                                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                                                Text="{Binding TargetWindow.Name, Mode=OneWay}" />
+                                                                Text="{Binding TargetWindow.Name, Mode=OneWay, StringFormat='Display  ({0})'}" />
                                                         </StackPanel>
 
                                                         <StackPanel

--- a/InfoPanel/Views/Pages/ProfilesPage.xaml.cs
+++ b/InfoPanel/Views/Pages/ProfilesPage.xaml.cs
@@ -97,6 +97,89 @@ namespace InfoPanel.Views.Pages
             }
         }
 
+        // ---- Display assignment dropdown ----
+        // The ComboBox lives inside the profile DataTemplate, so its DataContext is the Profile
+        // (exposed via Tag). We sync it manually rather than two-way binding SelectedItem because
+        // the selectable objects (DisplayOption) are not the stored object (TargetWindow), and
+        // because a profile's saved display may not be connected right now (leave nothing selected).
+
+        private bool _suppressDisplaySelection;
+        private Profile? _displayComboProfile;
+        private System.Windows.Controls.ComboBox? _displayCombo;
+
+        private void ComboBoxDisplay_Loaded(object sender, RoutedEventArgs e)
+        {
+            if (sender is System.Windows.Controls.ComboBox combo)
+                AttachDisplayCombo(combo, combo.DataContext as Profile);
+        }
+
+        private void ComboBoxDisplay_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            // The detail ContentControl reuses the same visual tree when switching profiles,
+            // so re-sync whenever the bound Profile changes.
+            if (sender is System.Windows.Controls.ComboBox combo)
+                AttachDisplayCombo(combo, e.NewValue as Profile);
+        }
+
+        private void AttachDisplayCombo(System.Windows.Controls.ComboBox combo, Profile? profile)
+        {
+            if (_displayComboProfile != null)
+                _displayComboProfile.PropertyChanged -= DisplayComboProfile_PropertyChanged;
+
+            _displayCombo = combo;
+            _displayComboProfile = profile;
+
+            if (profile != null)
+                profile.PropertyChanged += DisplayComboProfile_PropertyChanged;
+
+            SyncDisplayCombo();
+        }
+
+        private void DisplayComboProfile_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            // Keep the dropdown in step when the window is dragged onto another screen
+            // (DisplayWindow writes Profile.TargetWindow) or reset via the button.
+            if (e.PropertyName == nameof(Profile.TargetWindow))
+                Dispatcher.BeginInvoke(SyncDisplayCombo);
+        }
+
+        private void SyncDisplayCombo()
+        {
+            if (_displayCombo == null) return;
+            _suppressDisplaySelection = true;
+            try
+            {
+                _displayCombo.SelectedItem = ViewModel.FindDisplayFor(_displayComboProfile?.TargetWindow);
+            }
+            finally
+            {
+                _suppressDisplaySelection = false;
+            }
+        }
+
+        private void ComboBoxDisplay_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            if (sender is not System.Windows.Controls.ComboBox combo) return;
+            if (_suppressDisplaySelection) return;
+            if (combo.DataContext is not Profile profile) return;
+            if (combo.SelectedItem is not DisplayOption option) return;
+
+            var current = profile.TargetWindow;
+            if (current != null
+                && string.Equals(current.DeviceName, option.DeviceName, StringComparison.OrdinalIgnoreCase)
+                && current.X == option.X && current.Y == option.Y
+                && current.Width == option.Width && current.Height == option.Height)
+            {
+                return; // no change
+            }
+
+            // Assign the display and park the window at its top-left. DisplayWindow listens for
+            // TargetWindow/WindowX/WindowY changes and repositions a running panel immediately.
+            profile.TargetWindow = option.ToTargetWindow();
+            profile.WindowX = 0;
+            profile.WindowY = 0;
+        }
+
         private void ButtonResetPosition_Click(object sender, System.Windows.RoutedEventArgs e)
         {
             var screen = Screen.PrimaryScreen;


### PR DESCRIPTION
## Why?

Profiles are assigned to a specific display, but the Profiles page only showed the assignment as read-only text. The only way to move a profile to another screen was to drag its window there manually. Additionally, the raw GDI device names (`\.\DISPLAY1`) do not match the display numbers shown in Windows Settings, so the text was not very meaningful to users.

## How?

- Replaced the read-only display text on the Profiles page with a dropdown listing all connected displays. Selecting a display assigns the profile to it (window position resets to 0,0 on that screen).
- Added `DisplayNameHelper` which uses `QueryDisplayConfig`/`DisplayConfigGetDeviceInfo` to resolve EDID monitor friendly names (e.g. "DELL U2723QE"), so entries read as `FriendlyName [DISPLAY1]` instead of just the GDI device name.
- The dropdown stays in sync when the profile window is dragged to another screen (listens to `TargetWindow` property changes).
- Display list refreshes on page navigation, so newly connected monitors appear without restarting.

<sub>Generated with Claude Code</sub>
